### PR TITLE
Fix "database table is locked" on the in-memory (no --hashfile) db

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -303,6 +303,21 @@ static int dbfile_set_modes(sqlite3 *db)
 		return ret;
 	}
 
+	/*
+	 * The default (no --hashfile) database is an in-memory shared-cache db
+	 * (see MEMDB_FILENAME) shared by the listing reader, the batched writer
+	 * and the csum workers - all separate connections. Shared-cache does
+	 * table-level locking between connections, so the reader's lock on the
+	 * files table makes the writer's INSERT fail with SQLITE_LOCKED ("table
+	 * is locked"). read_uncommitted lets readers proceed without that lock;
+	 * it only affects shared-cache mode and is a no-op for WAL file dbs.
+	 */
+	ret = sqlite3_exec(db, "PRAGMA read_uncommitted = 1", NULL, NULL, NULL);
+	if (ret) {
+		perror_sqlite(ret, "enabling read-uncommitted");
+		return ret;
+	}
+
 	return ret;
 }
 

--- a/tests/integration/test_dedupe.py
+++ b/tests/integration/test_dedupe.py
@@ -45,6 +45,19 @@ class DedupeTest(DuperemoveTest):
         self.assertNoNewSharing()
         self.assertShared(a, b, "still shared after second run")
 
+    def test_in_memory_hashfile_dedupes_without_lock_errors(self):
+        # With no --hashfile duperemove uses an in-memory shared-cache db that
+        # the listing reader, the batched writer and the csum workers all open
+        # as separate connections. Shared-cache does table-level locking between
+        # connections, so without read_uncommitted every write failed with
+        # "Database error 6 ... database table is locked" and nothing was stored.
+        a, b = self.mkdup("tree/a", "tree/b", MiB)
+        self._sync()
+        self.dm("-rd", self.path("tree"), hashfile=False)
+        self.assertDmOk()
+        self._sync()
+        self.assertShared(a, b, "in-memory dedupe shared the pair")
+
     def test_leaves_distinct_files_alone(self):
         a = self.mkrand("tree/a", MiB)
         b = self.mkrand("tree/b", MiB)


### PR DESCRIPTION
## Bug
Running without `--hashfile` (e.g. `duperemove -dr ~/xy`) printed `Database error 6 ... database table is locked` for every file and stored nothing.

## Root cause
Without `--hashfile`, duperemove uses an in-memory shared-cache database (`file::memory:?cache=shared`) so the listing reader, the batched writer and the csum worker threads can share it over separate connections. Shared-cache mode does table-level locking **between** connections, so the reader's lock on the `files` table makes the writer's `INSERT` fail with `SQLITE_LOCKED`. File-backed hashfiles use WAL (no shared cache) and were unaffected — which is why it went unnoticed: tests and benchmarks all pass `--hashfile`.

## Fix
Enable `PRAGMA read_uncommitted` — the documented shared-cache mechanism for concurrent reader/writer access. Readers no longer take the table lock. It only affects shared-cache mode and is a no-op for WAL file dbs. The reads are change-detection lookups keyed by `(ino, subvol)` whose row is written after the read, so dropping read isolation is safe here.

## Verification
- `-dr` with no `--hashfile`: 0 locked errors, dedupe works (4.1 GiB across 160 groups on a test tree).
- `--hashfile` path unchanged.
- New integration test dedupes with no `--hashfile` and asserts an error-free run + shared pair; it fails without the fix with the exact `Database error 6 ... database table is locked`.
- Full suite: 37/37 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)