### PR TITLE
Build robustness + saner defaults (no --hashfile, thread cap)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags;)
-IS_RELEASE ?= $(if $(filter $(shell git rev-list $(shell git describe --abbrev=0 --tags --exclude '*dev';)..HEAD --count;),0),1,0)
+# Derive the version from git once (not per-compile), and stay quiet on clones
+# without tags: git describe then prints "fatal: No names found" to stderr.
+# --always makes VERSION fall back to a short hash; the release check treats a
+# missing tag as "not a release".
+ifndef VERSION
+VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
+endif
+ifndef IS_RELEASE
+LATEST_TAG := $(shell git describe --abbrev=0 --tags --exclude '*dev' 2>/dev/null)
+IS_RELEASE := $(if $(LATEST_TAG),$(if $(filter 0,$(shell git rev-list $(LATEST_TAG)..HEAD --count 2>/dev/null)),1,0),0)
+endif
 
 CC ?= gcc
 CFLAGS ?= -Wall -ggdb -std=gnu11 -Werror=strict-prototypes -MMD

--- a/duperemove.c
+++ b/duperemove.c
@@ -61,6 +61,9 @@ static enum {
 	H_UPDATE,
 } use_hashfile = H_UPDATE;
 
+/* Upper bound for the auto-detected worker thread count (overridable). */
+#define DEFAULT_MAX_AUTO_THREADS	8
+
 static void print_file(char *filename, char *ino, char *subvol)
 {
 	if (verbose)
@@ -692,6 +695,18 @@ int main(int argc, char **argv)
 	/* Set the default CPU limits before parsing the user options */
 	get_num_cpus(&(options.cpu_threads), &(options.io_threads));
 
+	/*
+	 * The detected core count can be very high (e.g. 64). Dedup is I/O
+	 * bound - reading and checksumming files, then FIDEDUPERANGE ioctls -
+	 * so beyond a handful of threads we mostly add lock contention and a
+	 * wall of progress lines. Cap the auto-detected default; an explicit
+	 * --io-threads / --cpu-threads (parsed below) still overrides it.
+	 */
+	if (options.io_threads > DEFAULT_MAX_AUTO_THREADS)
+		options.io_threads = DEFAULT_MAX_AUTO_THREADS;
+	if (options.cpu_threads > DEFAULT_MAX_AUTO_THREADS)
+		options.cpu_threads = DEFAULT_MAX_AUTO_THREADS;
+
 	ret = parse_options(argc, argv, &filelist_idx);
 	if (ret) {
 		exit(1);
@@ -742,8 +757,9 @@ int main(int argc, char **argv)
 		if (ret)
 			goto out;
 
-		qprintf("Hashfile \"%s\" written\n",
-			options.hashfile);
+		if (options.hashfile)
+			qprintf("Hashfile \"%s\" written\n",
+				options.hashfile);
 	}
 
 	if (use_hashfile == H_READ || use_hashfile == H_UPDATE)


### PR DESCRIPTION
Small fixes surfaced while running `duperemove -dr <dir>` with no `--hashfile` on a many-core machine.

## Build: stop the "No names found" wall
The version comes from `git describe`; the release check also ran `git describe --abbrev=0 --tags` with no `--always`, printing `fatal: No names found, cannot describe anything.` to stderr on a clone without tags. Because these were `$(shell)` calls in recursively-expanded (`?=`) variables used from `CFLAGS`, they re-ran for every compiled file — a wall of fatal messages. Now VERSION/IS_RELEASE are computed once (`:=`, guarded by `ifndef` so a dist override still wins) with git's stderr silenced; `--always` keeps VERSION as a short hash and a missing tag means `IS_RELEASE=0`.

## Runtime: quiet the in-memory "written" line
With no `--hashfile` the database is in-memory, but we still printed `Hashfile "(null)" written`. Only print it when a hashfile path actually exists.

## Runtime: cap the auto-detected thread default
The worker default was the logical core count (e.g. 64), which for I/O-bound dedup mostly adds lock contention and a wall of per-thread progress lines. Cap the auto-detected default at 8; an explicit `--io-threads` / `--cpu-threads` still overrides. Verified on a 32-core box: the pool drops from ~34 threads to 9 (8 workers + main).

37/37 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)