### PR TITLE
Advise the kernel about read-once hashing reads (posix_fadvise)

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -1348,6 +1348,9 @@ static void csum_whole_file(struct file_to_scan *file)
 		return;
 	}
 
+	/* We read each file once, front to back: ask for aggressive readahead. */
+	posix_fadvise(ctxt.fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+
 	ctxt.fiemap = do_fiemap(ctxt.fd);
 	if (!ctxt.fiemap)
 		return;
@@ -1433,6 +1436,13 @@ static void csum_whole_file(struct file_to_scan *file)
 
 	finish_running_checksum(ctxt.file_csum, file_digest);
 	ctxt.file_csum = NULL;
+
+	/*
+	 * We've read the whole file once and won't touch it again this scan.
+	 * Drop it from the page cache so hashing a large tree doesn't evict
+	 * everything else and push page allocation into the reclaim slowpath.
+	 */
+	posix_fadvise(ctxt.fd, 0, 0, POSIX_FADV_DONTNEED);
 
 	/*
 	 * Whether the last extent is inlined is a pure fiemap scan; compute it


### PR DESCRIPTION
`csum_whole_file()` reads every file once, front to back, through the page cache. On a large tree that floods the cache with read-once data — visible in profiles as page-cache folio allocation and reclaim (`alloc_pages_slowpath`) on top of the copy.

Add two `posix_fadvise` hints on the file fd:
- `POSIX_FADV_SEQUENTIAL` before reading (larger readahead window).
- `POSIX_FADV_DONTNEED` once the file is fully hashed (return its pages so hashing a big tree stops evicting everything and pushing allocation into the reclaim slowpath).

Hashing itself (XXH3) is unchanged and already optimal.

Note: `DONTNEED` means the later dedupe pass re-reads file data from disk for small trees that would otherwise stay cached; for trees larger than RAM (the case this helps) they wouldn't be cached anyway.

Digests unchanged; 37/37 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)