### PR TITLE
Stop "Skipping dedupe" from mangling the dedupe status bar

### DIFF
--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -336,7 +336,14 @@ static int dedupe_extent_list(struct dupe_extents *dext, uint64_t *fiemap_bytes,
 				dbfile_remove_file(dbfile_get_handle(), extent->e_file->filename);
 				dbfile_unlock();
 			}
-			eprintf("%s: Skipping dedupe.\n",
+			/*
+			 * Verbose-only: worker threads run while the in-place
+			 * dedupe status bar is redrawing, and an eprintf here
+			 * lands in the middle of that line. This matches the
+			 * other per-file dedupe notices (vprintf), and the bar
+			 * is disabled under -v anyway, so it prints cleanly.
+			 */
+			vprintf("%s: Skipping dedupe.\n",
 				extent->e_file->filename);
 			/*
 			 * If this was our last duplicate extent in


### PR DESCRIPTION
Running `duperemove -dr` showed garbled output when a file couldn't be opened during dedupe:

```
  Deduplicating #####>---------------- 12133/47875 (25%) · 18.4 GiB · 1m42s · ETA ~5m02s/…/foo.jar: Skipping dedupe.
```

The dedupe status bar is redrawn in place by a background thread; the per-file "Skipping dedupe." notice was an `eprintf` printed straight to the terminal by worker threads, so it landed in the middle of the bar. It's now `vprintf` (verbose-only), matching the sibling per-file dedupe notices — and since the bar only runs when `!verbose`, the two can never coexist. Default output stays clean; `-v` still shows the skips.

37/37 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)