### PR TITLE
tests: cover the extent-dedupe path; hoist sync() to the harness

### DIFF
--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -259,6 +259,10 @@ class DuperemoveTest(unittest.TestCase):
         os.makedirs(os.path.dirname(p), exist_ok=True)
         return p
 
+    def sync(self):
+        """Flush to disk so FIEMAP / on-disk sharing checks see settled state."""
+        subprocess.run(["sync"])
+
     def write(self, relpath, data):
         p = self.path(relpath)
         with open(p, "wb") as f:

--- a/tests/integration/test_dedupe.py
+++ b/tests/integration/test_dedupe.py
@@ -2,7 +2,6 @@
 is a no-op. Requires a reflink-capable filesystem."""
 
 import os
-import subprocess
 from harness import DuperemoveTest, requires_reflink
 
 MiB = 1 << 20
@@ -10,25 +9,22 @@ MiB = 1 << 20
 
 @requires_reflink
 class DedupeTest(DuperemoveTest):
-    def _sync(self):
-        subprocess.run(["sync"])
-
     def test_shares_identical_files(self):
         a, b = self.mkdup("tree/a", "tree/b", MiB)
-        self._sync()
+        self.sync()
         self.assertNotShared(a, b, "not shared before dedupe")
 
         before = self.tree_digest(self.path("tree"))
         self.dedupe(self.path("tree"))
         self.assertDmOk()
-        self._sync()
+        self.sync()
         self.assertShared(a, b, "shared after dedupe")
         self.assertEqual(before, self.tree_digest(self.path("tree")),
                          "dedupe preserved file contents")
 
     def test_reports_net_change(self):
         self.mkdup("tree/a", "tree/b", MiB)
-        self._sync()
+        self.sync()
         self.dedupe(self.path("tree"))
         self.assertDmOk()
         # Both copies become shared: net change counts the shared bytes on each.
@@ -36,10 +32,10 @@ class DedupeTest(DuperemoveTest):
 
     def test_is_idempotent(self):
         a, b = self.mkdup("tree/a", "tree/b", MiB)
-        self._sync()
+        self.sync()
         self.dedupe(self.path("tree"))
         self.assertDmOk()
-        self._sync()
+        self.sync()
         self.dedupe(self.path("tree"))               # second pass: nothing new
         self.assertDmOk()
         self.assertNoNewSharing()
@@ -52,19 +48,19 @@ class DedupeTest(DuperemoveTest):
         # connections, so without read_uncommitted every write failed with
         # "Database error 6 ... database table is locked" and nothing was stored.
         a, b = self.mkdup("tree/a", "tree/b", MiB)
-        self._sync()
+        self.sync()
         self.dm("-rd", self.path("tree"), hashfile=False)
         self.assertDmOk()
-        self._sync()
+        self.sync()
         self.assertShared(a, b, "in-memory dedupe shared the pair")
 
     def test_leaves_distinct_files_alone(self):
         a = self.mkrand("tree/a", MiB)
         b = self.mkrand("tree/b", MiB)
-        self._sync()
+        self.sync()
         self.dedupe(self.path("tree"))
         self.assertDmOk()
-        self._sync()
+        self.sync()
         self.assertNotShared(a, b, "distinct files stay independent")
 
     def test_multiway_group(self):
@@ -72,11 +68,11 @@ class DedupeTest(DuperemoveTest):
         data = open(a, "rb").read()
         b = self.write("tree/b", data)
         c = self.write("tree/c", data)
-        self._sync()
+        self.sync()
         before = self.tree_digest(self.path("tree"))
         self.dedupe(self.path("tree"))
         self.assertDmOk()
-        self._sync()
+        self.sync()
         self.assertShared(a, b, "a<->b shared")
         self.assertShared(a, c, "a<->c shared")
         self.assertEqual(before, self.tree_digest(self.path("tree")), "contents preserved")

--- a/tests/integration/test_einval.py
+++ b/tests/integration/test_einval.py
@@ -8,15 +8,11 @@ need a reflink-capable filesystem.
 """
 
 import os
-import subprocess
 from harness import DuperemoveTest, requires_reflink
 
 
 @requires_reflink
 class EinvalTest(DuperemoveTest):
-    def _sync(self):
-        subprocess.run(["sync"])
-
     def test_unaligned_shared_tail(self):
         # Unique aligned head, a hole, then an identical unaligned tail. The
         # tail is the shared extent whose block-rounded length overshoots EOF.
@@ -24,25 +20,25 @@ class EinvalTest(DuperemoveTest):
         tail = os.urandom(12345)
         a = self.make_sparse_headtail("tree/a", head_a, 327680, tail)
         b = self.make_sparse_headtail("tree/b", head_b, 327680, tail)
-        self._sync()
+        self.sync()
 
         before = self.tree_digest(self.path("tree"))
         self.dedupe(self.path("tree"))
         self.assertDmOk()                            # specifically: no EINVAL
         self.assertNotIn("Invalid argument", self.out, "EINVAL must not appear")
-        self._sync()
+        self.sync()
         self.assertShared(a, b, "the unaligned tail got shared")
         self.assertEqual(before, self.tree_digest(self.path("tree")),
                          "data preserved through clamp")
 
     def test_small_unaligned_whole_file(self):
         a, b = self.mkdup("tree/a", "tree/b", 196608 + 777)   # 192K + unaligned tail
-        self._sync()
+        self.sync()
         before = self.tree_digest(self.path("tree"))
         self.dedupe(self.path("tree"))
         self.assertDmOk()
         self.assertNotIn("Invalid argument", self.out, "no EINVAL on unaligned whole file")
-        self._sync()
+        self.sync()
         self.assertShared(a, b, "unaligned copies shared")
         self.assertEqual(before, self.tree_digest(self.path("tree")), "data preserved")
 

--- a/tests/integration/test_extent_dedupe.py
+++ b/tests/integration/test_extent_dedupe.py
@@ -1,0 +1,54 @@
+"""Extent-level dedupe: files that are not whole-file duplicates but share a
+region. This drives the extent pass end to end - including fiemap_scan_extent()
+and fiemap_count_shared(), which the whole-file dedupe tests never reach - and
+checks it shares the region, preserves data, and is idempotent.
+
+(It cannot pin fiemap_scan_extent()'s exact post-dedupe offset: that value is
+only a hint for the "already deduped" check, and the kernel byte-verifies every
+dedupe, so a wrong hint changes neither data nor sharing. This guards the path
+against crashes/errors and against sharing/data regressions.)
+
+Requires a reflink-capable filesystem.
+"""
+
+import os
+from harness import DuperemoveTest, requires_reflink
+
+MiB = 1 << 20
+
+
+@requires_reflink
+class ExtentDedupeTest(DuperemoveTest):
+    def _mkfile(self, rel, head, tail):
+        """head, an fsync to force an extent boundary, then the shared tail."""
+        p = self.path(rel)
+        with open(p, "wb") as f:
+            f.write(head)
+            f.flush()
+            os.fsync(f.fileno())
+            f.write(tail)
+        return p
+
+    def test_shared_tail_is_deduped(self):
+        # Distinct heads, identical tail -> not whole-file dupes, so only the
+        # extent pass can share the tail.
+        tail = os.urandom(4 * MiB)
+        a = self._mkfile("tree/a", os.urandom(64 * 1024), tail)
+        b = self._mkfile("tree/b", os.urandom(64 * 1024), tail)
+        self.sync()
+
+        self.assertNotShared(a, b, "independent before dedupe")
+        before = self.tree_digest(self.path("tree"))
+
+        self.dedupe(self.path("tree"))
+        self.assertDmOk()
+        self.sync()
+
+        self.assertShared(a, b, "shared tail deduped via the extent pass")
+        self.assertEqual(before, self.tree_digest(self.path("tree")),
+                         "dedupe preserved file contents")
+
+        # Extent dedupe is idempotent: a second pass adds no new sharing.
+        self.dedupe(self.path("tree"))
+        self.assertDmOk()
+        self.assertNoNewSharing()

--- a/tests/integration/test_integrity.py
+++ b/tests/integration/test_integrity.py
@@ -3,7 +3,6 @@ byte-for-byte, while duplicates actually get shared. The catch-all that would
 flag any dedupe path that corrupts, truncates, or loses data."""
 
 import os
-import subprocess
 from harness import DuperemoveTest, requires_reflink
 
 MiB = 1 << 20
@@ -11,9 +10,6 @@ MiB = 1 << 20
 
 @requires_reflink
 class IntegrityTest(DuperemoveTest):
-    def _sync(self):
-        subprocess.run(["sync"])
-
     def test_mixed_tree_integrity(self):
         t = self.path("tree")
 
@@ -38,13 +34,13 @@ class IntegrityTest(DuperemoveTest):
         self.make_sparse("tree/sparse/s1", head, 262144, tail)
         self.make_sparse("tree/sparse/s2", head, 262144, tail)
 
-        self._sync()
+        self.sync()
         before = self.tree_digest(t)
         nfiles = sum(len(f) for _r, _d, f in os.walk(t))
 
         self.dedupe(t)
         self.assertDmOk()
-        self._sync()
+        self.sync()
 
         # Nothing corrupted or lost.
         self.assertEqual(before, self.tree_digest(t), "every file byte-identical after dedupe")
@@ -64,11 +60,11 @@ class IntegrityTest(DuperemoveTest):
         t = self.path("tree")
         self.mkdup("tree/a", "tree/b", MiB)
         self.mkrand("tree/c", MiB)
-        self._sync()
+        self.sync()
 
-        self.dedupe(t); self.assertDmOk(); self._sync()
+        self.dedupe(t); self.assertDmOk(); self.sync()
         after_first = self.tree_digest(t)
 
-        self.dedupe(t); self.assertDmOk(); self._sync()
+        self.dedupe(t); self.assertDmOk(); self.sync()
         self.assertEqual(after_first, self.tree_digest(t), "second full run preserves data")
         self.assertNoNewSharing()


### PR DESCRIPTION
The `@requires_reflink` dedupe tests all use *identical* files → **whole-file** dedupe, never reaching `fiemap_scan_extent()`/`fiemap_count_shared()` (the functions #402/#14/#15 rewrote). Adds `test_extent_dedupe.py`: two files with distinct heads and an identical, separately-extented tail, so only the **extent pass** can share them. Asserts the tail is shared, data is preserved, and a second pass adds no new sharing.

Honest scope: it can't pin `fiemap_scan_extent()`'s exact post-dedupe offset — that value is only a hint for the "already-deduped" check, and the kernel byte-verifies every dedupe, so a wrong hint changes neither data nor sharing. It guards the path against crashes and sharing/data regressions (previously zero coverage).

`/simplify`: the review flagged that `_sync()` was now copy-pasted across four test files — hoisted it to the harness as `sync()` and dropped the local copies + unused imports. 43 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)