### PR TITLE
dbfile: set a busy_timeout to retry transient lock contention

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -304,6 +304,20 @@ static int dbfile_set_modes(sqlite3 *db)
 	}
 
 	/*
+	 * Wait out transient lock contention instead of failing immediately.
+	 * The hashfile is touched by several connections (the listing reader,
+	 * the batched writer, the csum and dedupe workers); without a timeout a
+	 * brief overlap - e.g. a WAL checkpoint racing a write - surfaces as
+	 * "database is locked" (SQLITE_BUSY). 30s comfortably covers the ~10s
+	 * batched write transaction.
+	 */
+	ret = sqlite3_exec(db, "PRAGMA busy_timeout = 30000", NULL, NULL, NULL);
+	if (ret) {
+		perror_sqlite(ret, "setting busy timeout");
+		return ret;
+	}
+
+	/*
 	 * The default (no --hashfile) database is an in-memory shared-cache db
 	 * (see MEMDB_FILENAME) shared by the listing reader, the batched writer
 	 * and the csum workers - all separate connections. Shared-cache does


### PR DESCRIPTION
The hashfile is opened by several connections (listing reader, batched writer, csum + dedupe workers). With **no `busy_timeout`**, SQLite returns "database is locked" (`SQLITE_BUSY`) the instant two of them briefly contend — e.g. a WAL checkpoint racing a write — instead of waiting.

Set `PRAGMA busy_timeout = 30000` in `dbfile_set_modes()` (runs on every handle), so operations retry for up to 30s (well over the ~10s batched write transaction) before erroring.

This fork already serializes all writes through a single connection, so it's far less exposed than upstream's per-worker writers — but this is cheap, universal insurance against the transient-`BUSY` class of error (which is what the Fedora/upstream binary hits). Worth upstreaming too.

Build clean; 43 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)