### PR TITLE
dbfile: gated VACUUM (reclaim space only after a large prune)

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -883,6 +883,57 @@ int dbfile_get_stats(struct dbhandle *db, struct dbfile_stats *stats)
 	return ret;
 }
 
+/* Read a single-integer PRAGMA (e.g. "PRAGMA page_count"). */
+static int dbfile_pragma_uint64(sqlite3 *db, const char *pragma, uint64_t *out)
+{
+	sqlite3_stmt *stmt = NULL;
+	int ret = sqlite3_prepare_v2(db, pragma, -1, &stmt, NULL);
+
+	if (ret != SQLITE_OK)
+		return ret;
+
+	ret = sqlite3_step(stmt);
+	if (ret == SQLITE_ROW) {
+		*out = sqlite3_column_int64(stmt, 0);
+		ret = SQLITE_OK;
+	} else if (ret == SQLITE_DONE) {
+		ret = SQLITE_ERROR;
+	}
+
+	sqlite3_finalize(stmt);
+	return ret;
+}
+
+/*
+ * VACUUM reclaims free pages, but SQLite reuses them - so under normal scanning
+ * the freelist stays near empty and a full-database rewrite would reclaim
+ * nothing. It only fills up after a large prune (e.g. many deleted files
+ * removed from the hashfile), which is exactly when the rewrite pays off. So
+ * VACUUM only when a meaningful fraction of the file is actually free.
+ */
+#define VACUUM_FREE_PCT		25
+
+void dbfile_maybe_vacuum(struct dbhandle *db)
+{
+	uint64_t freelist = 0, total = 0;
+	int ret;
+
+	if (dbfile_pragma_uint64(db->db, "PRAGMA freelist_count", &freelist) ||
+	    dbfile_pragma_uint64(db->db, "PRAGMA page_count", &total))
+		return;
+
+	if (total == 0 || freelist * 100 < total * VACUUM_FREE_PCT)
+		return;
+
+	vprintf("Vacuuming hashfile: %"PRIu64" of %"PRIu64" pages free\n",
+		freelist, total);
+
+	/* Maintenance only: a failure here must not fail the run. */
+	ret = sqlite3_exec(db->db, "VACUUM", NULL, NULL, NULL);
+	if (ret)
+		perror_sqlite(ret, "vacuuming hashfile");
+}
+
 static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val)
 {
 	int ret;

--- a/dbfile.h
+++ b/dbfile.h
@@ -99,6 +99,9 @@ struct dbfile_stats {
 };
 int dbfile_get_stats(struct dbhandle *db, struct dbfile_stats *stats);
 
+/* VACUUM the hashfile, but only when enough of it is free to be worth it. */
+void dbfile_maybe_vacuum(struct dbhandle *db);
+
 uint64_t count_file_by_digest(struct dbhandle *db, unsigned char *digest,
 				bool show_block_hashes);
 

--- a/duperemove.c
+++ b/duperemove.c
@@ -781,6 +781,11 @@ int main(int argc, char **argv)
 	if (use_hashfile == H_READ || use_hashfile == H_UPDATE)
 		process_duplicates(db);
 
+	/* Reclaim space if a prune this run left the hashfile mostly free. */
+	if (options.hashfile &&
+	    (use_hashfile == H_WRITE || use_hashfile == H_UPDATE))
+		dbfile_maybe_vacuum(db);
+
 out:
 	free_all_filerecs();
 

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -201,8 +201,14 @@ class DuperemoveTest(unittest.TestCase):
     # -- hashfile (SQLite) inspection --------------------------------------
 
     def hf_query(self, sql, params=()):
-        with sqlite3.connect(self.hf) as con:
+        # NB: `with sqlite3.connect(...)` commits but does NOT close the
+        # connection - a lingering reader would hold a WAL lock and block a
+        # later duperemove run (e.g. its VACUUM). Close it explicitly.
+        con = sqlite3.connect(self.hf)
+        try:
             return con.execute(sql, params).fetchall()
+        finally:
+            con.close()
 
     def hf_count(self, table):
         return self.hf_query(f"select count(*) from {table}")[0][0]

--- a/tests/integration/test_vacuum.py
+++ b/tests/integration/test_vacuum.py
@@ -1,0 +1,53 @@
+"""Gated VACUUM: the hashfile is only vacuumed when a prune has left it mostly
+free. Ordinary runs must not rewrite it - SQLite reuses freed pages, so the
+freelist stays near empty and a full VACUUM would reclaim nothing.
+"""
+
+import os
+import sqlite3
+from harness import DuperemoveTest
+
+# Enough files that the hashfile spans many pages, so pruning most rows frees
+# whole pages (SQLite only reclaims a page once it is entirely empty).
+N = 3000
+
+
+class VacuumTest(DuperemoveTest):
+    def _populate(self):
+        for i in range(N):
+            self.mkrand(f"tree/f{i}", 4096)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+
+    def _prune_deleted_rows(self):
+        """Delete hashfile rows for files no longer on disk (a big prune)."""
+        con = sqlite3.connect(self.hf)
+        gone = [r[0] for r in con.execute("select id, filename from files")
+                if not os.path.exists(r[1])]
+        con.executemany("delete from files where id = ?", [(i,) for i in gone])
+        con.execute("delete from extents where fileid not in (select id from files)")
+        con.execute("delete from blocks where fileid not in (select id from files)")
+        con.commit()
+        con.close()
+
+    def test_no_vacuum_on_ordinary_rescan(self):
+        self._populate()
+        size = os.path.getsize(self.hf)
+        self.scan(self.path("tree"))          # unchanged -> nothing freed
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_scalar("PRAGMA freelist_count"))
+        self.assertEqual(size, os.path.getsize(self.hf), "no-op rescan must not rewrite")
+
+    def test_vacuum_after_large_prune(self):
+        self._populate()
+        # remove 90% of the files and prune their rows -> free pages pile up
+        for i in range(N * 9 // 10):
+            os.remove(self.path(f"tree/f{i}"))
+        self._prune_deleted_rows()
+        before = os.path.getsize(self.hf)
+        self.assertGreater(self.hf_scalar("PRAGMA freelist_count"), 0, "prune should free pages")
+
+        self.scan(self.path("tree"))          # end-of-run vacuum kicks in
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_scalar("PRAGMA freelist_count"), "vacuum reclaimed free pages")
+        self.assertLess(os.path.getsize(self.hf), before, "hashfile shrank")


### PR DESCRIPTION
The hashfile can accumulate free pages after a big prune (many deleted files removed). VACUUM reclaims them — but a full VACUUM rewrites the whole database, and under normal use there's nothing to reclaim (SQLite reuses freed pages, so the freelist stays ~0). Running it every time would be pure waste.

So `dbfile_maybe_vacuum()` checks `freelist_count`/`page_count` (two instant pragmas) at end of run and VACUUMs **only when ≥25% of the file is free** — i.e. after a large prune, which is exactly when it pays off.

Measured: a no-op rescan reclaims nothing and is skipped; after pruning ~90% of rows the hashfile shrank e.g. **794K → 139K**.

Includes an integration test (both the no-vacuum and the vacuum-after-prune cases). Also fixes a harness bug it surfaced: `hf_query()` used `with sqlite3.connect(...)`, which commits but doesn't **close** the connection — the lingering reader held a WAL lock that blocked the VACUUM. Now closed explicitly. 45 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)