### PR TITLE
Unified live status for scan and dedupe; skip size-changed files instead of EINVAL

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -235,12 +235,23 @@ static void add_dedupe_request(struct dedupe_ctxt *ctxt,
 		(unsigned long long)req->req_loff, same->dest_count);
 }
 
+/*
+ * Cap on the length a single ioctl round requests. Modern kernels dedupe the
+ * whole requested length in one call, which would make a large group a single
+ * opaque multi-second syscall; short rounds keep the requeue loop (and with it
+ * the live status and cancellation points) turning over. The per-round setup
+ * cost is trivial next to the kernel's byte-compare of the data itself.
+ */
+#define DEDUPE_ROUND_LEN	(32ULL * 1024 * 1024)
+
 static void set_aligned_same_length(struct dedupe_ctxt *ctxt,
 				    struct file_dedupe_range *same)
 {
 	same->src_length = ctxt->len;
-	if (fs_blocksize != 0 && ctxt->len > fs_blocksize)
-		same->src_length = ctxt->len & ~(fs_blocksize - 1);
+	if (same->src_length > DEDUPE_ROUND_LEN)
+		same->src_length = DEDUPE_ROUND_LEN;
+	if (fs_blocksize != 0 && same->src_length > fs_blocksize)
+		same->src_length &= ~((uint64_t)fs_blocksize - 1);
 }
 
 static void populate_dedupe_request(struct dedupe_ctxt *ctxt,
@@ -390,6 +401,14 @@ retry:
 		}
 
 		process_dedupes(ctxt, ctxt->same);
+
+		if (ctxt->progress) {
+			uint64_t round = 0;
+
+			for (unsigned int i = 0; i < ctxt->same->dest_count; i++)
+				round += ctxt->same->info[i].bytes_deduped;
+			*ctxt->progress += round;
+		}
 	}
 
 	return ret;

--- a/dedupe.h
+++ b/dedupe.h
@@ -51,6 +51,13 @@ struct dedupe_ctxt {
 	struct list_head	in_progress;
 	struct list_head	completed;
 
+	/*
+	 * Optional live progress counter: when set, dedupe_extents() adds the
+	 * bytes deduped after every ioctl round, so a status display can show
+	 * movement inside large requests instead of one jump at the end.
+	 */
+	uint64_t		*progress;
+
 	struct file_dedupe_range *same;
 };
 

--- a/duperemove.c
+++ b/duperemove.c
@@ -552,6 +552,7 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq)
 	init_hash_tree(&dups_tree);
 
 	vprintf("Loading identical files...\n");
+	pdedupe_set_activity("loading identical files");
 	ret = dbfile_load_same_files(db, &res, seq + 1);
 	if (ret)
 		goto out;
@@ -568,6 +569,7 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq)
 		init_results_tree(&res);
 
 		vprintf("Loading duplicated hashes...\n");
+		pdedupe_set_activity("loading duplicate extents");
 
 		ret = dbfile_load_extent_hashes(db, &res, seq + 1);
 		if (ret)
@@ -598,6 +600,7 @@ out:
 static void process_duplicates(struct dbhandle *db)
 {
 	unsigned int max = get_max_dedupe_seq(db);
+	unsigned int first_seq = dedupe_seq;	/* bumped inside the loop */
 
 	/*
 	 * Ensure the find-dupes indexes exist. Normally built at the end of the
@@ -612,8 +615,9 @@ static void process_duplicates(struct dbhandle *db)
 	if (options.do_block_hash)
 		extents_search_init();
 
-	/* One status line + one summary spanning every pass below. Estimate the
-	 * total dup-group count first so the progress bar and ETA have a scale. */
+	/* One status area + one summary spanning every batch below. Estimate
+	 * the total dup-group count first so the progress and ETA have a
+	 * scale. */
 	if (options.run_dedupe) {
 		unsigned long long total;
 
@@ -622,10 +626,13 @@ static void process_duplicates(struct dbhandle *db)
 			fflush(stdout);
 		}
 		total = dbfile_count_dupe_groups(db, options.only_whole_files);
-		dedupe_begin(total);
+		pdedupe_begin(total, max > dedupe_seq ? max - dedupe_seq : 0);
 	}
 
-	for (unsigned int i = dedupe_seq; i < max; i++) {
+	for (unsigned int i = first_seq; i < max; i++) {
+		if (options.run_dedupe)
+			pdedupe_set_batch(i - first_seq + 1);
+
 		/* Drop all filerecs from the previous iteration. Needed filerecs will be
 		 * recreated by __process_duplicates()
 		 */

--- a/file_scan.c
+++ b/file_scan.c
@@ -1448,10 +1448,9 @@ static void csum_whole_file(struct file_to_scan *file)
 	 */
 	struct dbhandle *db = scan_writer;
 	static __thread struct buffer buffer = {0,};
-	static __thread struct pscan_thread *tls_progress = NULL;
 
 	/* Dummy variables used to trigger the cleanup code */
-	_cleanup_(pscan_reset_thread) struct pscan_thread *tprogress = tls_progress;
+	_cleanup_(pscan_reset_thread) struct pscan_thread *tprogress = NULL;
 	_cleanup_(freep) char *path = file->path;
 	_cleanup_(freep) struct file_to_scan *clean_file = file;
 
@@ -1480,13 +1479,10 @@ static void csum_whole_file(struct file_to_scan *file)
 		return;
 	}
 
-	if (!tls_progress) {
-		tls_progress = pscan_register_thread(gettid());
-		abort_on(!tls_progress);
-		tprogress = tls_progress;
-	}
+	/* Claimed per file, not per thread: see pscan_claim_slot(). */
+	tprogress = pscan_claim_slot(gettid(), thread_scanning);
+	abort_on(!tprogress);
 
-	tprogress->status = thread_scanning;
 	tprogress->file_scanned_bytes = 0;
 	tprogress->file_total_bytes = file->filesize;
 	strncpy(tprogress->file_path, file->path, PATH_MAX);

--- a/progress.c
+++ b/progress.c
@@ -92,7 +92,8 @@ static struct {
 #define s_clear() if (tty) printf("\33[J");
 #define s_printf(args...) do { if (tty) printf("\33[K"); printf(args); } while (0)
 
-#define percent(val1, val2) ((double) val1 / (double) val2 * 100)
+#define percent(val1, val2) \
+	((val2) ? (double) (val1) / (double) (val2) * 100 : 0.0)
 
 void pscan_finish_listing(void)
 {
@@ -124,8 +125,8 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 			tprogress->tid,
 			"checksumming:",
 			tprogress->file_path,
-			pretty_size(tprogress->file_scanned_bytes),
-			pretty_size(tprogress->file_total_bytes),
+			human_size(tprogress->file_scanned_bytes),
+			human_size(tprogress->file_total_bytes),
 			percent(tprogress->file_scanned_bytes, tprogress->file_total_bytes));
 		break;
 	case thread_waiting_lock:
@@ -133,22 +134,22 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 			tprogress->tid,
 			"waiting for lock:",
 			tprogress->file_path,
-			pretty_size(tprogress->file_total_bytes));
+			human_size(tprogress->file_total_bytes));
 		break;
 	case thread_committing:
 		snprintf(buf, BUF_LEN, "[%u] %-20s%s (size: %s)",
 			tprogress->tid,
 			"committing:",
 			tprogress->file_path,
-			pretty_size(tprogress->file_total_bytes));
+			human_size(tprogress->file_total_bytes));
 		break;
 	case thread_deduping:
 		snprintf(buf, BUF_LEN, "[%u] %-20s%s: %s/%s (%05.2f%%)",
 			tprogress->tid,
 			"deduping:",
 			tprogress->file_path,
-			pretty_size(tprogress->file_scanned_bytes),
-			pretty_size(tprogress->file_total_bytes),
+			human_size(tprogress->file_scanned_bytes),
+			human_size(tprogress->file_total_bytes),
 			percent(tprogress->file_scanned_bytes, tprogress->file_total_bytes));
 		break;
 	}
@@ -179,12 +180,12 @@ static void print_scan_progress(void)
 	s_printf("\tFiles scanned: %lu/%lu (%05.2f%%)\n",
 	      files_scanned, tf, tf ? (double)files_scanned / tf * 100 : 100.0);
 	s_printf("\tBytes scanned: %s/%s (%05.2f%%)",
-	      pretty_size(bytes_scanned), pretty_size(tb),
+	      human_size(bytes_scanned), human_size(tb),
 	      tb ? (double)bytes_scanned / tb * 100 : 100.0);
 	if (bytes_scanned && elapsed > 1.0) {
 		double rate = bytes_scanned / elapsed;
 
-		printf(" · %s/s", pretty_size((uint64_t)rate));
+		printf(" · %s/s", human_size((uint64_t)rate));
 		if (bytes_scanned < tb)
 			printf(" · ETA ~%s",
 			       human_duration((tb - bytes_scanned) / rate));
@@ -219,7 +220,7 @@ static void print_dedupe_progress(void)
 	printf("\n");
 
 	s_printf("\tSpace reclaimed: %s · kernel verified: %s\n",
-		 pretty_size(pdd.reclaimed), pretty_size(pdd.kern));
+		 human_size(pdd.reclaimed), human_size(pdd.kern));
 
 	s_printf("\tStatus: %s", pdd.activity ? pdd.activity : "working");
 	if (st)
@@ -427,12 +428,15 @@ void pscan_printf(char *fmt, ...)
 }
 
 /*
- * Claim a per-thread display slot for one dedupe group. Dedupe passes run on
- * short-lived exclusive thread pools (one per pass), so slots are claimed per
- * group and released via pscan_reset_thread() instead of being tied to the OS
- * thread - the number of live slots stays bounded by the pool size.
+ * Claim a per-thread display slot for one unit of work (a file scan, a dedupe
+ * group). Worker pools churn OS threads (glib reaps idle pool threads and
+ * spawns fresh ones), so slots are claimed per work item and released via
+ * pscan_reset_thread() instead of being tied to the OS thread - dead threads
+ * can't strand "idle" lines and the number of live slots stays bounded by the
+ * pool size instead of growing with thread turnover.
  */
-struct pscan_thread *pdedupe_claim_slot(pid_t tid)
+struct pscan_thread *pscan_claim_slot(pid_t tid,
+				      enum pscan_thread_status status)
 {
 	struct pscan_thread *slot = NULL;
 
@@ -441,7 +445,7 @@ struct pscan_thread *pdedupe_claim_slot(pid_t tid)
 		if (pscan.threads[i]->status == thread_idle) {
 			slot = pscan.threads[i];
 			slot->tid = tid;
-			slot->status = thread_deduping;
+			slot->status = status;
 			break;
 		}
 	}
@@ -449,7 +453,7 @@ struct pscan_thread *pdedupe_claim_slot(pid_t tid)
 
 	if (!slot) {
 		slot = pscan_register_thread(tid);
-		slot->status = thread_deduping;
+		slot->status = status;
 	}
 	return slot;
 }

--- a/progress.c
+++ b/progress.c
@@ -68,6 +68,25 @@ static uint64_t files_scanned, bytes_scanned;
  */
 static _Atomic uint64_t search_total, search_processed;
 
+/*
+ * Dedupe-phase status. The counters accumulate whether or not the live
+ * display runs (they feed the final summary). `running` gates the printer
+ * thread; `phase` switches the shared screen area between scan and dedupe
+ * rendering.
+ */
+static struct {
+	bool			phase;		/* rendering dedupe, not scan */
+	volatile int		running;
+	gint64			start_us;	/* phase start, monotonic */
+
+	_Atomic uint64_t	done;		/* groups finished */
+	_Atomic uint64_t	queued;		/* groups pushed to the pool */
+	uint64_t		estimate;	/* fuzzy total, see dbfile */
+	unsigned int		batch, batches;
+	const char		*activity;	/* static string */
+	_Atomic uint64_t	reclaimed, kern;
+} pdd;
+
 #define s_save_pos() if (tty) printf("\33[s");
 #define s_restore_pos() if (tty) printf("\33[u");
 #define s_clear() if (tty) printf("\33[J");
@@ -123,16 +142,26 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 			tprogress->file_path,
 			pretty_size(tprogress->file_total_bytes));
 		break;
+	case thread_deduping:
+		snprintf(buf, BUF_LEN, "[%u] %-20s%s: %s/%s (%05.2f%%)",
+			tprogress->tid,
+			"deduping:",
+			tprogress->file_path,
+			pretty_size(tprogress->file_scanned_bytes),
+			pretty_size(tprogress->file_total_bytes),
+			percent(tprogress->file_scanned_bytes, tprogress->file_total_bytes));
+		break;
 	}
 
 	/* Truncate the output to keep at most one line per thread */
 	s_printf("%.*s\n", w_col, buf);
 }
 
-static void print_total_progress(void)
+static void print_scan_progress(void)
 {
 	uint64_t tf = pscan.total_files_count;
 	uint64_t tb = pscan.total_bytes_count;
+	double elapsed = elapsed_seconds();
 
 	if (!pscan.listing_completed) {
 		/*
@@ -149,10 +178,66 @@ static void print_total_progress(void)
 
 	s_printf("\tFiles scanned: %lu/%lu (%05.2f%%)\n",
 	      files_scanned, tf, tf ? (double)files_scanned / tf * 100 : 100.0);
-	s_printf("\tBytes scanned: %s/%s (%05.2f%%)\n",
+	s_printf("\tBytes scanned: %s/%s (%05.2f%%)",
 	      pretty_size(bytes_scanned), pretty_size(tb),
 	      tb ? (double)bytes_scanned / tb * 100 : 100.0);
+	if (bytes_scanned && elapsed > 1.0) {
+		double rate = bytes_scanned / elapsed;
+
+		printf(" · %s/s", pretty_size((uint64_t)rate));
+		if (bytes_scanned < tb)
+			printf(" · ETA ~%s",
+			       human_duration((tb - bytes_scanned) / rate));
+	}
+	printf("\n");
 	s_printf("\tFile listing: completed\n");
+}
+
+static void print_dedupe_progress(void)
+{
+	uint64_t done = pdd.done;
+	uint64_t queued = pdd.queued;
+	uint64_t total = pdd.estimate > queued ? pdd.estimate : queued;
+	uint64_t sd = search_processed, st = search_total;
+	double elapsed = (g_get_monotonic_time() - pdd.start_us) / 1e6;
+	unsigned int pct = 0;
+
+	/*
+	 * The total is fuzzy until the very last batch is queued (and the
+	 * whole-file pass shrinks the extent-group count as it goes), so mark
+	 * it "~" and never claim 100% while the phase is still running.
+	 */
+	if (total) {
+		pct = (unsigned int)(100.0 * done / total);
+		if (pct > 99)
+			pct = 99;
+	}
+
+	s_printf("\tGroups deduped: %lu/~%lu (%u%%)", done, total, pct);
+	if (pdd.batches > 1)
+		printf(" · batch %u/%u", pdd.batch, pdd.batches);
+	printf("\n");
+
+	s_printf("\tSpace reclaimed: %s · kernel verified: %s\n",
+		 pretty_size(pdd.reclaimed), pretty_size(pdd.kern));
+
+	s_printf("\tStatus: %s", pdd.activity ? pdd.activity : "working");
+	if (st)
+		printf(" (%lu/%lu files)", sd, st);
+	if (elapsed > 1.0)
+		printf(" · elapsed %s", human_duration(elapsed));
+	if (done > 20 && elapsed > 2.0 && done < total)
+		printf(" · ETA ~%s",
+		       human_duration((total - done) / (done / elapsed)));
+	printf("\n");
+}
+
+static void print_total_progress(void)
+{
+	if (pdd.phase)
+		print_dedupe_progress();
+	else
+		print_scan_progress();
 }
 
 static void prepare_screen_area(void)
@@ -199,10 +284,11 @@ static void *pscan_progress_thread(void * p)
 {
 	struct winsize w;
 	do {
-		/* Refresh the tty properties */
+		/* Refresh the tty properties. Some ttys (e.g. bare ptys)
+		 * report a zero width; treat that as "don't truncate". */
 		if (tty) {
 			ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-			w_col = w.ws_col;
+			w_col = w.ws_col ? w.ws_col : UINT_MAX;
 		} else {
 			w_col = UINT_MAX;
 		}
@@ -213,11 +299,21 @@ static void *pscan_progress_thread(void * p)
 
 		/* Do not waste too much cpu */
 		usleep(1000 * (tty ? 100 : 1000));
-	} while (!pscan.listing_completed
-		|| files_scanned != pscan.total_files_count
-		|| bytes_scanned != pscan.total_bytes_count);
+	} while (pdd.phase ? pdd.running
+			   : (!pscan.listing_completed
+			      || files_scanned != pscan.total_files_count
+			      || bytes_scanned != pscan.total_bytes_count));
 
 	return NULL;
+}
+
+static void pscan_free_threads(void)
+{
+	for (unsigned int i = 0; i < pscan.thread_count; i++)
+		free(pscan.threads[i]);
+	free(pscan.threads);
+	pscan.threads = NULL;
+	pscan.thread_count = 0;
 }
 
 struct pscan_thread *pscan_register_thread(pid_t tid)
@@ -263,8 +359,7 @@ void pscan_join(void)
 
 	print_total_progress();
 
-	for (unsigned int i = 0; i < pscan.thread_count; i++)
-		free(pscan.threads[i]);
+	pscan_free_threads();
 
 	printer = NULL;
 }
@@ -331,6 +426,110 @@ void pscan_printf(char *fmt, ...)
 	g_mutex_unlock(&pscan.mutex);
 }
 
+/*
+ * Claim a per-thread display slot for one dedupe group. Dedupe passes run on
+ * short-lived exclusive thread pools (one per pass), so slots are claimed per
+ * group and released via pscan_reset_thread() instead of being tied to the OS
+ * thread - the number of live slots stays bounded by the pool size.
+ */
+struct pscan_thread *pdedupe_claim_slot(pid_t tid)
+{
+	struct pscan_thread *slot = NULL;
+
+	g_mutex_lock(&pscan.mutex);
+	for (unsigned int i = 0; i < pscan.thread_count; i++) {
+		if (pscan.threads[i]->status == thread_idle) {
+			slot = pscan.threads[i];
+			slot->tid = tid;
+			slot->status = thread_deduping;
+			break;
+		}
+	}
+	g_mutex_unlock(&pscan.mutex);
+
+	if (!slot) {
+		slot = pscan_register_thread(tid);
+		slot->status = thread_deduping;
+	}
+	return slot;
+}
+
+void pdedupe_begin(uint64_t estimated_groups, unsigned int batches)
+{
+	pdd.done = 0;
+	pdd.queued = 0;
+	pdd.reclaimed = 0;
+	pdd.kern = 0;
+	pdd.estimate = estimated_groups;
+	pdd.batches = batches;
+	pdd.batch = batches ? 1 : 0;
+	pdd.activity = "analyzing duplicates";
+	pdd.start_us = g_get_monotonic_time();
+	pdd.phase = true;
+
+	/*
+	 * The live area only makes sense on a tty; under -v the per-group
+	 * notices would fight with the redraws, and -q wants silence. The
+	 * counters above accumulate regardless, for the final summary.
+	 */
+	if (quiet || verbose || !isatty(STDOUT_FILENO))
+		return;
+
+	tty = true;
+	printf("\33[?25l");	/* hide the cursor */
+	prepare_screen_area();
+	pdd.running = 1;
+	printer = g_thread_new("progress_printer", pscan_progress_thread, NULL);
+}
+
+void pdedupe_end(void)
+{
+	if (pdd.running) {
+		pdd.running = 0;
+		g_thread_join(printer);
+		printer = NULL;
+
+		/* Show the cursor again and clear the status area; the caller
+		 * prints the final summary. */
+		printf("\33[?25h");
+		s_restore_pos();
+		s_clear();
+		s_restore_pos();
+		fflush(stdout);
+	}
+	pscan_free_threads();
+	pdd.phase = false;
+}
+
+void pdedupe_set_batch(unsigned int cur)
+{
+	pdd.batch = cur;
+}
+
+void pdedupe_set_activity(const char *activity)
+{
+	pdd.activity = activity;
+}
+
+void pdedupe_add_queued(uint64_t ngroups)
+{
+	atomic_fetch_add(&pdd.queued, ngroups);
+}
+
+void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes)
+{
+	atomic_fetch_add(&pdd.done, 1);
+	atomic_fetch_add(&pdd.reclaimed, reclaimed_bytes);
+	atomic_fetch_add(&pdd.kern, kern_bytes);
+}
+
+void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *kern)
+{
+	*groups = pdd.done;
+	*reclaimed = pdd.reclaimed;
+	*kern = pdd.kern;
+}
+
 static void *psearch_progress_thread(void * p)
 {
 	static int last_pos = -1;
@@ -368,11 +567,26 @@ void psearch_run(uint64_t num_filerecs)
 {
 	search_processed = 0;
 	search_total = num_filerecs;
+
+	/*
+	 * During the dedupe phase the search is rendered as a live count on
+	 * the shared status area; the standalone bar is only for runs without
+	 * that area (e.g. print-only mode).
+	 */
+	if (pdd.phase) {
+		pdedupe_set_activity("searching block-level matches");
+		return;
+	}
 	printer = g_thread_new("progress_printer", psearch_progress_thread, NULL);
 }
 
 void psearch_join(void)
 {
+	if (pdd.phase) {
+		search_total = 0;
+		search_processed = 0;
+		return;
+	}
 	g_thread_join(printer);
 	printer = NULL;
 }

--- a/progress.h
+++ b/progress.h
@@ -10,6 +10,7 @@ enum pscan_thread_status {
 	thread_scanning,
 	thread_waiting_lock,
 	thread_committing,
+	thread_deduping,
 };
 
 struct pscan_thread {
@@ -80,6 +81,44 @@ bool is_progress_printer_running(void);
  * This function is used to write something before that area
  */
 void pscan_printf(char *fmt, ...);
+
+/*
+ * Dedupe-phase status. Reuses the same reserved screen area, per-thread lines
+ * and totals block as the scan, so both phases look alike. The counters are
+ * always maintained (they feed the final summary); the live display only runs
+ * on a tty and outside -q/-v.
+ *
+ * The displayed total is max(estimated, queued-so-far) and the percentage is
+ * capped at 99% - the estimate is deliberately fuzzy (see
+ * dbfile_count_dupe_groups()), and a bar pinned at 100% while work continues
+ * is worse than one that finishes from 99%.
+ */
+void pdedupe_begin(uint64_t estimated_groups, unsigned int batches);
+void pdedupe_end(void);
+
+/* Starting duplicate-batch cur (1-based) of the batches passed to begin. */
+void pdedupe_set_batch(unsigned int cur);
+
+/*
+ * What the phase is doing right now ("loading identical files", ...): shown on
+ * the status line so the pauses between dedupes are explained. Must be a
+ * string literal / static string.
+ */
+void pdedupe_set_activity(const char *activity);
+
+/* A group was pushed to / finished by the dedupe pool. */
+void pdedupe_add_queued(uint64_t ngroups);
+void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes);
+
+/*
+ * Claim a per-thread display line for one dedupe group; fill in file_path /
+ * file_total_bytes / file_scanned_bytes like a scan thread would. Release it
+ * with pscan_reset_thread().
+ */
+struct pscan_thread *pdedupe_claim_slot(pid_t tid);
+
+/* Read back the accumulated totals (for the end-of-run summary). */
+void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *kern);
 
 /*
  * Start the "extent search" progress thread

--- a/progress.h
+++ b/progress.h
@@ -111,11 +111,14 @@ void pdedupe_add_queued(uint64_t ngroups);
 void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes);
 
 /*
- * Claim a per-thread display line for one dedupe group; fill in file_path /
- * file_total_bytes / file_scanned_bytes like a scan thread would. Release it
- * with pscan_reset_thread().
+ * Claim a per-thread display line for one unit of work (file scan / dedupe
+ * group) and mark it with `status`; fill in file_path / file_total_bytes /
+ * file_scanned_bytes afterwards. Release it with pscan_reset_thread(). Claim
+ * per work item, not per OS thread: pool threads get reaped and respawned,
+ * which would strand dead threads' lines and grow the display unboundedly.
  */
-struct pscan_thread *pdedupe_claim_slot(pid_t tid);
+struct pscan_thread *pscan_claim_slot(pid_t tid,
+				      enum pscan_thread_status status);
 
 /* Read back the accumulated totals (for the end-of-run summary). */
 void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *kern);

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <stdatomic.h>
+#include <sys/stat.h>
 
 #include <glib.h>
 
@@ -412,6 +413,42 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			if (ctxt && last)
 				goto run_dedupe;
 			continue;
+		}
+
+		/*
+		 * The file may have been rewritten since it was scanned. A
+		 * range past the current EOF makes the kernel fail the whole
+		 * destination with EINVAL, as does an unaligned length that no
+		 * longer ends exactly at EOF (whole-file dedupe of odd-sized
+		 * files relies on that). Either way the content changed - skip
+		 * the member and let the next scan re-hash it, and count it
+		 * with the "changed since scan" results.
+		 *
+		 * Whole-file groups carry the exact scanned size, so any size
+		 * change disqualifies. Extent lengths come from fiemap and are
+		 * rounded up to the next block, so a final extent legitimately
+		 * overshoots EOF by up to a block (clamped before the ioctl) -
+		 * only a shortfall of a whole block or more means the file
+		 * really shrank.
+		 */
+		{
+			struct stat st;
+
+			if (fstat(extent->e_file->fd, &st) == 0 &&
+			    (whole_file_dedup ?
+			     (uint64_t)st.st_size != len :
+			     (uint64_t)st.st_size + 4095 < extent->e_loff + len)) {
+				atomic_fetch_add(&dedupe_dest_differs, 1);
+				vprintf("%s: changed since scan (size %llu, "
+					"expected %llu). Skipping dedupe.\n",
+					extent->e_file->filename,
+					(unsigned long long)st.st_size,
+					(unsigned long long)(extent->e_loff + len));
+				/* stays on open_files; closed with the group */
+				if (ctxt && last)
+					goto run_dedupe;
+				continue;
+			}
 		}
 
 		vprintf("[%p] Add extent for file \"%s\" at offset %s (%d)\n",

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -51,11 +51,6 @@ static volatile unsigned long long curr_dedupe_pass;
 static unsigned int leading_spaces;
 static bool whole_file_dedup;
 
-/* Cross-pass dedupe stats, accumulated across every dedupe_results() call. */
-static volatile unsigned long long dedupe_groups_done;
-static uint64_t dedupe_total_bytes;
-static uint64_t dedupe_total_kern;
-
 void print_dupes_table(struct results_tree *res, bool whole_file)
 {
 	struct rb_root *root = &res->root;
@@ -306,8 +301,10 @@ static void pick_least_fragmented_target(struct dupe_extents *dext)
 }
 
 #define	DEDUPE_EXTENTS_CLEANED	(-1)
-static int dedupe_extent_list(struct dupe_extents *dext, uint64_t *fiemap_bytes,
-			      uint64_t *kern_bytes, unsigned long long passno)
+static int dedupe_extent_list(struct dupe_extents *dext,
+			      struct pscan_thread *slot,
+			      uint64_t *fiemap_bytes, uint64_t *kern_bytes,
+			      unsigned long long passno)
 {
 	int ret = 0;
 	int last = 0;
@@ -359,6 +356,14 @@ static int dedupe_extent_list(struct dupe_extents *dext, uint64_t *fiemap_bytes,
 	 */
 	if (whole_file_dedup)
 		pick_least_fragmented_target(dext);
+
+	/* clean_deduped/target selection may have changed the group; show the
+	 * real target and remaining work on this thread's status line. */
+	strncpy(slot->file_path,
+		list_first_entry(&dext->de_extents, struct extent,
+				 e_list)->e_file->filename, PATH_MAX);
+	slot->file_total_bytes = len * (dext->de_num_dupes - 1);
+	slot->file_scanned_bytes = 0;
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
 		if (list_is_last(&extent->e_list, &dext->de_extents))
@@ -422,6 +427,8 @@ static int dedupe_extent_list(struct dupe_extents *dext, uint64_t *fiemap_bytes,
 				ret = ENOMEM;
 				goto out;
 			}
+			/* Tick the status line as ioctl rounds complete. */
+			ctxt->progress = &slot->file_scanned_bytes;
 
 			/*
 			 * If we just picked the target, it got added
@@ -526,13 +533,8 @@ out:
 	return ret;
 }
 
-static GMutex dedupe_counts_mutex;
-struct dedupe_counts {
-	uint64_t	kern_bytes;
-	uint64_t	fiemap_bytes;
-};
-
 static int extent_dedupe_worker(struct dupe_extents *dext,
+				struct pscan_thread *slot,
 				uint64_t *fiemap_bytes, uint64_t *kern_bytes)
 {
 	int ret;
@@ -541,7 +543,7 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 	struct extent *extent;
 	struct dbhandle *db = dbfile_get_handle();
 
-	ret = dedupe_extent_list(dext, fiemap_bytes, kern_bytes, passno);
+	ret = dedupe_extent_list(dext, slot, fiemap_bytes, kern_bytes, passno);
 	if (ret) {
 		if (ret == DEDUPE_EXTENTS_CLEANED)
 			return 0;
@@ -549,7 +551,9 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 		return ret;
 	}
 
+	slot->status = thread_waiting_lock;
 	dbfile_lock();
+	slot->status = thread_committing;
 	/*
 	 * Wrap all of this group's hashfile updates in a single transaction.
 	 * Otherwise every dbfile_update_extent_poff()/remove is its own implicit
@@ -587,18 +591,29 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 	return 0;
 }
 
-static void dedupe_worker(void *priv, struct dedupe_counts *counts)
+static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 {
 	uint64_t fiemap_bytes = 0ULL;
 	uint64_t kern_bytes = 0ULL;
+	struct dupe_extents *dext = priv;
+	_cleanup_(pscan_reset_thread) struct pscan_thread *slot =
+						pdedupe_claim_slot(gettid());
 
-	extent_dedupe_worker(priv, &fiemap_bytes, &kern_bytes);
+	/*
+	 * Seed the display line from the group before any work: first member
+	 * as the (provisional) target path, and the data the kernel has to
+	 * byte-verify - group length times the number of copies to dedupe -
+	 * as the work total.
+	 */
+	strncpy(slot->file_path,
+		list_first_entry(&dext->de_extents, struct extent,
+				 e_list)->e_file->filename, PATH_MAX);
+	slot->file_total_bytes = dext->de_len * (dext->de_num_dupes - 1);
+	slot->file_scanned_bytes = 0;
 
-	g_mutex_lock(&dedupe_counts_mutex);
-	counts->fiemap_bytes += fiemap_bytes;
-	counts->kern_bytes += kern_bytes;
-	dedupe_groups_done++;		/* for the live status line */
-	g_mutex_unlock(&dedupe_counts_mutex);
+	extent_dedupe_worker(dext, slot, &fiemap_bytes, &kern_bytes);
+
+	pdedupe_group_done(fiemap_bytes, kern_bytes);
 }
 
 static GThreadPool *dedupe_pool = NULL;
@@ -637,115 +652,36 @@ static int push_extents(struct results_tree *res)
 			g_error_free(err);
 			return 1;
 		}
+		pdedupe_add_queued(1);
 	}
 	return 0;
 }
 
 /*
- * Cross-pass dedupe stats and a single, stable, in-place status line.
- *
- * duperemove runs the dedupe in a loop (per dedupe_seq batch, whole-file then
- * extent pass), so dedupe_results() is called many times. To keep the output
- * from scrolling, we accumulate the totals in these globals across every call
- * and draw one status line that updates in place; dedupe_end() prints a single
- * final summary. Nothing here is per-pass.
+ * Close the dedupe phase (the live status is started by pdedupe_begin() and
+ * fed from the workers; see progress.c) and print one aggregated summary
+ * spanning every dedupe_results() call.
  */
-static GThread *dedupe_status_thread_h;
-static volatile int dedupe_status_running;
-static unsigned long long dedupe_total_groups;	/* estimate, for the bar/ETA */
-
-static void draw_dedupe_status(void)
-{
-	const int width = 22;
-	unsigned long long done = dedupe_groups_done;
-	unsigned long long total = dedupe_total_groups;
-	double elapsed = elapsed_seconds();
-
-	printf("\r\33[K  %sDeduplicating%s  ", col_bold, col_reset);
-
-	/*
-	 * A determinate bar + ETA is only shown while the running count is below
-	 * the estimated total. duperemove revisits groups once per dedupe_seq
-	 * batch (already-deduped ones are quick skips but still counted), so on a
-	 * repeatedly-deduped hashfile the count can exceed the distinct-group
-	 * estimate. Rather than pin a misleading "100%" while work continues, we
-	 * fall back to an honest live count with no percentage or ETA.
-	 */
-	if (total && done < total) {
-		int pos = (int)((double)done / total * width);
-		int i;
-
-		printf("%s", col_cyan);
-		for (i = 0; i < width; i++)
-			putchar(i < pos ? '#' : (i == pos ? '>' : '-'));
-		printf("%s %llu/%llu (%d%%) · %s%s%s · %s", col_reset, done, total,
-		       (int)(100.0 * done / total), col_green,
-		       human_size(dedupe_total_bytes), col_reset,
-		       human_duration(elapsed));
-		if (done > 0) {
-			double rate = done / (elapsed > 0 ? elapsed : 1);
-			printf(" · ETA ~%s", human_duration((total - done) / rate));
-		}
-	} else {
-		printf("%s%llu%s groups · %s%s%s reclaimed · %s", col_cyan, done,
-		       col_reset, col_green, human_size(dedupe_total_bytes),
-		       col_reset, human_duration(elapsed));
-	}
-	fflush(stdout);
-}
-
-static void *dedupe_status_thread(void *arg [[maybe_unused]])
-{
-	do {
-		draw_dedupe_status();
-		usleep(200000);
-	} while (dedupe_status_running);
-	printf("\r\33[K");	/* erase the status line; dedupe_end() summarizes */
-	fflush(stdout);
-	return NULL;
-}
-
-/*
- * Begin the dedupe phase: reset totals and start the in-place status line.
- * total_groups is an estimate used for the progress bar and ETA (0 = unknown,
- * in which case the status shows an indeterminate group count).
- */
-void dedupe_begin(unsigned long long total_groups)
-{
-	dedupe_groups_done = 0;
-	dedupe_total_bytes = 0;
-	dedupe_total_kern = 0;
-	dedupe_total_groups = total_groups;
-
-	if (!quiet && !verbose && isatty(STDOUT_FILENO)) {
-		dedupe_status_running = 1;
-		dedupe_status_thread_h = g_thread_new("dedupe_status",
-						      dedupe_status_thread, NULL);
-	}
-}
-
-/* End the dedupe phase: stop the status line and print one final summary. */
 void dedupe_end(void)
 {
-	if (dedupe_status_thread_h) {
-		dedupe_status_running = 0;
-		g_thread_join(dedupe_status_thread_h);
-		dedupe_status_thread_h = NULL;
-	}
+	uint64_t groups, reclaimed, kern;
+
+	pdedupe_end();
+	pdedupe_counters(&groups, &reclaimed, &kern);
 
 	/* Human summary: skipped by -q. */
 	if (!quiet) {
-		if (dedupe_groups_done == 0) {
+		if (groups == 0) {
 			printf("%sNothing to deduplicate.%s\n", col_dim, col_reset);
 		} else {
 			printf("%s%sSummary%s\n", col_bold, col_blue, col_reset);
-			printf("  %sDeduplicated%s   %s%s%s across %llu group%s\n",
+			printf("  %sDeduplicated%s   %s%s%s across %lu group%s\n",
 			       col_dim, col_reset, col_green,
-			       human_size(dedupe_total_bytes), col_reset,
-			       dedupe_groups_done, dedupe_groups_done == 1 ? "" : "s");
-			if (dedupe_total_kern)
+			       human_size(reclaimed), col_reset,
+			       groups, groups == 1 ? "" : "s");
+			if (kern)
 				printf("  %sKernel scanned%s %s\n", col_dim,
-				       col_reset, human_size(dedupe_total_kern));
+				       col_reset, human_size(kern));
 			printf("  %sElapsed%s        %.1fs\n",
 			       col_dim, col_reset, elapsed_seconds());
 		}
@@ -758,13 +694,12 @@ void dedupe_end(void)
 	 */
 	if (!isatty(STDOUT_FILENO) || quiet)
 		printf("Comparison of extent info shows a net change in "
-		       "shared extents of: %s\n", pretty_size(dedupe_total_bytes));
+		       "shared extents of: %s\n", pretty_size(reclaimed));
 }
 
 void dedupe_results(struct results_tree *res, bool whole_file)
 {
 	int ret;
-	struct dedupe_counts counts = { 0ULL, };
 	GError *err = NULL;
 
 	/*
@@ -785,7 +720,10 @@ void dedupe_results(struct results_tree *res, bool whole_file)
 
 	vprintf("Using %u threads for dedupe phase\n", options.io_threads);
 
-	dedupe_pool = g_thread_pool_new((GFunc) dedupe_worker, &counts,
+	pdedupe_set_activity(whole_file ? "deduplicating identical files"
+					: "deduplicating duplicate extents");
+
+	dedupe_pool = g_thread_pool_new((GFunc) dedupe_worker, NULL,
 					options.io_threads, TRUE, &err);
 	if (err) {
 		eprintf("Unable to create dedupe thread pool: %s\n",
@@ -804,10 +742,6 @@ void dedupe_results(struct results_tree *res, bool whole_file)
 	}
 
 	g_thread_pool_free(dedupe_pool, FALSE, TRUE);	/* waits for all work */
-
-	/* Roll this pass's totals into the cross-pass accumulators. */
-	dedupe_total_bytes += counts.fiemap_bytes;
-	dedupe_total_kern += counts.kern_bytes;
 }
 
 int fdupes_dedupe(void)

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <string.h>
 #include <inttypes.h>
+#include <stdatomic.h>
 
 #include <glib.h>
 
@@ -92,6 +93,15 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
 	}
 }
 
+/*
+ * Per-destination failures, tallied across the whole phase. A single bad
+ * group can have a hundred failing destinations; printing one line each
+ * floods the console, so the default view is one aggregate line in the final
+ * summary and the per-file detail moved behind -v.
+ */
+static _Atomic uint64_t dedupe_dest_differs;
+static _Atomic uint64_t dedupe_dest_errors;
+
 static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 				   uint64_t *kern_bytes)
 {
@@ -108,7 +118,7 @@ static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 			*kern_bytes += target_bytes;
 
 		/*
-		 * Only print in case of error.
+		 * Only report errors.
 		 *
 		 * Kernels older than 4.2 can't handle the target and
 		 * dedupe files being the same and -EINVAL in that
@@ -119,14 +129,18 @@ static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 		    (target_status == -EINVAL && f == ctxt->ioctl_file))
 			continue;
 
-		if (target_status == FILE_DEDUPE_RANGE_DIFFERS)
+		if (target_status == FILE_DEDUPE_RANGE_DIFFERS) {
 			status_str = "data changed";
-		else if (target_status < 0)
-			status_str = strerror(-target_status);
-		printf("[%p] Dedupe for file \"%s\" had status (%d) "
-		       "\"%s\".\n",
-		       g_thread_self(), f->filename, target_status,
-		       status_str);
+			atomic_fetch_add(&dedupe_dest_differs, 1);
+		} else {
+			if (target_status < 0)
+				status_str = strerror(-target_status);
+			atomic_fetch_add(&dedupe_dest_errors, 1);
+		}
+		vprintf("[%p] Dedupe for file \"%s\" had status (%d) "
+			"\"%s\".\n",
+			g_thread_self(), f->filename, target_status,
+			status_str);
 	}
 }
 
@@ -597,7 +611,7 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	uint64_t kern_bytes = 0ULL;
 	struct dupe_extents *dext = priv;
 	_cleanup_(pscan_reset_thread) struct pscan_thread *slot =
-						pdedupe_claim_slot(gettid());
+				pscan_claim_slot(gettid(), thread_deduping);
 
 	/*
 	 * Seed the display line from the group before any work: first member
@@ -685,6 +699,12 @@ void dedupe_end(void)
 			printf("  %sElapsed%s        %.1fs\n",
 			       col_dim, col_reset, elapsed_seconds());
 		}
+		if (dedupe_dest_differs || dedupe_dest_errors)
+			printf("  %sNot deduped%s    %lu changed since scan, "
+			       "%lu failed (rerun with -v for detail)\n",
+			       col_dim, col_reset,
+			       (uint64_t)dedupe_dest_differs,
+			       (uint64_t)dedupe_dest_errors);
 	}
 
 	/*

--- a/run_dedupe.h
+++ b/run_dedupe.h
@@ -7,10 +7,8 @@
 void print_dupes_table(struct results_tree *res, bool whole_file);
 void dedupe_results(struct results_tree *res, bool whole_file);
 
-/* Bracket the whole dedupe phase (which runs dedupe_results() many times):
- * dedupe_begin() starts the single in-place status line and resets totals;
- * dedupe_end() stops it and prints one aggregated summary. */
-void dedupe_begin(unsigned long long total_groups);
+/* Close the dedupe phase (which runs dedupe_results() many times): stops the
+ * live status (see pdedupe_begin()) and prints one aggregated summary. */
 void dedupe_end(void);
 
 int fdupes_dedupe(void);

--- a/tests/integration/test_changed_since_scan.py
+++ b/tests/integration/test_changed_since_scan.py
@@ -1,0 +1,44 @@
+"""Files rewritten between scan and dedupe must be skipped, not EINVAL.
+
+A dedupe request that reaches past a destination's current EOF (the file
+shrank), or whose unaligned length no longer ends exactly at EOF (the file
+grew), makes the kernel fail that destination with EINVAL. duperemove now
+detects the size change up front, skips the member as "changed since scan",
+and still dedupes the unchanged members. Requires a reflink-capable fs.
+"""
+
+import os
+from harness import DuperemoveTest, requires_reflink
+
+
+@requires_reflink
+class ChangedSinceScanTest(DuperemoveTest):
+    SIZE = 19389        # deliberately unaligned, like a fuzz-corpus input
+
+    def _mkgroup(self, names):
+        data = os.urandom(self.SIZE)
+        return [self.write(f"tree/{n}", data) for n in names]
+
+    def test_shrunk_and_grown_dests_are_skipped(self):
+        a, b, c, d = self._mkgroup("abcd")
+        self.sync()
+
+        # scan only, then change two files behind the hashfile's back
+        self.dm("-r", self.path("tree"))
+        self.assertDmOk()
+        os.truncate(b, 12000)
+        with open(c, "ab") as f:
+            f.write(b"grown")
+        self.sync()
+
+        # dedupe purely from the (now stale) hashfile
+        self.dm("-d", f"--read-hashes={self.hf}", hashfile=False)
+        self.assertDmOk()
+        self.assertNotIn("Invalid argument", self.out,
+                         "size-changed dests must not reach the kernel")
+        self.sync()
+
+        # the unchanged pair still got deduped, the changed ones intact
+        self.assertShared(a, d, "unchanged members still dedupe")
+        self.assertEqual(os.path.getsize(b), 12000)
+        self.assertEqual(os.path.getsize(c), self.SIZE + 5)


### PR DESCRIPTION
## Status display rework

The scan and dedupe phases looked nothing alike (multi-line area vs one
transient colored line), the dedupe numbers were minimal, and the dedupe bar
routinely hit 100% and then kept working: its total was a deliberately
under-biased estimate (`dbfile_count_dupe_groups()`), so the running count
blew past it mid-run.

Both phases now render through the same reserved screen area:

- Per-worker lines with one shared vocabulary: `checksumming:` /
  `deduping: <target>: 1.4GB/2.0GB (71%)` / `waiting for lock:` / `committing:`.
- Dedupe totals show groups done vs total, current batch, space reclaimed,
  kernel-verified bytes, elapsed and ETA, plus a `Status:` line naming what
  the phase is doing right now (`loading identical files`, `searching
  block-level matches`, ...) so the silent SQL loads between batches are
  explained.
- The displayed total is `max(estimate, groups actually queued)`, marked `~`
  and capped at 99% - the bar can no longer sit at a false 100%; it finishes
  from 99% straight into the summary.
- Scan totals gained throughput and ETA.
- Display slots are claimed per work item, not per OS thread: glib reaps idle
  pool threads and spawns new ones, which stranded dead threads' lines as
  permanent `idle` rows and grew past the reserved area (seen in the field:
  10 lines with 8 io-threads).
- The live area always prints humanized sizes (it previously showed raw byte
  counts without `--human`); the machine-readable net-change line is unchanged.
- Modern kernels dedupe the entire requested length in one `FIDEDUPERANGE`
  call, making a big group one opaque multi-second syscall; rounds are now
  capped at 32MB (the requeue loop already handles partial rounds), which
  gives live in-group progress and regular cancellation points.

## Stale-hashfile EINVAL fix

Deduping from a hashfile whose entries went stale (files rewritten between
scan and dedupe - e.g. an active fuzz corpus during a long batched run)
produced a flood of per-destination `status (-22) "Invalid argument"` errors:
the source length is clamped to its current size, but destinations were never
re-checked, and the kernel rejects a range past a destination's EOF (shrunk)
or an unaligned length no longer ending at EOF (grown). Reproduced
deterministically (scan, truncate, then `--read-hashes` dedupe) - also
present in upstream master.

Each member's current size is now checked when opened for dedupe: whole-file
groups strictly (they carry the exact scanned size), extent groups with one
block of slack (fiemap lengths are block-rounded and legitimately overshoot
EOF). Changed members are skipped and tallied as one aggregate summary line
("Not deduped: N changed since scan, M failed", detail under `-v`); unchanged
members of the group still dedupe.

## Testing

- Full suite green (45 integration tests + C unit tests), including a new
  regression test for the changed-since-scan skip.
- Live rendering verified via captured pty runs: per-group progress ticks in
  ~3% steps on a 3x1GB group; no-op rerun still nets 0; slot count stays
  bounded at the pool size across thread churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
