### PR TITLE
dedupe: merge generations per pass, start the largest groups first

### DIFF
--- a/dbfile.c
+++ b/dbfile.c
@@ -530,13 +530,13 @@ struct dbhandle *dbfile_open_handle(char *filename)
 #define GET_DUPLICATE_BLOCKS						\
 "select blocks.digest, fileid, loff from blocks "			\
 "join files on fileid = id "						\
-"where dedupe_seq <= ?1 and blocks.digest in ( "			\
+"where dedupe_seq <= ?2 and blocks.digest in ( "			\
 "	select blocks.digest from blocks "				\
 "	join files on fileid = id "					\
-"	where dedupe_seq <= ?1 and blocks.digest in ( "			\
+"	where dedupe_seq <= ?2 and blocks.digest in ( "			\
 "		select blocks.digest from blocks "			\
 "		join files on fileid = id "				\
-"		where dedupe_seq = ?1) "				\
+"		where dedupe_seq > ?1 and dedupe_seq <= ?2) "		\
 "	group by blocks.digest having count(*) > 1);"
 	dbfile_prepare_stmt(get_duplicate_blocks, GET_DUPLICATE_BLOCKS);
 
@@ -550,28 +550,31 @@ struct dbhandle *dbfile_open_handle(char *filename)
 #define GET_DUPLICATE_EXTENTS						\
 "select extents.digest, fileid, loff, len, poff from extents "		\
 "join files on fileid = id "						\
-"where dedupe_seq <= ?1 and (extents.digest, len) in ( "		\
+"where dedupe_seq <= ?2 and (extents.digest, len) in ( "		\
 "	select extents.digest, len from extents "			\
 "	join files on fileid = id "					\
-"	where dedupe_seq <= ?1 and (extents.digest, len) in ( "		\
+"	where dedupe_seq <= ?2 and (extents.digest, len) in ( "		\
 "		select extents.digest, len from extents "		\
 "		join files on fileid = id "				\
-"		where dedupe_seq = ?1) "				\
+"		where dedupe_seq > ?1 and dedupe_seq <= ?2) "		\
 "	group by extents.digest, len having count(*) > 1);"
 	dbfile_prepare_stmt(get_duplicate_extents, GET_DUPLICATE_EXTENTS);
 
 /*
  * Select duplicates, excluding future files.
- * Then, only keep duplicates if at least one entry lives is related
- * to the current batch.
+ * Then, only keep duplicates if at least one entry is related to the
+ * current pass: the (?1, ?2] range of dedupe generations. Loading many
+ * generations per pass keeps the dedupe thread pool full instead of
+ * draining it at every 1024-file scan batch.
  */
 #define GET_DUPLICATE_FILES							\
 "select id, size, digest, filename from files "					\
-"where dedupe_seq <= ?1 and not (flags & 1) and (digest, size) in ( "		\
+"where dedupe_seq <= ?2 and not (flags & 1) and (digest, size) in ( "		\
 "	select digest, size from files "					\
-"	where dedupe_seq <= ?1 and not (flags & 1) and (digest, size) in ( "	\
+"	where dedupe_seq <= ?2 and not (flags & 1) and (digest, size) in ( "	\
 "		select digest, size from files "				\
-"		where dedupe_seq = ?1 and not (flags & 1)) "			\
+"		where dedupe_seq > ?1 and dedupe_seq <= ?2 "			\
+"		and not (flags & 1)) "						\
 "	group by digest, size having count(*) > 1);"
 	dbfile_prepare_stmt(get_duplicate_files, GET_DUPLICATE_FILES);
 
@@ -1309,7 +1312,7 @@ static int find_or_load_filerec(struct dbhandle *db, int64_t fileid,
 }
 
 int dbfile_load_block_hashes(struct dbhandle *db, struct hash_tree *hash_tree,
-			     unsigned int seq)
+			     unsigned int seq_lo, unsigned int seq_hi)
 {
 	int ret;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.get_duplicate_blocks;
@@ -1318,7 +1321,9 @@ int dbfile_load_block_hashes(struct dbhandle *db, struct hash_tree *hash_tree,
 	unsigned char *digest;
 	struct filerec *file;
 
-	ret = sqlite3_bind_int64(stmt, 1, seq);
+	ret = sqlite3_bind_int64(stmt, 1, seq_lo);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 2, seq_hi);
 	if (ret) {
 		perror_sqlite(ret, "binding value");
 		return ret;
@@ -1348,7 +1353,7 @@ int dbfile_load_block_hashes(struct dbhandle *db, struct hash_tree *hash_tree,
 }
 
 int dbfile_load_extent_hashes(struct dbhandle *db, struct results_tree *res,
-			      unsigned int seq)
+			      unsigned int seq_lo, unsigned int seq_hi)
 {
 	int ret;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.get_duplicate_extents;
@@ -1357,7 +1362,9 @@ int dbfile_load_extent_hashes(struct dbhandle *db, struct results_tree *res,
 	unsigned char *digest;
 	struct filerec *file;
 
-	ret = sqlite3_bind_int64(stmt, 1, seq);
+	ret = sqlite3_bind_int64(stmt, 1, seq_lo);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 2, seq_hi);
 	if (ret) {
 		perror_sqlite(ret, "binding value");
 		return ret;
@@ -1597,7 +1604,7 @@ out:
 }
 
 int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
-			   unsigned int seq)
+			   unsigned int seq_lo, unsigned int seq_hi)
 {
 	int ret;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.get_duplicate_files;
@@ -1607,7 +1614,9 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 	struct filerec *file;
 	const unsigned char *filename;
 
-	ret = sqlite3_bind_int64(stmt, 1, seq);
+	ret = sqlite3_bind_int64(stmt, 1, seq_lo);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 2, seq_hi);
 	if (ret) {
 		perror_sqlite(ret, "binding value");
 		return ret;

--- a/dbfile.h
+++ b/dbfile.h
@@ -110,11 +110,15 @@ struct hash_tree;
 /*
  * Load hashes into hash_tree only if they have a duplicate in the db.
  * The extent search is later run on the resulting hash_tree.
+ *
+ * All three loaders process one dedupe pass: the groups with at least one
+ * member whose generation is in (seq_lo, seq_hi], plus their partners from
+ * any generation <= seq_hi.
  */
 int dbfile_load_block_hashes(struct dbhandle *db, struct hash_tree *hash_tree,
-			     unsigned int seq);
+			     unsigned int seq_lo, unsigned int seq_hi);
 int dbfile_load_extent_hashes(struct dbhandle *db, struct results_tree *res,
-			      unsigned int seq);
+			      unsigned int seq_lo, unsigned int seq_hi);
 
 struct file_extent {
 	uint64_t	poff;
@@ -164,7 +168,7 @@ void dbfile_list_files(struct dbhandle *db, int (*callback)(void*, int, char**, 
 int dbfile_describe_file(struct dbhandle *db, uint64_t ino, uint64_t subvol,
 				struct file *dbfile);
 int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
-			   unsigned int seq);
+			   unsigned int seq_lo, unsigned int seq_hi);
 
 int dbfile_rename_file(struct dbhandle *db, int64_t fileid, char *path);
 

--- a/duperemove.c
+++ b/duperemove.c
@@ -542,7 +542,9 @@ static void print_header(void)
 	qprintf("%s%sScanning%s files...\n", col_bold, col_cyan, col_reset);
 }
 
-static void __process_duplicates(struct dbhandle *db, unsigned int seq)
+/* Process the dedupe generations in (seq_lo, seq_hi]. */
+static void __process_duplicates(struct dbhandle *db, unsigned int seq_lo,
+				 unsigned int seq_hi)
 {
 	int ret;
 	struct results_tree res;
@@ -553,7 +555,7 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq)
 
 	vprintf("Loading identical files...\n");
 	pdedupe_set_activity("loading identical files");
-	ret = dbfile_load_same_files(db, &res, seq + 1);
+	ret = dbfile_load_same_files(db, &res, seq_lo, seq_hi);
 	if (ret)
 		goto out;
 
@@ -571,13 +573,14 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq)
 		vprintf("Loading duplicated hashes...\n");
 		pdedupe_set_activity("loading duplicate extents");
 
-		ret = dbfile_load_extent_hashes(db, &res, seq + 1);
+		ret = dbfile_load_extent_hashes(db, &res, seq_lo, seq_hi);
 		if (ret)
 			goto out;
 
 		vprintf("Found %llu identical extents\n", res.num_extents);
 		if (options.do_block_hash) {
-			ret = dbfile_load_block_hashes(db, &dups_tree, seq + 1);
+			ret = dbfile_load_block_hashes(db, &dups_tree,
+						       seq_lo, seq_hi);
 			if (ret)
 				goto out;
 
@@ -597,10 +600,26 @@ out:
 	free_hash_tree(&dups_tree);
 }
 
+/*
+ * How many files' worth of dedupe generations to process per pass. The scan
+ * seals a generation every --batchsize (default 1024) files, and processing
+ * one generation per pass made each pass a barrier: the thread pool drained
+ * at every 1024 files, so one large group regularly left every other worker
+ * idle, thousands of times over on a big hashfile. Merging generations keeps
+ * the pool full; the cap keeps the per-pass filerec/results memory bounded.
+ */
+#define DEDUPE_FILES_PER_PASS	(64 * 1024)
+
 static void process_duplicates(struct dbhandle *db)
 {
 	unsigned int max = get_max_dedupe_seq(db);
 	unsigned int first_seq = dedupe_seq;	/* bumped inside the loop */
+	unsigned int stride = DEDUPE_FILES_PER_PASS / options.batch_size;
+	unsigned int passes, pass = 0;
+
+	if (stride < 1)
+		stride = 1;
+	passes = max > first_seq ? (max - first_seq + stride - 1) / stride : 0;
 
 	/*
 	 * Ensure the find-dupes indexes exist. Normally built at the end of the
@@ -626,25 +645,27 @@ static void process_duplicates(struct dbhandle *db)
 			fflush(stdout);
 		}
 		total = dbfile_count_dupe_groups(db, options.only_whole_files);
-		pdedupe_begin(total, max > dedupe_seq ? max - dedupe_seq : 0);
+		pdedupe_begin(total, passes);
 	}
 
-	for (unsigned int i = first_seq; i < max; i++) {
+	for (unsigned int i = first_seq; i < max; i += stride) {
+		unsigned int hi = i + stride < max ? i + stride : max;
+
 		if (options.run_dedupe)
-			pdedupe_set_batch(i - first_seq + 1);
+			pdedupe_set_batch(++pass);
 
 		/* Drop all filerecs from the previous iteration. Needed filerecs will be
 		 * recreated by __process_duplicates()
 		 */
 		free_all_filerecs();
-		__process_duplicates(db, i);
+		__process_duplicates(db, i, hi);
 
 		if (options.run_dedupe) {
 			/*
 			 * Bump dedupe_seq, this effectively marks the files
 			 * in our hashfile as having been through dedupe.
 			 */
-			dedupe_seq++;
+			dedupe_seq = hi;
 			dbfile_cfg.dedupe_seq = dedupe_seq;
 			dbfile_cfg.blocksize = blocksize;
 			dbfile_sync_config(db, &dbfile_cfg);

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -669,34 +669,59 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 
 static GThreadPool *dedupe_pool = NULL;
 
+/*
+ * The kernel byte-verifies group length times (copies - 1), so that product
+ * is the work a group costs. Largest first (longest-processing-time
+ * scheduling): a giant group started early runs concurrently with everything
+ * else, instead of alone at the tail of the pass while the other workers
+ * sit idle.
+ */
+static int cmp_dext_work(const void *pa, const void *pb)
+{
+	const struct dupe_extents *a = *(const struct dupe_extents **)pa;
+	const struct dupe_extents *b = *(const struct dupe_extents **)pb;
+	uint64_t wa = a->de_len * (a->de_num_dupes - 1);
+	uint64_t wb = b->de_len * (b->de_num_dupes - 1);
+
+	return wa > wb ? -1 : wa < wb ? 1 : 0;
+}
+
 /* Errors from this function are fatal. */
 static int push_extents(struct results_tree *res)
 {
-	struct rb_root *root = &res->root;
-	struct rb_node *node = rb_first(root);
+	struct rb_node *node;
 	struct dupe_extents *dext;
+	_cleanup_(freep) struct dupe_extents **sorted = NULL;
+	unsigned int nr = 0, i;
 	GError *err = NULL;
 
-	while (node) {
-		dext = rb_entry(node, struct dupe_extents, de_node);
+	/*
+	 * Nothing is pushed until the array is complete, so no worker owns any
+	 * group yet and the tree is stable while we collect and sort.
+	 */
+	sorted = malloc((size_t)res->num_dupes * sizeof(*sorted));
+	if (!sorted) {
+		eprintf("Out of memory while sorting dupe groups.\n");
+		return 1;
+	}
 
-		/*
-		 * dext may be free'd by the dedupe threads, so get
-		 * the next node now. In addition we want to lock
-		 * around the rbtree code here so rb_erase doesn't
-		 * change the tree underneath us.
-		 */
-		g_mutex_lock(&mutex);
-		node = rb_next(node);
-		g_mutex_unlock(&mutex);
+	for (node = rb_first(&res->root); node; node = rb_next(node)) {
+		dext = rb_entry(node, struct dupe_extents, de_node);
 
 		if (dext->de_num_dupes < 2) {
 			qprintf("Skipping extent - insufficient duplicates (%u)\n",
 				   dext->de_num_dupes);
 			continue;
 		}
+		if (nr >= res->num_dupes)	/* should not happen */
+			break;
+		sorted[nr++] = dext;
+	}
 
-		g_thread_pool_push(dedupe_pool, dext, &err);
+	qsort(sorted, nr, sizeof(*sorted), cmp_dext_work);
+
+	for (i = 0; i < nr; i++) {
+		g_thread_pool_push(dedupe_pool, sorted[i], &err);
 		if (err) {
 			eprintf("Fatal error while deduping: %s\n",
 				err->message);

--- a/tests/integration/test_pass_stride.py
+++ b/tests/integration/test_pass_stride.py
@@ -1,0 +1,36 @@
+"""Dedupe passes merge many scan generations (see DEDUPE_FILES_PER_PASS).
+
+A tiny --batchsize seals a dedupe generation every few files; the pass loop
+must still dedupe every group exactly once - including pairs whose members
+land in different generations - and a rerun must net zero. Requires a
+reflink-capable filesystem.
+"""
+
+import os
+from harness import DuperemoveTest, requires_reflink
+
+
+@requires_reflink
+class PassStrideTest(DuperemoveTest):
+    def test_pairs_across_generations(self):
+        # 30 pairs; names interleave so a pair's two members usually end up
+        # in different 4-file scan batches (= different generations).
+        pairs = []
+        for i in range(30):
+            data = os.urandom(8192)
+            a = self.write(f"tree/a{i:02}", data)
+            b = self.write(f"tree/z{i:02}", data)
+            pairs.append((a, b))
+        self.sync()
+
+        self.dedupe(self.path("tree"), "-B", "4")
+        self.assertDmOk()
+        self.sync()
+
+        for a, b in pairs:
+            self.assertShared(a, b, f"{os.path.basename(a)} pair deduped")
+
+        # a rerun over the same (fully deduped) tree must be a no-op
+        self.dedupe(self.path("tree"), "-B", "4")
+        self.assertDmOk()
+        self.assertEqual(self.net_change() or 0, 0, "no-op rerun nets zero")


### PR DESCRIPTION
The dedupe phase drained its whole thread pool at every scan generation (one
per `--batchsize`=1024 files) and again between the whole-file and extent
passes. On a big hashfile that is thousands of barriers, each with a straggler
tail: a batch holds only a handful of groups, so one large group regularly
left every other worker idle. Seen in the field: 7 of 8 workers idle behind a
single 1.6 GiB group, at batch 652 of 2762.

## Merge generations per pass

The group loaders (same-files, extents, blocks) now take a generation range
`(seq_lo, seq_hi]` instead of a single generation, and the pass loop strides
`DEDUPE_FILES_PER_PASS` (64k files) worth of generations per pass - about 64x
fewer pool drains at the default batchsize, while per-pass filerec/results
memory stays bounded. `dedupe_seq` advances to the pass end after each pass,
so interrupted runs resume at pass granularity. Group-once semantics are
unchanged: the pivot subquery selects generations in the range, partners still
come from any generation `<= seq_hi`.

## Largest groups first

`push_extents()` sorts each pass's groups by verify work - group length times
(copies - 1) - and pushes the largest first (longest-processing-time
scheduling). A giant group started early runs concurrently with everything
else instead of alone at the tail of the pass.

## Verification

- Pty run with one 2x1GB group + 80 small groups at `-B 8`: the 1 GiB group
  is active from the very first dedupe frame with up to 7 workers busy
  alongside it, and the ~11 generations merged into a single pass.
- New integration test forces many tiny generations (`-B 4`) with pair
  members interleaved across them: every pair dedupes, a rerun nets zero.
- Full suite green (48 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
