### PR TITLE
file_scan: don't abort in --fdupes on hard links (#389)

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -1783,5 +1783,17 @@ void add_file_fdupes(char *path)
 		eprintf("statx on %s: %s\n", path, strerror(errno));
 		return;
 	}
+
+	/*
+	 * Filerecs are keyed by inode. Two hardlinks in the same fdupes group
+	 * would produce a duplicate key and abort in insert_filerec(). They
+	 * already share storage, so deduping them is pointless anyway - skip
+	 * any inode we've already listed.
+	 */
+	if (filerec_find(st.stx_ino)) {
+		vprintf("Skipping %s: hardlink to an already-listed file\n",
+			path);
+		return;
+	}
 	filerec_new(path, st.stx_ino, st.stx_size);
 }

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -167,13 +167,16 @@ class DuperemoveTest(unittest.TestCase):
 
     # -- running duperemove ------------------------------------------------
 
-    def dm(self, *args, hashfile=True):
-        """Run duperemove; capture combined output in self.out and code in self.rc."""
+    def dm(self, *args, hashfile=True, stdin=None):
+        """Run duperemove; capture combined output in self.out and code in self.rc.
+
+        Pass stdin=<str> to feed the process on standard input (e.g. --fdupes).
+        """
         cmd = [DUPEREMOVE, "-q", "--io-threads=4"]
         if hashfile:
             cmd += ["--hashfile", self.hf]
         cmd += list(args)
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE,
+        proc = subprocess.run(cmd, input=stdin, stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT, text=True)
         self.out = proc.stdout
         self.rc = proc.returncode

--- a/tests/integration/test_fdupes.py
+++ b/tests/integration/test_fdupes.py
@@ -1,0 +1,31 @@
+"""`--fdupes` mode: read groups of duplicate paths on stdin and dedupe each.
+
+Regression for upstream #389: two hard links in the same fdupes group share an
+inode, which collided on the inode-keyed filerec index and aborted. They must
+be skipped (they already share storage), and genuine duplicates must still
+dedupe. Requires a reflink-capable filesystem.
+"""
+
+import os
+from harness import DuperemoveTest, requires_reflink
+
+
+@requires_reflink
+class FdupesTest(DuperemoveTest):
+    def test_hardlinks_in_group_do_not_crash(self):
+        data = os.urandom(200000)
+        a = self.write("tree/a", data)
+        b = self.write("tree/b", data)
+        h1 = self.write("tree/h1", os.urandom(4096))
+        h2 = self.path("tree/h2")
+        os.link(h1, h2)          # hard link: same inode as h1
+        self.sync()
+
+        # One group with a real duplicate pair, one group with two hard links.
+        groups = f"{a}\n{b}\n\n{h1}\n{h2}\n\n"
+        self.dm("--fdupes", hashfile=False, stdin=groups)
+
+        self.assertEqual(self.rc, 0, "fdupes must not crash on hard links")
+        self.assertNotIn("ERROR:", self.out)
+        self.sync()
+        self.assertShared(a, b, "the genuine duplicate pair still deduped")


### PR DESCRIPTION
## Bug (upstream #389)

`duperemove --fdupes` core-dumps when a group contains two hard links to the
same inode:

```
$ printf 'test/file1\ntest/file2\n' | duperemove --fdupes   # file2 = ln file1
ERROR: filerec.c:140
Aborted (core dumped)
```

Filerecs are indexed by inode (`add_file_fdupes()` passes `stx_ino` as the
fileid). Two hard links share an inode, so the second insert hit the
"should never happen" `abort_lineno()` in `insert_filerec()`.

## Fix

Hard links already share storage, so deduping them is pointless — skip any
inode that's already listed (`filerec_find()` before `filerec_new()`). The
scan path already has an equivalent inode guard; only `--fdupes` was missing
one.

## Test

New `test_fdupes.py`: one group with a genuine duplicate pair, one with two
hard links. Verifies no crash and that the real pair still shares extents.
Full suite green (49 tests). Reproduced the crash before, gone after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)