### PR TITLE
progress/output: 32-bit counters, sanitized filenames, no-NaN search bar

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -13,6 +13,7 @@
  */
 #include <sys/ioctl.h>
 #include <stdatomic.h>
+#include <inttypes.h>
 
 #include "debug.h"
 #include "opt.h"
@@ -139,6 +140,7 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 {
 	char buf[BUF_LEN];
 	char prefix[64], suffix[128], path[PATH_MAX + 4];
+	char clean[PATH_MAX + 1];
 	int avail;
 
 	switch (tprogress->status) {
@@ -174,7 +176,9 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 		avail = INT_MAX;
 	else
 		avail = (int)w_col - (int)strlen(prefix) - (int)strlen(suffix);
-	ellipsize_path(tprogress->file_path, path, sizeof(path), avail);
+	/* Never emit raw control bytes from a filename to the terminal (#353). */
+	sanitize_ctrl(tprogress->file_path, clean, sizeof(clean));
+	ellipsize_path(clean, path, sizeof(path), avail);
 
 	/*
 	 * No byte-truncation here: it would eat the suffix (the ellipsis is
@@ -198,13 +202,14 @@ static void print_scan_progress(void)
 		 * know - files walked and how many need (re)hashing - rather than
 		 * a misleading 0/0.
 		 */
-		s_printf("\tListing files: %lu examined\n", pscan.files_examined);
-		s_printf("\t%lu need hashing\n", tf);
+		s_printf("\tListing files: %" PRIu64 " examined\n",
+			 pscan.files_examined);
+		s_printf("\t%" PRIu64 " need hashing\n", tf);
 		s_printf("\tFile listing: in progress\n");
 		return;
 	}
 
-	s_printf("\tFiles scanned: %lu/%lu (%05.2f%%)\n",
+	s_printf("\tFiles scanned: %" PRIu64 "/%" PRIu64 " (%05.2f%%)\n",
 	      files_scanned, tf, tf ? (double)files_scanned / tf * 100 : 100.0);
 	s_printf("\tBytes scanned: %s/%s (%05.2f%%)",
 	      human_size(bytes_scanned), human_size(tb),
@@ -241,7 +246,8 @@ static void print_dedupe_progress(void)
 			pct = 99;
 	}
 
-	s_printf("\tGroups deduped: %lu/~%lu (%u%%)", done, total, pct);
+	s_printf("\tGroups deduped: %" PRIu64 "/~%" PRIu64 " (%u%%)",
+		 done, total, pct);
 	if (pdd.batches > 1)
 		printf(" · batch %u/%u", pdd.batch, pdd.batches);
 	printf("\n");
@@ -251,7 +257,7 @@ static void print_dedupe_progress(void)
 
 	s_printf("\tStatus: %s", pdd.activity ? pdd.activity : "working");
 	if (st)
-		printf(" (%lu/%lu files)", sd, st);
+		printf(" (%" PRIu64 "/%" PRIu64 " files)", sd, st);
 	if (elapsed > 1.0)
 		printf(" · elapsed %s", human_duration(elapsed));
 	if (done > 20 && elapsed > 2.0 && done < total)
@@ -569,7 +575,9 @@ static void *psearch_progress_thread(void * p)
 		int pos;
 		int width = 40;
 
-		pos = (float) search_processed / search_total * width;
+		/* Guard the empty-search case so pos is 0, not NaN (#348). */
+		pos = search_total ?
+			(float) search_processed / search_total * width : width;
 
 		/* Only update our status every width% */
 		if (pos > last_pos) {

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -85,9 +85,14 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
 		printf("\n");
 		printf("Start\t\tFilename\n");
 		list_for_each_entry(extent, &dext->de_extents, e_list) {
+			char clean[PATH_MAX + 1];
+
+			/* Default (non-quiet) output: keep control bytes in a
+			 * filename from reaching the terminal (#353). */
+			sanitize_ctrl(extent->e_file->filename, clean,
+				      sizeof(clean));
 			printf("%s\t\"%s\"\n",
-			       pretty_size(extent->e_loff),
-			       extent->e_file->filename);
+			       pretty_size(extent->e_loff), clean);
 		}
 
 		node = rb_next(node);

--- a/tests.c
+++ b/tests.c
@@ -160,12 +160,36 @@ MU_TEST(test_get_extent) {
 	free(fm);
 }
 
+MU_TEST(test_sanitize_ctrl) {
+	char out[64];
+
+	/* Plain ASCII and legitimate multi-byte UTF-8 pass through unchanged. */
+	sanitize_ctrl("plain.txt", out, sizeof(out));
+	mu_check(strcmp(out, "plain.txt") == 0);
+	sanitize_ctrl("café-Β.txt", out, sizeof(out));   /* é=C3A9, Β=CE92 */
+	mu_check(strcmp(out, "café-Β.txt") == 0);
+
+	/* C0 control and DEL become '?'. */
+	sanitize_ctrl("a\tb\nc\x7f", out, sizeof(out));
+	mu_check(strcmp(out, "a?b?c?") == 0);
+
+	/* C1 control U+009F (UTF-8 C2 9F) becomes a single '?' (#353). */
+	sanitize_ctrl("Te\xc2\x9ft", out, sizeof(out));
+	mu_check(strcmp(out, "Te?t") == 0);
+
+	/* Truncation stays NUL-terminated and within bounds. */
+	char small[4];
+	sanitize_ctrl("abcdef", small, sizeof(small));
+	mu_check(strcmp(small, "abc") == 0);
+}
+
 MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_block_zeroed);
 	MU_RUN_TEST(test_block_len);
 	MU_RUN_TEST(test_is_file_renamed);
 	MU_RUN_TEST(test_seen_inode);
 	MU_RUN_TEST(test_get_extent);
+	MU_RUN_TEST(test_sanitize_ctrl);
 }
 
 int main(int argc [[maybe_unused]], char *argv[]) {

--- a/util.c
+++ b/util.c
@@ -403,3 +403,25 @@ void debug_print_uuid(uuid_t uuid)
 	uuid_unparse(uuid, buf);
 	eprintf("%s", buf);
 }
+
+void sanitize_ctrl(const char *in, char *out, size_t out_sz)
+{
+	const unsigned char *p = (const unsigned char *)in;
+	size_t o = 0;
+
+	if (out_sz == 0)
+		return;
+
+	while (*p && o + 1 < out_sz) {
+		if (*p < 0x20 || *p == 0x7f) {
+			out[o++] = '?';
+			p++;
+		} else if (p[0] == 0xc2 && p[1] >= 0x80 && p[1] <= 0x9f) {
+			out[o++] = '?';
+			p += 2;
+		} else {
+			out[o++] = *p++;
+		}
+	}
+	out[o] = '\0';
+}

--- a/util.h
+++ b/util.h
@@ -112,4 +112,12 @@ static inline void closefd(int *fd)
 
 void debug_print_uuid(uuid_t uuid);
 
+/*
+ * Copy `in` to `out` (up to out_sz bytes, always NUL-terminated), replacing
+ * terminal control characters with '?': C0 controls (< 0x20), DEL (0x7f), and
+ * the two-byte UTF-8 encodings of the C1 controls (U+0080..U+009F). Some
+ * terminals act on these when a filename is printed verbatim (#353).
+ */
+void sanitize_ctrl(const char *in, char *out, size_t out_sz);
+
 #endif	/* __UTIL_H__ */


### PR DESCRIPTION
Three output-layer fixes:

- **#394 (32-bit output)** — progress counters are `uint64_t` but were printed
  with `%lu` (32-bit on i386/armel); the varargs misparse produced totals like
  `3/0`. Switched to `PRIu64`.
- **#353 (control chars block terminal)** — filenames were printed verbatim, so
  a control byte (e.g. C1 `U+009F`, which konsole acts on) could hijack the
  continuously-redrawn status line. Added `sanitize_ctrl()` (C0, DEL, and the
  UTF-8-encoded C1 range → `?`) and applied it to the live status area and to
  `print_dupes_table`'s default output. Legitimate multi-byte UTF-8 is
  preserved.
- **#348 (NaN in search bar)** — the block-search progress divided by
  `search_total` without guarding zero, printing a NaN position. Guarded.

Tests: new C unit test for `sanitize_ctrl` (ASCII/UTF-8 pass-through, control →
`?`, bounded truncation); verified the sanitizer on a real `U+009F` filename via
a pty capture (raw bytes gone, name shows as `te?st`). Full suite green (49
integration + 6 unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)