### PR TITLE
dedupe: stop instead of spinning when a round makes no progress (#396/#407)

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -383,6 +383,8 @@ int dedupe_extents(struct dedupe_ctxt *ctxt)
 	clamp_len_to_ioctl_file(ctxt);
 
 	while (!list_empty(&ctxt->queued)) {
+		uint64_t round;
+
 		/* Convert the queued list into an actual request */
 		populate_dedupe_request(ctxt, ctxt->same);
 
@@ -400,14 +402,28 @@ retry:
 			goto retry;
 		}
 
+		round = 0;
+		for (unsigned int i = 0; i < ctxt->same->dest_count; i++)
+			round += ctxt->same->info[i].bytes_deduped;
+
 		process_dedupes(ctxt, ctxt->same);
 
-		if (ctxt->progress) {
-			uint64_t round = 0;
-
-			for (unsigned int i = 0; i < ctxt->same->dest_count; i++)
-				round += ctxt->same->info[i].bytes_deduped;
+		if (ctxt->progress)
 			*ctxt->progress += round;
+
+		/*
+		 * Guard against an infinite loop (upstream #396/#407): if a full
+		 * round deduped nothing yet the kernel reported no error, every
+		 * still-queued request just got requeued unchanged. Reissuing the
+		 * identical ioctl would return the same zero, so stop here and
+		 * account the stuck requests as completed instead of spinning at
+		 * 100% CPU forever. Productive dedupe always moves >0 bytes per
+		 * round (a large extent progresses in fs-block chunks), so this
+		 * never cuts real work short.
+		 */
+		if (round == 0 && !list_empty(&ctxt->queued)) {
+			list_splice_init(&ctxt->queued, &ctxt->completed);
+			break;
 		}
 	}
 


### PR DESCRIPTION
## Bug (upstream #396, #407, and likely #370/#305/#319)

The `dedupe_extents()` ioctl loop requeues any request the kernel didn't finish
this round. If a round dedupes **zero** bytes but the kernel returns no error
(`status == 0`), every request is requeued unchanged — and reissuing the
identical `FIDEDUPERANGE` returns the same zero. That's an infinite loop at
100% CPU, matching the reported 0.15.2 hangs (`length: 0, bytes_deduped: 0,
status: 0` repeating).

The existing `len < fs_blocksize` splice only fires once `fs_blocksize` is set
(via an EINVAL round), so a status-0 zero-progress round with `fs_blocksize`
still 0 loops forever.

## Fix

After each round, if it moved no bytes and requests are still queued, splice
them to `completed` (accounted as not-deduped) and stop, instead of looping.

Productive dedupe always advances >0 bytes per round — a large extent
progresses in fs-block chunks — so the guard never cuts real work short.

## Verification

- A 256 MB extent (8 × 32 MB rounds) still fully shares after dedupe → the
  guard does not terminate legitimate multi-round work early.
- Instrumented the guard and ran the entire integration suite: it fired **zero**
  times on normal dedupe (no false positives).
- NoCOW dedupe still completes cleanly; full suite green (49 + 6 tests).

I could not reproduce the exact upstream hang locally (it depends on a
kernel/fs returning status-0 zero-progress, which the fork's length clamping and
changed-since-scan skip already avoid in the common cases), so there's no new
deterministic test — the guard is a provably-safe backstop validated by the
no-regression and no-false-positive checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)