### PR TITLE
Makefile: install the show-shared-extents helper script (#388)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ CFILES = $(filter-out tests.c,$(sort $(wildcard *.c)))
 DEPENDS := $(CFILES:.c=.d)
 OBJECTS := $(CFILES:.c=.o)
 install_progs = duperemove hashstats btrfs-extent-same
+# Shipped helper scripts (not build targets) that also belong in $(BINDIR).
+install_scripts = show-shared-extents
 progs = $(install_progs) csum-test
 PROGS_OBJECTS := $(addsuffix .o,$(basename $(progs)))
 SHARED_OBJECTS := $(filter-out $(PROGS_OBJECTS),$(OBJECTS))
@@ -91,7 +93,7 @@ check: test integration
 
 install: $(install_progs) $(MANPAGES) $(ZSH_COMPLETION)
 	mkdir -p -m 0755 $(DESTDIR)$(BINDIR)
-	for prog in $(install_progs); do \
+	for prog in $(install_progs) $(install_scripts); do \
 		install -m 0755 $$prog $(DESTDIR)$(BINDIR); \
 	done
 	mkdir -p -m 0755 $(DESTDIR)$(MANDIR)/man8
@@ -104,7 +106,7 @@ install: $(install_progs) $(MANPAGES) $(ZSH_COMPLETION)
 	done
 
 uninstall:
-	for prog in $(install_progs); do \
+	for prog in $(install_progs) $(install_scripts); do \
 		rm -f $(DESTDIR)$(BINDIR)/$$prog; \
 	done
 	for man in $(MANPAGES); do \


### PR DESCRIPTION
`show-shared-extents.8` was installed but the `show-shared-extents` script
itself was not: only `$(install_progs)` (the compiled binaries) were copied to
`$(BINDIR)`, and the script is a shipped shell helper, not a build target.

Adds an `$(install_scripts)` list and installs/uninstalls it alongside the
programs. Verified with `make install DESTDIR=…` that the script lands in
`bin/` and `make uninstall` removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)