### PR TITLE
file_scan: handle sparse files with a trailing hole (#374)

### DIFF
--- a/file_scan.c
+++ b/file_scan.c
@@ -1323,15 +1323,19 @@ static int process_extents(struct scan_ctxt *ctxt, struct buffer *buffer,
 	while (file_off < ctxt->off + bytes) {
 		extent = get_extent(ctxt->fiemap, file_off, &ctxt->extent_cursor);
 		if (!extent) {
-			eprintf("process_extents: unable to get extent\n");
-
-			/* Cleanup the partial checksum and skip
-			 * the rest of the buffer
+			/*
+			 * No extent covers file_off, and get_extent() returns
+			 * the next extent for a hole, so this means file_off is
+			 * past the last mapped extent: a trailing hole in a
+			 * sparse file (FIEMAP does not report holes). There is
+			 * no more data to checksum here - the last real extent
+			 * was already stored below - so stop cleanly instead of
+			 * aborting the whole file's scan.
 			 */
 			if (ctxt->extent_csum)
 				finish_running_checksum(ctxt->extent_csum, NULL);
 			ctxt->extent_csum = NULL;
-			return 1;
+			return 0;
 		}
 
 		ext_end_off = extent->fe_logical + extent->fe_length;
@@ -1362,10 +1366,14 @@ static int process_extents(struct scan_ctxt *ctxt, struct buffer *buffer,
 		 * to the block size of the file system.
 		 * So, if we are processing the last extent, then
 		 * ext_end_off may be larger than the filesize. For those extents, add
-		 * the part that will never exist.
+		 * the part that will never exist. Only when the extent actually
+		 * runs past EOF though - a last extent that ends before filesize
+		 * (a file with a trailing hole) must not underflow dummy, or the
+		 * store below would never fire and the extent would be lost.
 		 */
 		size_t dummy = 0;
-		if (extent->fe_flags & FIEMAP_EXTENT_LAST)
+		if ((extent->fe_flags & FIEMAP_EXTENT_LAST) &&
+		    ext_end_off > ctxt->filesize)
 			dummy = ext_end_off - ctxt->filesize;
 		if (file_off + dummy == ext_end_off) {
 			ret = store_extent(ctxt, hashes, extent);

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -308,6 +308,12 @@ class DuperemoveTest(unittest.TestCase):
             f.write(tail)
         return p
 
+    def make_trailing_hole(self, relpath, data, size):
+        """Write `data`, then extend the file to `size` so it ends in a hole."""
+        p = self.write(relpath, data)
+        os.truncate(p, size)
+        return p
+
     def hardlink(self, rel_src, rel_dst):
         dst = self.path(rel_dst)
         os.link(self.path(rel_src), dst)

--- a/tests/integration/test_sparse.py
+++ b/tests/integration/test_sparse.py
@@ -1,7 +1,7 @@
 """Sparse files, holes, unaligned tails, and empty/zero files."""
 
 import os
-from harness import DuperemoveTest
+from harness import DuperemoveTest, requires_reflink
 
 
 class SparseTest(DuperemoveTest):
@@ -33,6 +33,35 @@ class SparseTest(DuperemoveTest):
         self.assertEqual(
             1, self.hf_scalar("select count(*) from files where filename like '%/data'"),
             "non-empty file recorded")
+
+    def test_trailing_hole_scans(self):
+        # A file whose last extent ends before EOF (data then a big hole).
+        # FIEMAP omits the hole, so walking extents past the last one used to
+        # error ("unable to get extent") and abandon the file (upstream #374).
+        self.make_trailing_hole("tree/th", os.urandom(200000), 4 * 1024 * 1024)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertNotIn("unable to get extent", self.out)
+        self.assertNotIn("changed", self.out)
+        self.assertEqual(1, self.hf_count("files"), "trailing-hole file recorded")
+        self.assertEqual(
+            0, self.hf_scalar("select count(*) from files where digest is null"),
+            "trailing-hole file digested (not abandoned)")
+
+    @requires_reflink
+    def test_trailing_hole_dedupes_and_preserves_data(self):
+        data = os.urandom(240000)
+        a = self.make_trailing_hole("tree/a", data, 8 * 1024 * 1024)
+        b = self.make_trailing_hole("tree/b", data, 8 * 1024 * 1024)
+        self.sync()
+        before = open(a, "rb").read()
+
+        self.dedupe(self.path("tree"))
+        self.assertDmOk()
+        self.sync()
+
+        self.assertShared(a, b, "identical trailing-hole files dedupe")
+        self.assertEqual(before, open(a, "rb").read(), "data intact after dedupe")
 
     def test_unaligned_sizes(self):
         self.mkrand("tree/a", 131072 + 1)


### PR DESCRIPTION
## Bug (upstream #374)

Reported as *"extent handling for compressed filesystems is broken"* with:
```
process_extents: unable to get extent
file <myfile> changed
```
A commenter noted it's really about **sparse files**, not compression — and
that's correct. On current kernels FIEMAP maps compressed extents fine (logical
offsets/lengths with the `ENCODED` flag; verified empirically). The real trigger
is a **trailing hole**: a file whose data ends before EOF.

FIEMAP never reports holes, so the last mapped extent ends before `filesize`.
`process_extents()` then broke twice once `file_off` entered the hole:

1. `dummy = ext_end_off - filesize` **underflowed** (`size_t`) because the last
   extent ends *before* filesize, so `file_off + dummy == ext_end_off` never
   held and the last real extent was **never stored**.
2. The next `get_extent()` returned NULL → printed the error and returned 1, so
   the caller declared the file *"changed"* and **abandoned it** — never hashed,
   never deduped.

## Fix

- Only subtract the block-rounded past-EOF overshoot when the extent actually
  runs past filesize (`ext_end_off > filesize`).
- Treat NULL from `get_extent()` as "past the last extent = trailing hole; stop
  cleanly", not an error. (Middle holes are unaffected — `get_extent` returns
  the *next* extent for those, so only a genuine trailing hole yields NULL.)

## Tests

New cases: a trailing-hole file now scans and is digested (not abandoned); two
identical trailing-hole files dedupe with content preserved byte-for-byte.
Verified middle- and leading-hole files still dedupe and data is intact. Full
suite green (51 + 6). Reviewed via `/simplify` (reuse + altitude): confirmed the
NULL branch can't mask real errors and the fix sits at the right layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)