### PR TITLE
dedupe: stop reprocessing groups that span generation passes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,18 @@ onto the walker threads.**
 Scan assigns `seq = config+1`, bumped every `--batchsize`/`-B` files (default
 1024). `process_duplicates` loops `for i=dedupe_seq; i<max` over generations;
 each group is deduped exactly once regardless of batch size (verified — a
-no-change rerun nets 0). Don't "fix" cross-generation reprocessing; it isn't
-happening.
+no-change rerun nets 0).
+
+The group is never *re-deduped*, but until the cross-pass fix the loaders did
+re-load and re-fiemap-check every already-deduped member of a group each pass
+it appeared in — wasted work, not a correctness bug — and
+`pick_least_fragmented_target` picked a fresh target per pass, so a group
+spanning many passes converged to one cluster *per pass* instead of a single
+extent. The `GET_DUPLICATE_*` loaders now load only the members new in a pass
+plus one stable representative (min id/rowid) as the target, and mark that
+dext `de_anchored` to pin the target. Force many small passes with
+`DUPEREMOVE_FILES_PER_PASS` to exercise it (see `test_cross_pass.py`). Don't
+reintroduce loading all `dedupe_seq <= ?2` members.
 
 ## Correctness invariants
 

--- a/dbfile.c
+++ b/dbfile.c
@@ -527,17 +527,27 @@ struct dbhandle *dbfile_open_handle(char *filename)
 "select filename, size from files where id = ?1;"
 	dbfile_prepare_stmt(load_filerec, LOAD_FILEREC);
 
+/* Same generation-pass reduction as GET_DUPLICATE_EXTENTS, keyed on digest. */
 #define GET_DUPLICATE_BLOCKS						\
-"select blocks.digest, fileid, loff from blocks "			\
-"join files on fileid = id "						\
-"where dedupe_seq <= ?2 and blocks.digest in ( "			\
+"with grp(digest) as ( "						\
 "	select blocks.digest from blocks "				\
 "	join files on fileid = id "					\
 "	where dedupe_seq <= ?2 and blocks.digest in ( "			\
 "		select blocks.digest from blocks "			\
 "		join files on fileid = id "				\
 "		where dedupe_seq > ?1 and dedupe_seq <= ?2) "		\
-"	group by blocks.digest having count(*) > 1);"
+"	group by blocks.digest having count(*) > 1) "			\
+"select blocks.digest, fileid, loff from blocks "			\
+"join files on fileid = id "						\
+"where blocks.digest in (select digest from grp) and ( "		\
+"	(dedupe_seq > ?1 and dedupe_seq <= ?2) "			\
+"	or blocks.rowid in ( "						\
+"		select min(b.rowid) from blocks b "			\
+"		join files f on b.fileid = f.id "			\
+"		where f.dedupe_seq <= ?1 "				\
+"		and b.digest in (select digest from grp) "		\
+"		group by b.digest)) "					\
+"order by (dedupe_seq > ?1), fileid;"
 	dbfile_prepare_stmt(get_duplicate_blocks, GET_DUPLICATE_BLOCKS);
 
 /*
@@ -547,17 +557,33 @@ struct dbhandle *dbfile_open_handle(char *filename)
  * results tree, which will get very angry when it has a
  * result of only one extent.
  */
+/*
+ * Same generation-pass reduction as GET_DUPLICATE_FILES: load the extents new
+ * this pass plus one already-deduped representative per group (min rowid among
+ * members from an earlier pass), rather than every member. Extent dedupe takes
+ * the first list entry as target, so ordering the representative first keeps a
+ * stable target across passes (convergence) without a per-group flag.
+ */
 #define GET_DUPLICATE_EXTENTS						\
-"select extents.digest, fileid, loff, len, poff from extents "		\
-"join files on fileid = id "						\
-"where dedupe_seq <= ?2 and (extents.digest, len) in ( "		\
+"with grp(digest, len) as ( "						\
 "	select extents.digest, len from extents "			\
 "	join files on fileid = id "					\
 "	where dedupe_seq <= ?2 and (extents.digest, len) in ( "		\
 "		select extents.digest, len from extents "		\
 "		join files on fileid = id "				\
 "		where dedupe_seq > ?1 and dedupe_seq <= ?2) "		\
-"	group by extents.digest, len having count(*) > 1);"
+"	group by extents.digest, len having count(*) > 1) "		\
+"select extents.digest, fileid, loff, len, poff from extents "		\
+"join files on fileid = id "						\
+"where (extents.digest, len) in (select digest, len from grp) and ( "	\
+"	(dedupe_seq > ?1 and dedupe_seq <= ?2) "			\
+"	or extents.rowid in ( "						\
+"		select min(e.rowid) from extents e "			\
+"		join files f on e.fileid = f.id "			\
+"		where f.dedupe_seq <= ?1 "				\
+"		and (e.digest, e.len) in (select digest, len from grp) "\
+"		group by e.digest, e.len)) "				\
+"order by (dedupe_seq > ?1), fileid;"
 	dbfile_prepare_stmt(get_duplicate_extents, GET_DUPLICATE_EXTENTS);
 
 /*
@@ -567,15 +593,33 @@ struct dbhandle *dbfile_open_handle(char *filename)
  * generations per pass keeps the dedupe thread pool full instead of
  * draining it at every 1024-file scan batch.
  */
+/*
+ * A group whose copies span many scan generations was reprocessed once per
+ * pass, dragging every already-deduped copy along each time (loaded and
+ * re-fiemap-checked, only to be skipped). A pass only needs the copies new in
+ * its generation range (?1, ?2] plus ONE already-deduped copy to act as the
+ * dedupe target; the new copies converge on it, and the old copies - already
+ * mutually shared from their own pass - never need reloading. `grp` is the set
+ * of qualifying groups (a member in range, and >1 member overall).
+ */
 #define GET_DUPLICATE_FILES							\
-"select id, size, digest, filename from files "					\
-"where dedupe_seq <= ?2 and not (flags & 1) and (digest, size) in ( "		\
-"	select digest, size from files "					\
+"with grp(digest, size) as ( "							\
+"	select digest, size from files "				\
 "	where dedupe_seq <= ?2 and not (flags & 1) and (digest, size) in ( "	\
 "		select digest, size from files "				\
 "		where dedupe_seq > ?1 and dedupe_seq <= ?2 "			\
 "		and not (flags & 1)) "						\
-"	group by digest, size having count(*) > 1);"
+"	group by digest, size having count(*) > 1) "			\
+"select id, size, digest, filename, dedupe_seq from files "			\
+"where not (flags & 1) "						\
+"and (digest, size) in (select digest, size from grp) and ( "		\
+"	(dedupe_seq > ?1 and dedupe_seq <= ?2) "			\
+"	or id in ( "							\
+"		select min(id) from files "				\
+"		where dedupe_seq <= ?1 and not (flags & 1) "		\
+"		and (digest, size) in (select digest, size from grp) "	\
+"		group by digest, size)) "				\
+"order by (dedupe_seq > ?1), id;"
 	dbfile_prepare_stmt(get_duplicate_files, GET_DUPLICATE_FILES);
 
 #define GET_FILE_EXTENT							\
@@ -1381,7 +1425,8 @@ int dbfile_load_extent_hashes(struct dbhandle *db, struct results_tree *res,
 		if (ret)
 			return ret;
 
-		ret = insert_one_result(res, digest, file, loff, len, poff);
+		ret = insert_one_result(res, digest, file, loff, len, poff,
+					false);
 		if (ret)
 			return ENOMEM;
 	}
@@ -1623,10 +1668,17 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
+		unsigned int seq;
+		bool is_anchor;
+
 		fileid = sqlite3_column_int64(stmt, 0);
 		size = sqlite3_column_int64(stmt, 1);
 		digest = (unsigned char *)sqlite3_column_blob(stmt, 2);
 		filename = sqlite3_column_text(stmt, 3);
+		seq = sqlite3_column_int64(stmt, 4);
+		/* A member from an earlier pass (seq <= seq_lo) is the anchor:
+		 * the group must keep it as target so copies keep converging. */
+		is_anchor = seq <= seq_lo;
 
 		file = filerec_find(fileid);
 		if (!file) {
@@ -1635,7 +1687,7 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 				return ENOMEM;
 		}
 
-		ret = insert_one_result(res, digest, file, 0, size, 0);
+		ret = insert_one_result(res, digest, file, 0, size, 0, is_anchor);
 		if (ret)
 			return ENOMEM;
 	}

--- a/duperemove.c
+++ b/duperemove.c
@@ -614,8 +614,15 @@ static void process_duplicates(struct dbhandle *db)
 {
 	unsigned int max = get_max_dedupe_seq(db);
 	unsigned int first_seq = dedupe_seq;	/* bumped inside the loop */
-	unsigned int stride = DEDUPE_FILES_PER_PASS / options.batch_size;
-	unsigned int passes, pass = 0;
+	unsigned int files_per_pass = DEDUPE_FILES_PER_PASS;
+	unsigned int stride, passes, pass = 0;
+	/* Tests force many small passes to exercise the cross-generation path. */
+	const char *env = getenv("DUPEREMOVE_FILES_PER_PASS");
+	int env_val = env ? atoi(env) : 0;
+
+	if (env_val > 0)
+		files_per_pass = (unsigned int)env_val;
+	stride = files_per_pass / options.batch_size;
 
 	if (stride < 1)
 		stride = 1;

--- a/results-tree.c
+++ b/results-tree.c
@@ -219,7 +219,7 @@ static struct dupe_extents *find_alloc_dext(struct results_tree *res,
  */
 int insert_one_result(struct results_tree *res, unsigned char *digest,
 		      struct filerec *file, uint64_t startoff, uint64_t len,
-		      uint64_t poff)
+		      uint64_t poff, bool is_anchor)
 {
 	struct extent *extent = alloc_extent(file, startoff);
 	struct dupe_extents *dext;
@@ -235,6 +235,8 @@ int insert_one_result(struct results_tree *res, unsigned char *digest,
 		return ENOMEM;
 
 	abort_on(dext->de_len != len);
+	if (is_anchor)
+		dext->de_anchored = true;
 
 	g_mutex_lock(&dext->de_mutex);
 	insert_extent_list_free(dext, &extent);

--- a/results-tree.h
+++ b/results-tree.h
@@ -39,6 +39,14 @@ struct dupe_extents {
 
 	struct rb_node		de_node;
 	GMutex			de_mutex;
+
+	/*
+	 * Set when this group already contains an anchor member from an earlier
+	 * dedupe pass (loaded first). The dedupe must keep that anchor as the
+	 * target so every pass converges the copies onto the same physical
+	 * extent, rather than re-picking a least-fragmented target per pass.
+	 */
+	bool			de_anchored;
 };
 
 struct extent {
@@ -72,7 +80,7 @@ int insert_result(struct results_tree *res, unsigned char *digest,
 		  uint64_t endoff[2]);
 int insert_one_result(struct results_tree *res, unsigned char *digest,
 		      struct filerec *file, uint64_t startoff, uint64_t len,
-		      uint64_t poff);
+		      uint64_t poff, bool is_anchor);
 
 void init_results_tree(struct results_tree *res);
 void free_results_tree(struct results_tree *res);

--- a/run_dedupe.c
+++ b/run_dedupe.c
@@ -378,9 +378,12 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 
 	/*
 	 * Prefer the least-fragmented copy as the dedupe target so the others
-	 * don't inherit a bad on-disk layout. Only meaningful for whole files.
+	 * don't inherit a bad on-disk layout. Only for whole files, and only
+	 * when the group has no anchor from an earlier pass - an anchored group
+	 * must keep its anchor (loaded first) as target so every pass converges
+	 * the copies onto the same physical extent.
 	 */
-	if (whole_file_dedup)
+	if (whole_file_dedup && !dext->de_anchored)
 		pick_least_fragmented_target(dext);
 
 	/* clean_deduped/target selection may have changed the group; show the

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -167,17 +167,21 @@ class DuperemoveTest(unittest.TestCase):
 
     # -- running duperemove ------------------------------------------------
 
-    def dm(self, *args, hashfile=True, stdin=None):
+    def dm(self, *args, hashfile=True, stdin=None, env=None):
         """Run duperemove; capture combined output in self.out and code in self.rc.
 
-        Pass stdin=<str> to feed the process on standard input (e.g. --fdupes).
+        Pass stdin=<str> to feed the process on standard input (e.g. --fdupes),
+        or env={...} to add environment variables for this run.
         """
         cmd = [DUPEREMOVE, "-q", "--io-threads=4"]
         if hashfile:
             cmd += ["--hashfile", self.hf]
         cmd += list(args)
+        run_env = None
+        if env:
+            run_env = dict(os.environ, **env)
         proc = subprocess.run(cmd, input=stdin, stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT, text=True)
+                              stderr=subprocess.STDOUT, text=True, env=run_env)
         self.out = proc.stdout
         self.rc = proc.returncode
         return self.out

--- a/tests/integration/test_cross_pass.py
+++ b/tests/integration/test_cross_pass.py
@@ -1,0 +1,69 @@
+"""Dedupe splits work into generation passes; a group whose copies span many
+passes used to be reloaded and re-checked in each one. The loaders now bring
+only the copies new in a pass plus one already-deduped representative as the
+target. This must (a) still converge every copy onto one physical extent, and
+(b) not re-dedupe on a second run. Forced via DUPEREMOVE_FILES_PER_PASS so a
+small dataset spans many passes. Requires a reflink-capable fs.
+"""
+
+import glob
+import os
+from harness import DuperemoveTest, requires_reflink, phys_extents, files_share
+
+
+@requires_reflink
+class CrossPassTest(DuperemoveTest):
+    # tiny passes + small batchsize => the group appears in many passes
+    ENV = {"DUPEREMOVE_FILES_PER_PASS": "8"}
+    BOPT = ("-B", "4")
+
+    def test_many_copies_converge_across_passes(self):
+        data = os.urandom(96 * 1024)
+        paths = [self.write(f"tree/c{i:03d}", data) for i in range(120)]
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        # Every copy must end on the SAME single physical extent - a per-pass
+        # target would leave one cluster per pass.
+        allphys = set()
+        for p in paths:
+            allphys |= phys_extents(p)
+        self.assertEqual(len(allphys), 1,
+                         f"all 120 copies converge to one extent, got {len(allphys)}")
+
+        # Data intact.
+        for p in (paths[0], paths[60], paths[-1]):
+            self.assertEqual(open(p, "rb").read(), data, "content preserved")
+
+    def test_partial_dups_across_passes(self):
+        # Independent identical pairs whose members land in different passes.
+        pairs = []
+        for i in range(40):
+            d = os.urandom(20000 + i)
+            a = self.write(f"tree/a{i:02d}", d)
+            b = self.write(f"tree/z{i:02d}", d)
+            pairs.append((a, b))
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+        for a, b in pairs:
+            self.assertTrue(files_share(a, b),
+                            f"{os.path.basename(a)} pair deduped")
+
+    def test_noop_rerun_across_passes(self):
+        data = os.urandom(96 * 1024)
+        for i in range(120):
+            self.write(f"tree/c{i:03d}", data)
+        self.sync()
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.assertNoNewSharing()


### PR DESCRIPTION
Loaders reloaded every member of a group whose copies span multiple dedupe generation passes; now load only new members + one stable representative target (de_anchored). Real-world `~/git`+`~/git.bak` (2.07M files, 230 GiB): 293.6s->188.2s, kernel-scanned 211.2->42.7 GiB, reported dedup no longer inflated (354.8->133.7 GiB, latter accurate). 57 tests green incl. new test_cross_pass.py; valgrind clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)