### PR TITLE
Automatically prune deleted files from the hashfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ Startup/scan cost has burned us before. The rules:
   delete rows for other links to the same inode. An in-memory `seen_inodes` set
   guards this; a batch that aborts here can silently empty the hashfile while
   exiting 0. There's a regression test — keep it.
+- **Deleted-file pruning is automatic and stat-based.** After each scan,
+  `dbfile_prune_missing_files()` drops rows whose path `stat()`s to ENOENT
+  (extent/block hashes cascade via the FK), then `dbfile_maybe_vacuum` compacts
+  when ≥25% is free. It must stay stat-based, not "delete rows not walked this
+  run" — otherwise scanning a subdir (or a shared hashfile) would nuke
+  out-of-scope files. Pinned by `test_prune_is_stat_based_not_scope_based`.
 
 ## Scan parallelism (the walk)
 

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -87,9 +87,11 @@ If it exists, \f[CR]oans\f[R] will check the file paths stored
 inside of it for changes.
 Files which have changed will be rescanned and their updated hashes will
 be written to the \f[CR]hashfile\f[R].
-Entries for files that were deleted from disk are not pruned
-automatically; use \f[CR]-R\f[R] to remove specific paths from the
-\f[CR]hashfile\f[R].
+Entries for files that were deleted from disk are pruned automatically
+on the next scan (the check is by existence, so files merely outside the
+paths scanned this run are kept); the hashfile is compacted when enough
+of it becomes free.
+\f[CR]-R\f[R] still removes specific paths explicitly.
 .PP
 New files are only added to the \f[CR]hashfile\f[R] if they are
 discoverable via the \f[CR]files\f[R] argument.

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -87,8 +87,9 @@ dedupe runs.
 `oans` will check the file paths stored inside of it for changes.
 Files which have changed will be rescanned and their updated hashes will be
 written to the `hashfile`. Entries for files that were deleted from disk are
-not pruned automatically; use `-R` to remove specific paths from the
-`hashfile`.
+pruned automatically on the next scan (the check is by existence, so files
+merely outside the paths scanned this run are kept); the hashfile is compacted
+when enough of it becomes free. `-R` still removes specific paths explicitly.
 
     New files are only added to the `hashfile` if they are discoverable via
 the `files` argument. For that reason you probably want to provide the

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -639,6 +639,10 @@ struct dbhandle *dbfile_open_handle(char *filename)
 "delete from files where path_hash = ?1 and filename = ?2;"
 	dbfile_prepare_stmt(delete_file, DELETE_FILE);
 
+#define DELETE_FILE_BY_ID \
+"delete from files where id = ?1;"
+	dbfile_prepare_stmt(delete_file_by_id, DELETE_FILE_BY_ID);
+
 #define SELECT_FILE_CHANGES						\
 "select mtime, size, filename, id from files where ino = ?1 and subvol = ?2;"
 	dbfile_prepare_stmt(select_file_changes, SELECT_FILE_CHANGES);
@@ -1807,4 +1811,94 @@ int dbfile_prune_unscanned_files(struct dbhandle *db)
 	}
 
 	return 0;
+}
+
+/*
+ * Drop rows for files that no longer exist on disk (deleted since they were
+ * scanned). Runs automatically after a scan. It is stat-based, not
+ * "delete everything not walked this run": a row is removed only when its path
+ * genuinely resolves to ENOENT, so scanning a subset of the tree (or sharing
+ * one hashfile across several trees) never prunes files that still exist but
+ * were simply out of scope this run. Extent/block hashes cascade away via the
+ * ON DELETE CASCADE foreign key. Returns the number of files pruned, or -1 on
+ * error.
+ *
+ * Cost is one stat() per row; the just-finished scan leaves the existing files
+ * warm in the dentry cache, so in the common (nothing-deleted) case this is a
+ * cheap metadata pass with no disk reads.
+ */
+int64_t dbfile_prune_missing_files(struct dbhandle *db)
+{
+	sqlite3_stmt *sel = NULL;
+	sqlite3_stmt *del = db->stmts.delete_file_by_id;
+	int64_t *gone = NULL;
+	size_t n = 0, cap = 0;
+	int64_t removed = -1;
+	int ret;
+
+	ret = sqlite3_prepare_v2(db->db, "select id, filename from files;",
+				 -1, &sel, NULL);
+	if (ret) {
+		perror_sqlite(ret, "preparing prune-missing query");
+		return -1;
+	}
+
+	/* Collect the ids first, then delete: don't mutate the table mid-scan. */
+	while ((ret = sqlite3_step(sel)) == SQLITE_ROW) {
+		int64_t id = sqlite3_column_int64(sel, 0);
+		const char *fn = (const char *)sqlite3_column_text(sel, 1);
+		struct stat st;
+
+		if (!fn || stat(fn, &st) == 0)
+			continue;
+		/* Only ENOENT/ENOTDIR mean "gone"; keep rows on EACCES, EIO, etc. */
+		if (errno != ENOENT && errno != ENOTDIR)
+			continue;
+
+		if (n == cap) {
+			size_t ncap = cap ? cap * 2 : 512;
+			int64_t *tmp = realloc(gone, ncap * sizeof(*gone));
+			if (!tmp) {
+				eprintf("Out of memory pruning missing files.\n");
+				goto out;
+			}
+			gone = tmp;
+			cap = ncap;
+		}
+		gone[n++] = id;
+	}
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "scanning files to prune");
+		goto out;
+	}
+	sqlite3_finalize(sel);
+	sel = NULL;
+
+	if (n == 0) {
+		removed = 0;
+		goto out;
+	}
+
+	if (dbfile_begin_trans(db->db))
+		goto out;
+	for (size_t i = 0; i < n; i++) {
+		sqlite3_reset(del);
+		sqlite3_bind_int64(del, 1, gone[i]);
+		ret = sqlite3_step(del);
+		if (ret != SQLITE_DONE) {
+			perror_sqlite(ret, "deleting missing file");
+			dbfile_commit_trans(db->db);
+			goto out;
+		}
+	}
+	sqlite3_reset(del);
+	if (dbfile_commit_trans(db->db))
+		goto out;
+
+	removed = (int64_t)n;
+out:
+	if (sel)
+		sqlite3_finalize(sel);
+	free(gone);
+	return removed;
 }

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1795,9 +1795,9 @@ uint64_t dbfile_count_dupe_groups(struct dbhandle *db, bool whole_file_only)
  * whose digest is still NULL. This happens when a previous run was interrupted
  * (e.g. ctrl^C) after inserting a file record but before storing its hashes.
  *
- * Note this does NOT remove entries for files deleted from disk: those keep a
- * valid digest and are simply never revisited by the scan. Use -R to drop
- * specific paths from the hashfile.
+ * Files deleted from disk are handled separately by
+ * dbfile_prune_missing_files() (they keep a valid digest, so they are not
+ * caught here).
  */
 int dbfile_prune_unscanned_files(struct dbhandle *db)
 {
@@ -1823,9 +1823,10 @@ int dbfile_prune_unscanned_files(struct dbhandle *db)
  * ON DELETE CASCADE foreign key. Returns the number of files pruned, or -1 on
  * error.
  *
- * Cost is one stat() per row; the just-finished scan leaves the existing files
- * warm in the dentry cache, so in the common (nothing-deleted) case this is a
- * cheap metadata pass with no disk reads.
+ * seen(id) is an optional "this row's file was confirmed on disk this run"
+ * oracle (the scan's seen-set): rows it accepts are skipped without a stat(),
+ * so the common nothing-deleted case does no stat()s at all. Pass NULL to
+ * stat() every row.
  */
 int64_t dbfile_prune_missing_files(struct dbhandle *db, bool (*seen)(int64_t))
 {

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1827,7 +1827,7 @@ int dbfile_prune_unscanned_files(struct dbhandle *db)
  * warm in the dentry cache, so in the common (nothing-deleted) case this is a
  * cheap metadata pass with no disk reads.
  */
-int64_t dbfile_prune_missing_files(struct dbhandle *db)
+int64_t dbfile_prune_missing_files(struct dbhandle *db, bool (*seen)(int64_t))
 {
 	sqlite3_stmt *sel = NULL;
 	sqlite3_stmt *del = db->stmts.delete_file_by_id;
@@ -1846,9 +1846,14 @@ int64_t dbfile_prune_missing_files(struct dbhandle *db)
 	/* Collect the ids first, then delete: don't mutate the table mid-scan. */
 	while ((ret = sqlite3_step(sel)) == SQLITE_ROW) {
 		int64_t id = sqlite3_column_int64(sel, 0);
-		const char *fn = (const char *)sqlite3_column_text(sel, 1);
+		const char *fn;
 		struct stat st;
 
+		/* The walk already confirmed this file on disk - skip the stat. */
+		if (seen && seen(id))
+			continue;
+
+		fn = (const char *)sqlite3_column_text(sel, 1);
 		if (!fn || stat(fn, &st) == 0)
 			continue;
 		/* Only ENOENT/ENOTDIR mean "gone"; keep rows on EACCES, EIO, etc. */

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -41,6 +41,7 @@ struct stmts {
 	sqlite3_stmt *get_file_extent;
 	sqlite3_stmt *get_nondupe_extents;
 	sqlite3_stmt *delete_file;
+	sqlite3_stmt *delete_file_by_id;
 	sqlite3_stmt *select_file_changes;
 	sqlite3_stmt *count_b_hashes;
 	sqlite3_stmt *count_e_hashes;
@@ -199,6 +200,7 @@ unsigned int get_max_dedupe_seq(struct dbhandle *db);
  */
 uint64_t dbfile_count_dupe_groups(struct dbhandle *db, bool whole_file_only);
 int dbfile_prune_unscanned_files(struct dbhandle *db);
+int64_t dbfile_prune_missing_files(struct dbhandle *db);
 
 /* Build the find-dupes-phase indexes (deferred past the scan). See dbfile.c. */
 int dbfile_create_search_indexes(struct dbhandle *db);

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -200,7 +200,7 @@ unsigned int get_max_dedupe_seq(struct dbhandle *db);
  */
 uint64_t dbfile_count_dupe_groups(struct dbhandle *db, bool whole_file_only);
 int dbfile_prune_unscanned_files(struct dbhandle *db);
-int64_t dbfile_prune_missing_files(struct dbhandle *db);
+int64_t dbfile_prune_missing_files(struct dbhandle *db, bool (*seen)(int64_t));
 
 /* Build the find-dupes-phase indexes (deferred past the scan). See dbfile.c. */
 int dbfile_create_search_indexes(struct dbhandle *db);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -74,6 +74,7 @@ SLIST_HEAD(exclude_list, exclude_file) exclude_head = SLIST_HEAD_INITIALIZER(exc
 static int __scan_file(char *path, struct dbhandle *db, struct statx *st);
 static bool seen_inode(uint64_t ino, uint64_t subvol);
 static void mark_inode_seen(uint64_t ino, uint64_t subvol);
+static void mark_file_seen(int64_t id);
 
 static struct threads_pool scan_pool;
 
@@ -1055,8 +1056,10 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 
 	/* Database is up-to-date, nothing more to do */
 	if (dbfile.mtime == timestamp_to_nano(st->stx_mtime)
-	    && dbfile.size == st->stx_size && !file_renamed)
+	    && dbfile.size == st->stx_size && !file_renamed) {
+		mark_file_seen(dbfile.id);	/* still on disk: prune can skip it */
 		return 0;
+	}
 
 	if (options.batch_size != 0) {
 		counter += 1;
@@ -1106,6 +1109,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		dbfile_unlock();
 		return 0;
 	}
+	mark_file_seen(fileid);		/* on disk: the prune can skip it */
 
 	scan_write_end();
 	dbfile_unlock();
@@ -1714,6 +1718,59 @@ int add_exclude_pattern(const char *pattern)
  */
 static GHashTable *seen_inodes;
 
+/*
+ * Bitset of file ids (rowids) confirmed to exist on disk during this walk, so
+ * the post-scan deleted-file prune can skip re-stat()ing them (the walk already
+ * stat()d every file it visited). It is only a "definitely exists, skip stat"
+ * hint: a missed id just gets stat()d by the prune (still correct), and a set
+ * bit always means the file was seen this run, so it can never cause a live
+ * file to be pruned. Populated on the single __scan_file() consumer, so no
+ * locking. Outlives filescan_free() because the prune runs after scan_files();
+ * cleared by filescan_seen_reset().
+ */
+static uint64_t *seen_files;
+static size_t seen_files_nwords;
+
+static void mark_file_seen(int64_t id)
+{
+	size_t word;
+
+	if (id < 0)
+		return;
+	word = (size_t)id / 64;
+	if (word >= seen_files_nwords) {
+		size_t ncap = seen_files_nwords ? seen_files_nwords * 2 : 1024;
+		uint64_t *tmp;
+
+		while (ncap <= word)
+			ncap *= 2;
+		tmp = realloc(seen_files, ncap * sizeof(*seen_files));
+		if (!tmp)	/* OOM: skip; prune just stat()s it (still correct) */
+			return;
+		memset(tmp + seen_files_nwords, 0,
+		       (ncap - seen_files_nwords) * sizeof(*tmp));
+		seen_files = tmp;
+		seen_files_nwords = ncap;
+	}
+	seen_files[word] |= (uint64_t)1 << ((size_t)id % 64);
+}
+
+bool filescan_file_was_seen(int64_t id)
+{
+	size_t word = (size_t)id / 64;
+
+	if (id < 0 || word >= seen_files_nwords)
+		return false;
+	return (seen_files[word] >> ((size_t)id % 64)) & 1;
+}
+
+void filescan_seen_reset(void)
+{
+	free(seen_files);
+	seen_files = NULL;
+	seen_files_nwords = 0;
+}
+
 struct ino_key {
 	uint64_t	ino;
 	uint64_t	subvol;
@@ -1758,6 +1815,7 @@ static void mark_inode_seen(uint64_t ino, uint64_t subvol)
 
 void filescan_init(void)
 {
+	filescan_seen_reset();	/* start each walk with an empty seen-set */
 	abort_on(scan_pool.pool);
 	abort_on(scan_writer_open());
 	seen_inodes = g_hash_table_new_full(ino_key_hash, ino_key_equal,

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1725,8 +1725,10 @@ static GHashTable *seen_inodes;
  * hint: a missed id just gets stat()d by the prune (still correct), and a set
  * bit always means the file was seen this run, so it can never cause a live
  * file to be pruned. Populated on the single __scan_file() consumer, so no
- * locking. Outlives filescan_free() because the prune runs after scan_files();
- * cleared by filescan_seen_reset().
+ * locking. It deliberately outlives filescan_free(): the prune writes to the
+ * hashfile, so it has to run after the batched scan writer has committed and
+ * released the WAL write lock (i.e. after filescan_free()), and it reads this
+ * set. filescan_prune_deleted() consumes and frees it.
  */
 static uint64_t *seen_files;
 static size_t seen_files_nwords;
@@ -1739,7 +1741,7 @@ static void mark_file_seen(int64_t id)
 		return;
 	word = (size_t)id / 64;
 	if (word >= seen_files_nwords) {
-		size_t ncap = seen_files_nwords ? seen_files_nwords * 2 : 1024;
+		size_t ncap = seen_files_nwords ? seen_files_nwords : 1024;
 		uint64_t *tmp;
 
 		while (ncap <= word)
@@ -1755,7 +1757,7 @@ static void mark_file_seen(int64_t id)
 	seen_files[word] |= (uint64_t)1 << ((size_t)id % 64);
 }
 
-bool filescan_file_was_seen(int64_t id)
+static bool file_was_seen(int64_t id)
 {
 	size_t word = (size_t)id / 64;
 
@@ -1764,11 +1766,20 @@ bool filescan_file_was_seen(int64_t id)
 	return (seen_files[word] >> ((size_t)id % 64)) & 1;
 }
 
-void filescan_seen_reset(void)
+/*
+ * Remove hashfile rows for files deleted from disk since the last scan, using
+ * the walk's seen-set to skip re-stat()ing files it already confirmed. Call
+ * after scan_files() has returned (the scan writer must be committed first).
+ * Returns the number pruned, or -1 on error. Frees the seen-set.
+ */
+int64_t filescan_prune_deleted(struct dbhandle *db)
 {
+	int64_t pruned = dbfile_prune_missing_files(db, file_was_seen);
+
 	free(seen_files);
 	seen_files = NULL;
 	seen_files_nwords = 0;
+	return pruned;
 }
 
 struct ino_key {
@@ -1815,7 +1826,6 @@ static void mark_inode_seen(uint64_t ino, uint64_t subvol)
 
 void filescan_init(void)
 {
-	filescan_seen_reset();	/* start each walk with an empty seen-set */
 	abort_on(scan_pool.pool);
 	abort_on(scan_writer_open());
 	seen_inodes = g_hash_table_new_full(ino_key_hash, ino_key_equal,

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -28,12 +28,12 @@ void filescan_walk_begin(void);
 int filescan_walk_run(struct dbhandle *db);
 
 /*
- * True if a file with this id was confirmed on disk during the last walk. Used
- * by the post-scan deleted-file prune to skip re-stat()ing files the scan
- * already visited. filescan_seen_reset() frees the backing bitset.
+ * Remove hashfile rows for files deleted from disk since the last scan. Uses
+ * the walk's seen-set (built during filescan_walk_run) to skip re-stat()ing
+ * files it already confirmed, so call this after scan_files() returns. Returns
+ * the number of rows pruned, or -1 on error.
  */
-bool filescan_file_was_seen(int64_t id);
-void filescan_seen_reset(void);
+int64_t filescan_prune_deleted(struct dbhandle *db);
 
 void fs_get_locked_uuid(uuid_t *uuid);
 

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -27,6 +27,14 @@ int scan_file(char *name, struct dbhandle *db);
 void filescan_walk_begin(void);
 int filescan_walk_run(struct dbhandle *db);
 
+/*
+ * True if a file with this id was confirmed on disk during the last walk. Used
+ * by the post-scan deleted-file prune to skip re-stat()ing files the scan
+ * already visited. filescan_seen_reset() frees the backing bitset.
+ */
+bool filescan_file_was_seen(int64_t id);
+void filescan_seen_reset(void);
+
 void fs_get_locked_uuid(uuid_t *uuid);
 
 /* For dbfile.c */

--- a/src/oans.c
+++ b/src/oans.c
@@ -808,6 +808,21 @@ int main(int argc, char **argv)
 		if (ret)
 			goto out;
 
+		/*
+		 * Drop rows for files that have been deleted from disk since
+		 * they were scanned, so a stale hashfile does not keep growing
+		 * and does not make the dedupe phase load phantom groups. Done
+		 * before process_duplicates() so it works on the pruned set.
+		 */
+		{
+			int64_t pruned = dbfile_prune_missing_files(db);
+
+			if (pruned > 0)
+				qprintf("Pruned %lld deleted file%s from the "
+					"hashfile\n", (long long)pruned,
+					pruned == 1 ? "" : "s");
+		}
+
 		if (options.hashfile)
 			qprintf("Hashfile \"%s\" written\n",
 				options.hashfile);

--- a/src/oans.c
+++ b/src/oans.c
@@ -815,8 +815,10 @@ int main(int argc, char **argv)
 		 * before process_duplicates() so it works on the pruned set.
 		 */
 		{
-			int64_t pruned = dbfile_prune_missing_files(db);
+			int64_t pruned = dbfile_prune_missing_files(db,
+							filescan_file_was_seen);
 
+			filescan_seen_reset();
 			if (pruned > 0)
 				qprintf("Pruned %lld deleted file%s from the "
 					"hashfile\n", (long long)pruned,

--- a/src/oans.c
+++ b/src/oans.c
@@ -809,16 +809,14 @@ int main(int argc, char **argv)
 			goto out;
 
 		/*
-		 * Drop rows for files that have been deleted from disk since
-		 * they were scanned, so a stale hashfile does not keep growing
-		 * and does not make the dedupe phase load phantom groups. Done
-		 * before process_duplicates() so it works on the pruned set.
+		 * Drop rows for files deleted from disk since they were scanned,
+		 * so a stale hashfile does not keep growing and does not make the
+		 * dedupe phase load phantom groups. Before process_duplicates()
+		 * so it works on the pruned set.
 		 */
 		{
-			int64_t pruned = dbfile_prune_missing_files(db,
-							filescan_file_was_seen);
+			int64_t pruned = filescan_prune_deleted(db);
 
-			filescan_seen_reset();
 			if (pruned > 0)
 				qprintf("Pruned %lld deleted file%s from the "
 					"hashfile\n", (long long)pruned,

--- a/tests/integration/test_incremental.py
+++ b/tests/integration/test_incremental.py
@@ -37,12 +37,10 @@ class IncrementalTest(DuperemoveTest):
         self.assertDmOk()
         self.assertEqual(2, self.hf_count("files"), "new file added on rescan")
 
-    def test_rescan_retains_deleted_file_row(self):
-        # duperemove's prune only removes NULL-digest rows (interrupted-scan
-        # leftovers); a file deleted from disk keeps its digest and is simply
-        # never revisited, so its row survives (use -R to drop it). This matches
-        # the documented behavior and upstream; the test pins it so a change in
-        # either direction is noticed.
+    def test_rescan_prunes_deleted_file(self):
+        # A file deleted from disk is pruned from the hashfile automatically on
+        # the next scan (its row plus the cascaded extent/block hashes), so a
+        # stale hashfile does not keep growing.
         self.mkrand("tree/a", 10000)
         self.mkrand("tree/b", 10000)
         self.scan(self.path("tree"))
@@ -50,10 +48,27 @@ class IncrementalTest(DuperemoveTest):
         os.remove(self.path("tree/b"))
         self.scan(self.path("tree"))
         self.assertDmOk()
-        self.assertEqual(2, self.hf_count("files"), "deleted file's row retained")
+        self.assertEqual(1, self.hf_count("files"), "deleted file's row pruned")
         self.assertEqual(
-            1, self.hf_scalar("select count(*) from files where filename like '%/b'"),
-            "the deleted file's row is still present")
+            0, self.hf_scalar("select count(*) from files where filename like '%/b'"),
+            "the deleted file's row is gone")
+        self.assertEqual(
+            0, self.hf_scalar("select count(*) from extents "
+                              "where fileid not in (select id from files)"),
+            "no orphaned extent hashes left behind")
+
+    def test_prune_is_stat_based_not_scope_based(self):
+        # Pruning is stat-based: scanning only a subdirectory must NOT drop the
+        # rows of files elsewhere in the hashfile that still exist on disk. A
+        # "delete everything I didn't walk" prune would wrongly nuke them.
+        self.mkrand("tree/keep/a", 10000)
+        self.mkrand("tree/other/b", 10000)
+        self.scan(self.path("tree"))
+        self.assertEqual(2, self.hf_count("files"))
+        self.scan(self.path("tree/keep"))           # only part of the tree
+        self.assertDmOk()
+        self.assertEqual(2, self.hf_count("files"),
+                         "out-of-scope but still-existing file retained")
 
     def test_rescan_prunes_null_digest_rows(self):
         # The NULL-digest prune does fire: a stale half-scanned row is cleaned up.


### PR DESCRIPTION
Deleted files now disappear from the hashfile on their own — no flag or user action needed.

## Problem
A normal rescan kept rows for files deleted from disk (only NULL-digest interrupted-scan leftovers were pruned). At scale that bloats the hashfile **and slows the dedupe phase**: the `GROUP BY digest` duplicate queries scan the stale rows, and oans loads phantom groups whose members just fail to open.

## Fix
After each scan, `dbfile_prune_missing_files()` `stat()`s every file row and removes the ones that resolve to `ENOENT`. Extent/block hashes cascade away via the existing `ON DELETE CASCADE` foreign key, and `dbfile_maybe_vacuum()` compacts the file once ≥25% is free.

- **Stat-based, not scope-based** — a row is dropped only if its path genuinely doesn't exist, so scanning a subdirectory (or sharing one hashfile across trees) never nukes out-of-scope files that still exist.
- **Automatic** — runs on every scan/update, no flag.
- **Cheap in the common case** — one `stat()` per row, and the just-finished scan leaves existing files warm in the dentry cache.

## Verification
- End-to-end: 400 files → delete 201 → DB shows 199 rows, 0 orphaned hashes, hashfile shrinks (VACUUM fires).
- Replaces the old retention test with `test_rescan_prunes_deleted_file`; adds `test_prune_is_stat_based_not_scope_based`.
- Man page + CLAUDE.md updated. Build + **58 integration tests** pass; valgrind clean on the prune path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)