### PR TITLE
Fix uninitialised UUID read in config load; add valgrind suppressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,24 @@ dext `de_anchored` to pin the target. Force many small passes with
 `DUPEREMOVE_FILES_PER_PASS` to exercise it (see `test_cross_pass.py`). Don't
 reintroduce loading all `dedupe_seq <= ?2` members.
 
+## Valgrind
+
+Run with the suppressions file, which filters the one class of library
+false-positive:
+
+```sh
+valgrind --leak-check=full --track-origins=yes \
+    --suppressions=tests/valgrind.supp ./oans -rd --hashfile=/tmp/h.db <tree>
+```
+
+The suppressed noise is GLib/glibc **thread TLS** ("possibly lost" under
+`pthread_create` -> `_dl_allocate_tls`): GLib caches idle pool threads instead
+of joining them all at exit. Not an oans leak. Everything else must be clean —
+`definitely lost` and any uninitialised-value / invalid-access errors are real.
+(One such was fixed: `__dbfile_get_config` read an unterminated UUID buffer;
+config string buffers from `get_config_text` are raw `memcpy`, so anything
+`strlen`'d must be zero-initialised.)
+
 ## Correctness invariants
 
 - Ctrl+C is safe: `FIDEDUPERANGE` is atomic and the hashfile stays WAL-consistent

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1044,7 +1044,13 @@ static int get_config_text(sqlite3_stmt *stmt, const char *name, char *val, int 
 static int __dbfile_get_config(sqlite3 *db, struct dbfile_config *cfg)
 {
 	int ret;
-	char uuid[37]; /* 36-bytes uuid + \0 */
+	/*
+	 * Zero-initialised so the buffer is always NUL-terminated: get_config_text
+	 * memcpy()s exactly `len` (36) bytes without terminating, and if the
+	 * config row is absent it writes nothing at all - either way uuid_parse()
+	 * below would otherwise strlen() past uninitialised bytes.
+	 */
+	char uuid[37] = "";	/* 36-byte uuid + NUL */
 	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
 
 #define SELECT_CONFIG "select keyval from config where keyname=?1;"

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -1,0 +1,19 @@
+# Valgrind suppressions for oans.
+#
+# These are library-level false positives, NOT leaks in oans code. Run with:
+#   valgrind --leak-check=full --suppressions=tests/valgrind.supp ./oans ...
+#
+# GLib/glibc thread TLS: every thread GLib spawns (the walker/dedupe thread
+# pools and the progress thread) allocates its stack + thread-local storage via
+# pthread_create -> _dl_allocate_tls. GLib caches idle worker threads rather
+# than joining all of them at exit, so valgrind reports that TLS as "possibly
+# lost". The oans thread pools are freed (g_thread_pool_free with wait=TRUE);
+# the residue is glibc/GLib internal thread bookkeeping we do not own.
+{
+   glib-glibc-thread-tls-possibly-lost
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_dl_allocate_tls
+   ...
+}


### PR DESCRIPTION
A valgrind sweep across all the main paths (fresh scan+dedupe with block hashing, incremental rescan, deleted-file prune, `-R`, `--fdupes`, read-only, plus `hashstats`/`csum-test`/`btrfs-extent-same` and the `--skip-zeroes`/`-b`/`only_whole_files` options).

## Real bug fixed
`__dbfile_get_config()` read an **uninitialised UUID buffer**: `get_config_text()` `memcpy()`s exactly `len` bytes with no NUL terminator (and writes nothing at all when the config row is absent), so `uuid_parse()`→`strlen()` ran past the 36-byte uuid into uninitialised stack — and on a missing config row could parse garbage over the default `fs_uuid`. Fixed by zero-initialising the buffer. (`hash_type` is a fixed-width 8-byte field, so its `memcpy` is correct and unchanged.)

## Library noise, suppressed
The only remaining output is GLib/glibc **thread-TLS** "possibly lost" (`pthread_create`→`_dl_allocate_tls`): GLib caches idle pool threads rather than joining them all at exit. Not an oans leak — added `tests/valgrind.supp` (documented) and a CLAUDE.md section on running valgrind.

## Result
With the suppressions, every swept path reports **0 errors, 0 definitely-lost**. Build + **58 integration tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)