### PR TITLE
Brand the hashfile with a SQLite application_id; bump format to 5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,18 @@ of joining them all at exit. Not an oans leak. Everything else must be clean —
 config string buffers from `get_config_text` are raw `memcpy`, so anything
 `strlen`'d must be zero-initialised.)
 
+## Hashfile identity (oans vs duperemove)
+
+The hashfile schema version is `DB_FILE_MAJOR.MINOR` in `dbfile.h` (5.0; oans
+forked at upstream duperemove's 4.1 and jumped to 5.0 as a deliberate clean
+break). Every oans hashfile is also stamped with SQLite `PRAGMA application_id =
+OANS_APP_ID` ("oans" in ASCII) and `dbfile_check()` **strictly** refuses any file
+that doesn't carry the brand — foreign, or a pre-brand/duperemove file. A
+brand-new empty file (`dbfile_config_empty()`) is stamped *before* the check, so
+a fresh scan doesn't recreate-loop; existing files must already carry the brand.
+A failed check unlinks and recreates the hashfile (it's only a cache). Bump
+`DB_FILE_MINOR` on any schema change.
+
 ## Correctness invariants
 
 - Ctrl+C is safe: `FIDEDUPERANGE` is atomic and the hashfile stays WAL-consistent

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ data.
 oans can store the hashes it computes in a **hashfile**. Given an existing
 hashfile it only re-hashes files that changed since the last run, so you can
 run it repeatedly on your data as it changes without re-checksumming
-everything. The hashfile format is unchanged from upstream duperemove.
+everything. The hashfile is a SQLite database branded with oans's own
+`application_id`, so oans and upstream duperemove will not read each other's
+hashfiles (each rebuilds its own) — but they are just caches, so nothing is
+lost.
 
 See [the upstream duperemove man page](http://markfasheh.github.io/duperemove/duperemove.html)
 for the full reference (options, FAQ, and examples) — this fork keeps the same
@@ -34,8 +37,9 @@ command-line interface.
 
 ## What's different in this fork
 
-Everything below is additive: the CLI, hashfile format, and behavior stay
-compatible with upstream. The theme is **doing less redundant work** and
+Everything below is additive: the CLI and behavior stay compatible with
+upstream (the hashfile is oans-branded, see above). The theme is **doing less
+redundant work** and
 **telling you more clearly what happened**.
 
 ### Performance

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -132,9 +132,62 @@ static int dbfile_get_dbpath(sqlite3 *db, char *path)
 	return 0;
 }
 
+static int dbfile_get_application_id(sqlite3 *db, int *out)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int ret;
+
+	*out = 0;
+	ret = sqlite3_prepare_v2(db, "PRAGMA application_id;", -1, &stmt, NULL);
+	if (ret)
+		return ret;
+	if (sqlite3_step(stmt) == SQLITE_ROW)
+		*out = sqlite3_column_int(stmt, 0);
+	return 0;
+}
+
+/* Best-effort: a read-only handle can't write the header, which is fine. */
+static void dbfile_stamp_application_id(sqlite3 *db)
+{
+	char sql[64];
+
+	snprintf(sql, sizeof(sql), "PRAGMA application_id = %d;", OANS_APP_ID);
+	sqlite3_exec(db, sql, NULL, NULL, NULL);
+}
+
+/* True for a brand-new hashfile: create_tables() has run but nothing has
+ * written the config rows yet (that happens after the check, in sync_config). */
+static bool dbfile_config_empty(sqlite3 *db)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	bool empty = true;
+
+	if (sqlite3_prepare_v2(db, "select 1 from config limit 1;", -1,
+			       &stmt, NULL) == SQLITE_OK)
+		empty = (sqlite3_step(stmt) != SQLITE_ROW);
+	return empty;
+}
+
 static int dbfile_check(sqlite3 *db, struct dbfile_config *cfg)
 {
 	char path[PATH_MAX + 1];
+	int app_id = 0;
+
+	dbfile_get_dbpath(db, path);
+
+	/*
+	 * oans requires its brand. A brand-new file was stamped before this
+	 * check (see dbfile_prepare); anything reaching here without the brand
+	 * is a foreign or pre-brand (e.g. duperemove) hashfile - refuse it, and
+	 * the caller recreates it as an oans file.
+	 */
+	dbfile_get_application_id(db, &app_id);
+	if (app_id != OANS_APP_ID) {
+		eprintf("Hashfile %s is not an oans hashfile "
+			"(application_id 0x%08x); refusing to use it\n", path,
+			(unsigned)app_id);
+		return EIO;
+	}
 
 	if (cfg->major != DB_FILE_MAJOR || cfg->minor != DB_FILE_MINOR) {
 		eprintf("Hash db version mismatch (mine: %d.%d, file: %d.%d)\n",
@@ -142,7 +195,6 @@ static int dbfile_check(sqlite3 *db, struct dbfile_config *cfg)
 		return EIO;
 	}
 
-	dbfile_get_dbpath(db, path);
 
 	if (strncasecmp(cfg->hash_type, HASH_TYPE, 8)) {
 		eprintf("Error: Hashfile %s uses \"%.*s\" for checksums "
@@ -364,6 +416,14 @@ static int dbfile_prepare(sqlite3 *db)
 			return ret;
 		}
 	}
+
+	/*
+	 * A brand-new hashfile (empty config) is ours: brand it now, before the
+	 * strict application_id check below. An existing file must already carry
+	 * the brand or dbfile_check() rejects it and we recreate it fresh.
+	 */
+	if (dbfile_config_empty(db))
+		dbfile_stamp_application_id(db);
 
 	ret = dbfile_get_config(db, &cfg);
 	if (ret) {

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -18,8 +18,21 @@ struct extent_csum;
 struct results_tree;
 struct dbfile_config;
 
-#define DB_FILE_MAJOR	4
-#define DB_FILE_MINOR	2
+/*
+ * oans's own hashfile format generation. Forked from upstream duperemove's 4.1;
+ * bumped to 5.0 as a deliberate clean break so oans and duperemove never share
+ * a version number.
+ */
+#define DB_FILE_MAJOR	5
+#define DB_FILE_MINOR	0
+
+/*
+ * SQLite application_id stamped into every oans hashfile ("oans" in ASCII).
+ * oans requires this brand: dbfile_check() refuses any hashfile that does not
+ * carry it (a foreign file, or a pre-brand/duperemove one). A brand-new empty
+ * hashfile is stamped before the check; existing files must already carry it.
+ */
+#define OANS_APP_ID	0x6f616e73
 
 struct stmts {
 	sqlite3_stmt *insert_block;

--- a/tests/integration/test_appid.py
+++ b/tests/integration/test_appid.py
@@ -1,0 +1,60 @@
+"""The hashfile is branded with a SQLite application_id ("oans") so oans owns
+its own format: it stamps its own files and strictly refuses any hashfile that
+does not carry the brand (a foreign program's, or a pre-brand/duperemove one),
+recreating it fresh.
+"""
+
+import sqlite3
+from harness import DuperemoveTest
+
+OANS_APP_ID = 0x6F616E73  # ascii "oans"
+
+
+def app_id(path):
+    # Note: sqlite3's context manager commits but does NOT close, and a lingering
+    # connection holds a WAL lock that breaks oans's unlink+recreate. Close it.
+    con = sqlite3.connect(path)
+    try:
+        return con.execute("PRAGMA application_id").fetchone()[0]
+    finally:
+        con.close()
+
+
+def set_app_id(path, value):
+    con = sqlite3.connect(path)
+    try:
+        con.execute(f"PRAGMA application_id = {value}")
+        con.commit()
+    finally:
+        con.close()
+
+
+class AppIdTest(DuperemoveTest):
+    def test_fresh_hashfile_is_branded(self):
+        self.mkrand("tree/a", 8000)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertEqual(OANS_APP_ID, app_id(self.hf), "fresh hashfile carries the oans brand")
+
+    def test_unbranded_is_refused_and_rebuilt(self):
+        # A file without the brand (application_id 0: a pre-brand oans file or a
+        # duperemove one) is strictly refused and recreated fresh.
+        self.mkrand("tree/a", 8000)
+        self.mkrand("tree/b", 8000)
+        self.scan(self.path("tree"))
+        set_app_id(self.hf, 0)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertIn("Recreating", self.out, "unbranded hashfile rebuilt")
+        self.assertEqual(OANS_APP_ID, app_id(self.hf), "recreated as an oans file")
+
+    def test_foreign_application_is_refused(self):
+        # A hashfile branded by some other program is refused and recreated.
+        self.mkrand("tree/a", 8000)
+        self.mkrand("tree/b", 8000)
+        self.scan(self.path("tree"))
+        set_app_id(self.hf, 0x12345678)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertIn("Recreating", self.out, "foreign hashfile rebuilt")
+        self.assertEqual(OANS_APP_ID, app_id(self.hf), "rebuilt as an oans file")


### PR DESCRIPTION
Gives the oans hashfile its own identity — a deliberate clean break from duperemove, so neither tool ever mis-reads the other's file.

## What
- **Bump the schema version to 5.0.** oans forked at duperemove's `4.1`; jumping to `5.0` guarantees the two never share a version number.
- **Stamp `PRAGMA application_id = 0x6f616e73` ("oans")** into every hashfile, and have `dbfile_check()` **strictly require** it. Any file without the brand — a foreign program's, or a pre-brand/duperemove one — is refused and recreated fresh (the hashfile is only a cache). A brand-new empty file is stamped *before* the check (`dbfile_config_empty()`) so a fresh scan doesn't recreate-loop.

## Strict, by choice
Pre-brand oans hashfiles are **rebuilt once** rather than upgraded in place. Chosen deliberately — the fork has no other users yet, so the one-time fallout is minimal, and the result is fully future-proof.

## Tests
`test_appid.py`: a fresh hashfile is branded at 5.0; an unbranded (`application_id 0`) file and a foreign-branded file are both refused and recreated. Build + **61 integration tests** pass. README/CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)