### PR TITLE
Compact the hashfile with a VACUUM after a from-scratch build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,12 @@ a fresh scan doesn't recreate-loop; existing files must already carry the brand.
 A failed check unlinks and recreates the hashfile (it's only a cache). Bump
 `DB_FILE_MINOR` on any schema change.
 
+A from-scratch build (new hashfile or a recreated one) sets `hashfile_rebuilt`,
+which makes `dbfile_maybe_vacuum()` force a one-off `VACUUM` at the end: a fresh
+build is at insert density (random-key `path_hash`/digest indexes fill ~2/3), so
+it lands ~15-20% smaller than the un-vacuumed size. Normal incremental runs
+still only VACUUM once ≥25% of the file is free.
+
 ## Correctness invariants
 
 - Ctrl+C is safe: `FIDEDUPERANGE` is atomic and the hashfile stays WAL-consistent

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -387,6 +387,13 @@ static int dbfile_set_modes(sqlite3 *db)
 	return ret;
 }
 
+/*
+ * Set when this run built the hashfile from scratch - a brand-new file or one
+ * recreated after a failed check. Such a file is written at insert density with
+ * no freelist, so dbfile_maybe_vacuum() forces a one-off compaction for it.
+ */
+static bool hashfile_rebuilt;
+
 static int dbfile_prepare(sqlite3 *db)
 {
 	struct dbfile_config cfg;
@@ -422,8 +429,10 @@ static int dbfile_prepare(sqlite3 *db)
 	 * strict application_id check below. An existing file must already carry
 	 * the brand or dbfile_check() rejects it and we recreate it fresh.
 	 */
-	if (dbfile_config_empty(db))
+	if (dbfile_config_empty(db)) {
 		dbfile_stamp_application_id(db);
+		hashfile_rebuilt = true;
+	}
 
 	ret = dbfile_get_config(db, &cfg);
 	if (ret) {
@@ -1021,6 +1030,10 @@ static int dbfile_pragma_uint64(sqlite3 *db, const char *pragma, uint64_t *out)
  * nothing. It only fills up after a large prune (e.g. many deleted files
  * removed from the hashfile), which is exactly when the rewrite pays off. So
  * VACUUM only when a meaningful fraction of the file is actually free.
+ *
+ * The exception is a from-scratch build (hashfile_rebuilt): it has no freelist,
+ * but its pages sit at insert density - the random-key path_hash/digest indexes
+ * fill to only ~2/3 - so a one-off VACUUM meaningfully compacts it.
  */
 #define VACUUM_FREE_PCT		25
 
@@ -1033,11 +1046,16 @@ void dbfile_maybe_vacuum(struct dbhandle *db)
 	    dbfile_pragma_uint64(db->db, "PRAGMA page_count", &total))
 		return;
 
-	if (total == 0 || freelist * 100 < total * VACUUM_FREE_PCT)
+	if (!hashfile_rebuilt &&
+	    (total == 0 || freelist * 100 < total * VACUUM_FREE_PCT))
 		return;
 
-	vprintf("Vacuuming hashfile: %"PRIu64" of %"PRIu64" pages free\n",
-		freelist, total);
+	if (hashfile_rebuilt) {
+		qprintf("Compacting the rebuilt hashfile ...\n");
+	} else {
+		vprintf("Vacuuming hashfile: %"PRIu64" of %"PRIu64" pages free\n",
+			freelist, total);
+	}
 
 	/* Maintenance only: a failure here must not fail the run. */
 	ret = sqlite3_exec(db->db, "VACUUM", NULL, NULL, NULL);

--- a/tests/integration/test_appid.py
+++ b/tests/integration/test_appid.py
@@ -5,7 +5,8 @@ recreating it fresh.
 """
 
 import sqlite3
-from harness import DuperemoveTest
+import subprocess
+from harness import DuperemoveTest, DUPEREMOVE
 
 OANS_APP_ID = 0x6F616E73  # ascii "oans"
 
@@ -58,3 +59,18 @@ class AppIdTest(DuperemoveTest):
         self.assertDmOk()
         self.assertIn("Recreating", self.out, "foreign hashfile rebuilt")
         self.assertEqual(OANS_APP_ID, app_id(self.hf), "rebuilt as an oans file")
+
+    def test_rebuild_is_compacted(self):
+        # A from-scratch build is written at insert density, so oans VACUUMs it
+        # once at the end. Run non-quiet (the message is suppressed by -q) after
+        # forcing a rebuild and check the compaction fired.
+        self.mkrand("tree/a", 8000)
+        self.scan(self.path("tree"))
+        set_app_id(self.hf, 0x12345678)  # force a rebuild on the next run
+        proc = subprocess.run(
+            [DUPEREMOVE, "-r", "--hashfile", self.hf, self.path("tree")],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        self.assertIn("Recreating", proc.stdout)
+        self.assertIn("Compacting", proc.stdout, "rebuilt hashfile is VACUUMed")
+        self.assertEqual(0, sqlite3.connect(self.hf).execute(
+            "PRAGMA freelist_count").fetchone()[0], "no free pages after compaction")


### PR DESCRIPTION
Follow-up to the auto-prune work: a rebuilt hashfile was ending larger than expected.

## Why
A freshly built hashfile — a brand-new one, or one **recreated** after a failed version/`application_id` check (e.g. the 1.1.0 format-5.0 upgrade) — is written at **insert density**. The random-key `path_hash` and digest B-tree indexes fill to only ~2/3, so the file is ~15–20% larger than needed. `dbfile_maybe_vacuum()` only fires at ≥25% freelist, which a fresh build never reaches, so that slack persisted — which is why a rebuild landed noticeably larger than the earlier prune+vacuumed file (real case: 913 MB rebuild vs 662 MB; a manual VACUUM took it to 741 MB).

## What
Set `hashfile_rebuilt` when the config table is empty at prepare time (covers both new and recreated files) and force the end-of-run VACUUM for it. Prints `Compacting the rebuilt hashfile ...`. Normal incremental runs are unchanged — still VACUUM only once ≥25% of the file is free.

## Tests
`test_rebuild_is_compacted`: after a forced rebuild, the compaction message appears and the file has zero free pages. Build + **62 integration tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)