### PR TITLE
Makefile: drop dead multi-program scaffolding, simplify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ compat symlink. Some identifiers keep the old name on purpose: the
 ## Build & test
 
 ```sh
-make -j$(nproc)                         # builds oans + helpers
+make -j$(nproc)                         # builds oans
 make check                              # C unit tests (src/tests.c) + Python integration suite
 DUPEREMOVE=./oans python3 tests/run.py           # integration suite only
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
-# Derive the version from git once (not per-compile), and stay quiet on clones
-# without tags: git describe then prints "fatal: No names found" to stderr.
-# --always makes VERSION fall back to a short hash; the release check treats a
-# missing tag as "not a release".
+# Version from git, falling back to a shipped `version` file (release tarballs
+# have no .git) and then "unknown", so the build never fails for lack of it.
 ifndef VERSION
 VERSION := $(shell git describe --abbrev=4 --dirty --always --tags 2>/dev/null)
-# Outside a git checkout (e.g. a release tarball) git prints nothing; fall back
-# to a shipped `version` file, then a placeholder, so the build never fails and
-# still reports a version (#387). `make tarball` writes the file below.
 ifeq ($(VERSION),)
 VERSION := $(shell cat version 2>/dev/null)
 endif
@@ -14,132 +9,103 @@ ifeq ($(VERSION),)
 VERSION := unknown
 endif
 endif
-ifndef IS_RELEASE
-LATEST_TAG := $(shell git describe --abbrev=0 --tags --exclude '*dev' 2>/dev/null)
-IS_RELEASE := $(if $(LATEST_TAG),$(if $(filter 0,$(shell git rev-list $(LATEST_TAG)..HEAD --count 2>/dev/null)),1,0),0)
-endif
 
 CC ?= gcc
 CFLAGS ?= -Wall -ggdb -std=gnu11 -Werror=strict-prototypes -MMD
 PKG_CONFIG ?= pkg-config
 
-MANPAGES=docs/man/oans.8
-ZSH_COMPLETION=completion/zsh/_oans
+MANPAGE    = docs/man/oans.8
+COMPLETION = completion/zsh/_oans
 
-# All C sources live under src/. tests.c is ugly: it includes lots of c files,
-# to get access to inlined code, so it is built separately (see the test rule).
-CFILES = $(filter-out src/tests.c,$(sort $(wildcard src/*.c)))
-DEPENDS := $(CFILES:.c=.d)
+# All C sources live under src/. tests.c is built on its own (the test rule):
+# it #includes other .c files to reach their static/inlined code.
+CFILES  := $(filter-out src/tests.c,$(sort $(wildcard src/*.c)))
 OBJECTS := $(CFILES:.c=.o)
-# Main program is 'oans' (compat 'duperemove' symlink added on install).
-install_progs = oans
-progs = $(install_progs)
-# The object holding each prog's main() lives at src/<prog>.o.
-PROGS_OBJECTS := $(addprefix src/,$(addsuffix .o,$(progs)))
-SHARED_OBJECTS := $(filter-out $(PROGS_OBJECTS),$(OBJECTS))
+DEPENDS := $(CFILES:.c=.d)
 
-DIST_SOURCES:=$(CFILES) $(sort $(wildcard src/*.h)) LICENSE Makefile \
-	README.md $(MANPAGES)
-DIST=oans-$(VERSION)
-DIST_TARBALL=$(VERSION).tar.gz
-TEMP_INSTALL_DIR:=$(shell mktemp -du -p .)
-
-EXTRA_CFLAGS=$(shell $(PKG_CONFIG) --cflags glib-2.0,sqlite3,blkid,mount,uuid,libbsd)
-EXTRA_LIBS=$(shell $(PKG_CONFIG) --libs glib-2.0,sqlite3,blkid,mount,uuid)
+EXTRA_CFLAGS = $(shell $(PKG_CONFIG) --cflags glib-2.0,sqlite3,blkid,mount,uuid,libbsd)
+EXTRA_LIBS   = $(shell $(PKG_CONFIG) --libs glib-2.0,sqlite3,blkid,mount,uuid)
 
 ifdef DEBUG
-	DEBUG_FLAGS = -ggdb3 -fsanitize=address -fno-omit-frame-pointer	-O0 \
-			-DDEBUG_BUILD -DSQLITE_DEBUG -DSQLITE_MEMDEBUG \
-			-DSQLITE_ENABLE_EXPLAIN_COMMENTS -fsanitize-address-use-after-scope
+	DEBUG_FLAGS = -ggdb3 -fsanitize=address -fno-omit-frame-pointer -O0 \
+		-DDEBUG_BUILD -DSQLITE_DEBUG -DSQLITE_MEMDEBUG \
+		-DSQLITE_ENABLE_EXPLAIN_COMMENTS -fsanitize-address-use-after-scope
 else
 	CFLAGS += -O2
 endif
 
-override CFLAGS += -D_FILE_OFFSET_BITS=64 -DVERSTRING=\"$(VERSION)\" \
-	$(EXTRA_CFLAGS) $(DEBUG_FLAGS) \
-	-DIS_RELEASE=$(IS_RELEASE) -D_GNU_SOURCE
+override CFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \
+	-DVERSTRING=\"$(VERSION)\" $(EXTRA_CFLAGS) $(DEBUG_FLAGS)
 LIBRARY_FLAGS += -Wl,--as-needed -latomic -lm $(EXTRA_LIBS)
 
-# make C=1 to enable sparse
+# make C=1 to check with sparse.
 ifdef C
 	CC = sparse -D__CHECKER__ -D__CHECK_ENDIAN__ -Wbitwise \
 		-Wuninitialized -Wshadow -Wundef
 endif
 
 DESTDIR ?= /
-PREFIX ?= /usr/local
-SHAREDIR = $(PREFIX)/share
-BINDIR = $(PREFIX)/bin
-MANDIR = $(SHAREDIR)/man
+PREFIX  ?= /usr/local
+BINDIR  = $(PREFIX)/bin
+MANDIR  = $(PREFIX)/share/man/man8
+ZSHDIR  = $(PREFIX)/share/zsh/site-functions
 
-all: $(progs)
-debug:
-	@echo "Deprecated, use \"make DEBUG=1\" instead please."
-
-$(MANPAGES): docs/man/%.8: docs/man/%.md
-	pandoc --standalone $< --to man -o $@
+all: oans
 
 -include $(DEPENDS)
-$(progs): $(OBJECTS)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(SHARED_OBJECTS) src/$@.o -o $@ $(LIBRARY_FLAGS)
 
+# oans is the only program: src/oans.c has main(), the rest is its library.
+oans: $(OBJECTS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBRARY_FLAGS)
+
+# C unit tests: tests.c pulls in the other .c files, so build it standalone.
 .PHONY: test
 test:
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) src/tests.c -o $@ $(LIBRARY_FLAGS)
 	./test
 
-# End-to-end tests: drive the built binary against a scratch tree and assert on
-# the hashfile and on-disk sharing (Python stdlib unittest, no extra deps).
-# Needs a reflink-capable scratch fs for the dedupe cases (override with
-# DUPEREMOVE_TEST_DIR=/path on e.g. btrfs/xfs).
+# End-to-end suite (Python stdlib unittest). Dedupe cases need a reflink fs;
+# override the scratch dir with DUPEREMOVE_TEST_DIR=/path.
 .PHONY: integration
 integration: oans
 	DUPEREMOVE=./oans python3 tests/run.py
 
-# Everything: unit tests plus the integration suite.
 .PHONY: check
 check: test integration
 
-install: $(install_progs) $(MANPAGES) $(ZSH_COMPLETION)
-	mkdir -p -m 0755 $(DESTDIR)$(BINDIR)
-	for prog in $(install_progs); do \
-		install -m 0755 $$prog $(DESTDIR)$(BINDIR); \
-	done
-	# Backward-compatible 'duperemove' name pointing at 'oans'.
+# Install oans plus a backward-compatible 'duperemove' symlink, the man page,
+# and the zsh completion. `install -D` creates the target directories.
+install: oans $(MANPAGE) $(COMPLETION)
+	install -D -m 0755 oans $(DESTDIR)$(BINDIR)/oans
 	ln -sf oans $(DESTDIR)$(BINDIR)/duperemove
-	mkdir -p -m 0755 $(DESTDIR)$(MANDIR)/man8
-	for man in $(MANPAGES); do \
-		install -m 0644 $$man $(DESTDIR)$(MANDIR)/man8; \
-	done
-	ln -sf oans.8 $(DESTDIR)$(MANDIR)/man8/duperemove.8
-	mkdir -p -m 0755 $(DESTDIR)$(SHAREDIR)/zsh/site-functions
-	for completion in $(ZSH_COMPLETION); do \
-		install -m 0644 $$completion $(DESTDIR)$(SHAREDIR)/zsh/site-functions; \
-	done
+	install -D -m 0644 $(MANPAGE) $(DESTDIR)$(MANDIR)/oans.8
+	ln -sf oans.8 $(DESTDIR)$(MANDIR)/duperemove.8
+	install -D -m 0644 $(COMPLETION) $(DESTDIR)$(ZSHDIR)/_oans
 
 uninstall:
-	rm -f $(DESTDIR)$(BINDIR)/duperemove
-	for prog in $(install_progs); do \
-		rm -f $(DESTDIR)$(BINDIR)/$$prog; \
-	done
-	rm -f $(DESTDIR)$(MANDIR)/man8/duperemove.8
-	for man in $(MANPAGES); do \
-		rm -f $(DESTDIR)$(MANDIR)/man8/$${man##*/}; \
-	done
-	for completion in $(ZSH_COMPLETION); do \
-		rm -f $(DESTDIR)$(SHAREDIR)/zsh/site-functions/$${completion##*/}; \
-	done
+	rm -f $(DESTDIR)$(BINDIR)/oans $(DESTDIR)$(BINDIR)/duperemove
+	rm -f $(DESTDIR)$(MANDIR)/oans.8 $(DESTDIR)$(MANDIR)/duperemove.8
+	rm -f $(DESTDIR)$(ZSHDIR)/_oans
 
+# The man page is committed, so building and installing never need pandoc;
+# `make doc` regenerates it from the markdown source (for maintainers).
+.PHONY: doc
+doc:
+	pandoc --standalone docs/man/oans.md --to man -o $(MANPAGE)
+
+DIST         = oans-$(VERSION)
+DIST_TARBALL = $(VERSION).tar.gz
+DIST_SOURCES = $(CFILES) $(sort $(wildcard src/*.h)) LICENSE Makefile \
+	README.md $(MANPAGE)
+
+# Source tarball with the resolved version embedded, so tarball builds (no
+# .git) still report it.
 tarball: clean $(DIST_SOURCES)
-	mkdir -p $(TEMP_INSTALL_DIR)/$(DIST)
-	cp $(DIST_SOURCES) $(TEMP_INSTALL_DIR)/$(DIST)
-	# Embed the resolved version so builds from the tarball (no .git) report
-	# it instead of falling back to "unknown" (#387).
-	echo '$(VERSION)' > $(TEMP_INSTALL_DIR)/$(DIST)/version
-	tar -C $(TEMP_INSTALL_DIR) -zcf $(DIST_TARBALL) $(DIST)
-	rm -fr $(TEMP_INSTALL_DIR)
+	tmp=$$(mktemp -d) && mkdir -p "$$tmp/$(DIST)" && \
+	cp $(DIST_SOURCES) "$$tmp/$(DIST)" && \
+	echo '$(VERSION)' > "$$tmp/$(DIST)/version" && \
+	tar -C "$$tmp" -zcf $(DIST_TARBALL) $(DIST) && \
+	rm -fr "$$tmp"
 
 clean:
-	rm -fr $(OBJECTS) $(progs) $(DIST_TARBALL) $(DEPENDS) *~
-
-doc: $(MANPAGES)
+	rm -f $(OBJECTS) $(DEPENDS) oans test $(DIST_TARBALL) *~


### PR DESCRIPTION
Now that oans is the only binary (the `hashstats`/`csum-test`/`btrfs-extent-same` tools were removed and folded into `oans --stats`), the Makefile still carried scaffolding for building several programs. This trims it to fit the single-binary reality.

## Changes
- **Remove multi-program machinery**: `install_progs`/`progs`/`PROGS_OBJECTS`/`SHARED_OBJECTS` and the per-prog link split. `oans` now links all objects directly (`src/oans.c` holds the only `main()`).
- **Collapse single-element loops**: the `for prog`/`for man`/`for completion` loops (each iterated over one item) become plain `install`/`rm`. Using `install -D` removes the `mkdir -p` lines.
- **Delete dead `IS_RELEASE`/`LATEST_TAG`**: nothing in the code references `IS_RELEASE` — the whole derivation and `-DIS_RELEASE=` define were dead since the fork.
- **Drop the deprecated `debug:` echo stub.**
- **Committed man page is authoritative**: build and install no longer invoke pandoc; only `make doc` regenerates `docs/man/oans.8` from its markdown. This keeps `make install` working on boxes without pandoc.
- **Fix stale CLAUDE.md comment** (`oans + helpers` → `oans`).

Net −34 lines, no behavior change to the build output.

## Verification
- `make clean && make -j4` — clean build, version string embedded.
- `make -n install` — tidy one-liners, correct paths + `duperemove` symlinks.
- `make check` — Ran 64 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)