### PR TITLE
build: harden release flags, enable -Wextra, drop dead defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ endif
 endif
 
 CC ?= gcc
-CFLAGS ?= -Wall -ggdb -std=gnu11 -Werror=strict-prototypes -MMD
+CFLAGS ?= -Wall -Wextra -Wno-unused-parameter -ggdb -std=gnu11 \
+	-Werror=strict-prototypes -MMD
 PKG_CONFIG ?= pkg-config
 
 MANPAGE    = docs/man/oans.8
@@ -27,11 +28,15 @@ EXTRA_CFLAGS = $(shell $(PKG_CONFIG) --cflags glib-2.0,sqlite3,blkid,mount,uuid,
 EXTRA_LIBS   = $(shell $(PKG_CONFIG) --libs glib-2.0,sqlite3,blkid,mount,uuid)
 
 ifdef DEBUG
+	# We link the system libsqlite3, so SQLITE_* build defines don't apply here.
 	DEBUG_FLAGS = -ggdb3 -fsanitize=address -fno-omit-frame-pointer -O0 \
-		-DDEBUG_BUILD -DSQLITE_DEBUG -DSQLITE_MEMDEBUG \
-		-DSQLITE_ENABLE_EXPLAIN_COMMENTS -fsanitize-address-use-after-scope
+		-DDEBUG_BUILD -fsanitize-address-use-after-scope
 else
-	CFLAGS += -O2
+	# Release hardening (needs optimization, hence not in the debug build).
+	# Override with HARDENING= to disable.
+	HARDENING ?= -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection
+	CFLAGS += -O2 $(HARDENING)
+	LIBRARY_FLAGS += -Wl,-z,relro -Wl,-z,now
 endif
 
 override CFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1678,10 +1678,15 @@ int add_exclude_pattern(const char *pattern)
 	if (pattern[0] == '/') {
 		exclude->pattern = strdup(pattern);
 	} else {
-		getcwd(cwd, PATH_MAX);
+		if (!getcwd(cwd, PATH_MAX)) {
+			eprintf("Error: cannot read cwd for pattern %s\n", pattern);
+			free(exclude);
+			return 1;
+		}
 
 		if (strlen(cwd) + strlen(pattern) > PATH_MAX) {
 			eprintf("Error: cannot prepend cwd to %s\n", pattern);
+			free(exclude);
 			return 1;
 		}
 

--- a/src/list_sort.c
+++ b/src/list_sort.c
@@ -139,7 +139,7 @@ void list_sort(void *priv, struct list_head *head,
 			part[lev] = NULL;
 		}
 		if (lev > max_lev) {
-			if (unlikely(lev >= ARRAY_SIZE(part)-1)) {
+			if (unlikely((size_t)lev >= ARRAY_SIZE(part)-1)) {
 				printk_once(KERN_DEBUG "list too long for efficiency\n");
 				lev--;
 			}


### PR DESCRIPTION
Follow-up to the compile-flag review. Three flag changes plus the two real bugs `-Wextra` and `_FORTIFY_SOURCE` surfaced.

## Flags
- **`-Wextra` (with `-Wno-unused-parameter`).** Only the unused-parameter noise (benign callback signatures) is suppressed; everything else stays on. Build is now warning-clean.
- **Release hardening** (release build only — it needs optimization, so it's *not* in the `-O0` ASan debug build): `-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection` plus `-Wl,-z,relro -Wl,-z,now`. This is what distros inject anyway; now hand-builds get it too. Override with `HARDENING=` to disable. Verified in the binary: `BIND_NOW`, full `GNU_RELRO`, stack canaries, and fortified libc calls.
- **Drop dead `SQLITE_*` defines.** The debug build passed `-DSQLITE_DEBUG -DSQLITE_MEMDEBUG -DSQLITE_ENABLE_EXPLAIN_COMMENTS`, but we link the **system `libsqlite3`** (no amalgamation in the tree), so they only affect compiling `sqlite3.c` and did nothing here.

## Bugs the flags caught
- **`file_scan.c` `add_exclude_pattern()`** — `getcwd()`'s return value was ignored (`_FORTIFY_SOURCE` flagged it). On failure `cwd` stays uninitialized and `strlen(cwd)` reads garbage. Now checked; also `free(exclude)` on the error paths (the pre-existing `PATH_MAX` error path leaked it too).
- **`list_sort.c`** — signed/unsigned comparison (`-Wextra`) of the non-negative level counter against `ARRAY_SIZE()`; made the `(size_t)` cast explicit.

## Verification
- `make` — **zero warnings**, hardening confirmed in the ELF; `make HARDENING=` cleanly disables it.
- `make check` — Ran 64 tests, OK.
- `valgrind` (scan with relative `--exclude`, exercising the `getcwd` path) — 0 errors, 0 leaks, only the 2 known GLib-TLS suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)