### PR TITLE
scan: statx relative to the open dir fd (less per-file kernel work)

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -830,7 +830,14 @@ static void process_dir(const char *path, struct dbhandle *db)
 
 		strcpy(child + dirlen, entry->d_name);
 
-		if (statx(0, child, 0, STATX_BASIC_STATS, &st) ||
+		/*
+		 * Stat relative to the open directory fd, not via the absolute
+		 * `child` path: the kernel then resolves only the single leaf
+		 * name instead of walking every path component from / on each
+		 * file (link_path_walk dominated the warm-rescan profile). We
+		 * still build `child` for the DB (paths are stored absolute).
+		 */
+		if (statx(dirfd(dirp), entry->d_name, 0, STATX_BASIC_STATS, &st) ||
 		    !(st.stx_mask & STATX_BASIC_STATS)) {
 			eprintf("Failed to stat %s: %s\n", child, strerror(errno));
 			continue;


### PR DESCRIPTION
## What

The parallel directory walker stat's every entry with its **absolute path** (`statx(0, child, …)`). That forces the kernel to re-resolve every path component from `/` on each file (`link_path_walk` / `filename_lookup`), which was the single largest slice of a warm-rescan `perf` profile.

The walker already holds the directory fd from `opendir()`. This stats relative to `dirfd(dirp)` with the bare leaf name, so the kernel resolves only that one component — exactly what `get_dirent_type()` one function above already does. `child` is still built because the hashfile stores absolute paths.

## Impact (measured, btrfs, 174k-file `~/git`, warm)

- **~5–8% less total scan CPU** (`perf stat task-clock`: ~850ms → ~790ms).
- **Wall-clock unchanged** (~2.02s). On this workload the walk is *not* the wall-clock bottleneck — the single-consumer change-detection pipeline is — and it's fully parallel across walker threads, so reducing its CPU doesn't move the headline number. This is strictly less kernel work per file (energy/heat/contention), not a critical-path win. I'm not overselling it.

No behavior change: the resulting `statx` is identical (same file, same follow-symlink semantics; `child` still used for the DB and error messages).

## Verification

- 6/6 unit, 64/64 integration, valgrind clean (0 errors / 0 lost).
- No-op rescan still nets 0 changes with identical row counts.
- 0 warnings under `-Wextra`.

## Investigation notes (why this is the change, and what was rejected)

I profiled first (per `CLAUDE.md`) and checked the previously-deferred candidates:

- **`is_area_ignored` O(extents²)** and **`clean_deduped` O(n²)** — *not hot* on realistic warm rescans. Block hashing is off by default, and on an already-deduped tree files are skipped, so neither runs meaningfully. Not worth touching.
- **Bulk in-memory change-detection** (replace the per-file `dbfile_describe_file` SQLite query with a hashtable preloaded from the `files` table) — prototyped and **measured a regression** (2.02s → 3.09s). The per-file query is only ~0.12s of CPU, not the bottleneck; the 2.0s warm rescan is pipeline-latency-bound through the single consumer (~11.6µs/file: statx + queue handoff + bookkeeping). Bulk-loading just added ~1s of upfront allocation. Rejected.

The remaining real lever — the single-consumer pipeline latency — is inherent to the mandated single-consumer DB design and would be a larger, riskier redesign, not a safe drop-in. Flagging it here rather than forcing it.