### PR TITLE
Self-describing hashfile: replay a run from the hashfile alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ and filesystem.
 - A **human-readable, colorful summary** (respecting `NO_COLOR` and non-TTY
   output) instead of a wall of per-extent text.
 - A **live dedupe progress bar** with throughput rate and ETA.
+- A **self-describing hashfile**: each run records its options, paths and
+  excludes, so `oans --hashfile=FILE` with no arguments replays the last run —
+  a cron job need only name the hashfile. If the stored paths have all vanished
+  (e.g. an unmounted drive) it refuses rather than pruning the hashfile.
 
 ### Testing
 
@@ -148,6 +152,9 @@ oans -dhr file1 file2 dir1/
 
 # Recursively dedupe a tree, reusing a hashfile across runs:
 oans -dr --hashfile=/path/to/hashfile /my/data
+
+# Replay that run later — the hashfile remembers the options and paths:
+oans --hashfile=/path/to/hashfile
 
 # Report what a hashfile holds (files, hashes, duplication):
 oans --stats --hashfile=/path/to/hashfile

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -169,10 +169,12 @@ Will print additional information about each file when run with
 \f[CR]\-v\f[R].
 .TP
 \f[B]\-\-stats\f[R]
-Print a summary of the hashfile and exit: its format and identity, how
-many files and hashes it holds, the total logical data tracked, and how
-much whole\-file duplication it records (duplicate groups and
-reclaimable bytes).
+Print a summary of the hashfile and exit: its format and identity, the
+stored scan configuration if any (the options, paths and excludes a bare
+\f[CR]oans \-\-hashfile=FILE\f[R] would replay), how many files and
+hashes it holds, the total logical data tracked, and how much
+whole\-file duplication it records (duplicate groups and reclaimable
+bytes).
 Requires the \f[CR]\-\-hashfile\f[R] option.
 (Replaces the standalone \f[CR]hashstats\f[R] tool.)
 .TP

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -27,6 +27,16 @@ Thus you can run \f[CR]oans\f[R] repeatedly on your data as it changes,
 without having to re\-checksum unchanged data.
 For more on hashfiles see the \f[CR]\-\-hashfile\f[R] option below as
 well as the \f[CR]Examples\f[R] section.
+.PP
+The hashfile is also \f[B]self\-describing\f[R]: each run records its
+scan\-shaping options (\f[CR]\-d\f[R], \f[CR]\-r\f[R],
+\f[CR]\-\-skip\-zeroes\f[R], \f[CR]\-\-min\-filesize\f[R],
+\f[CR]\-\-dedupe\-options\f[R]), its paths, and its
+\f[CR]\-\-exclude\f[R] patterns.
+Running \f[CR]oans \-\-hashfile=FILE\f[R] with no file arguments replays
+that stored configuration, so a periodic job only needs to name the
+hashfile.
+See the \f[CR]Examples\f[R] section.
 .SH GENERAL
 oans has two major modes of operation, one of which is a subset of the
 other.
@@ -93,6 +103,15 @@ For that reason you probably want to provide the same \f[CR]files\f[R]
 list and \f[CR]\-r\f[R] arguments on each run of \f[CR]oans\f[R].
 The file discovery algorithm is efficient and will only visit each file
 once, even if it is already in the \f[CR]hashfile\f[R].
+.PP
+You need not repeat them, though: each run records its scan\-shaping
+options, paths and \f[CR]\-\-exclude\f[R] patterns in the hashfile, so
+running \f[CR]oans \-\-hashfile=FILE\f[R] with no file arguments replays
+the last such run (any other options given on that command line are
+ignored).
+If none of the stored paths still exist, oans refuses to run rather than
+prune every entry (guarding against, for example, an unmounted drive);
+paths that are individually missing are skipped with a warning.
 .PP
 Adding a new path to a hashfile is as simple as adding it to the
 \f[CR]files\f[R] argument.
@@ -265,15 +284,16 @@ dedupe changed or newly added files:
 oans \-dr \-\-hashfile=foo.hash foo/
 .EE
 .PP
-Don\[cq]t scan for new files, only update changed or deleted files, then
-dedupe:
+Replay the last run: with no file arguments, oans reuses the options,
+paths and excludes saved in the hashfile.
+Handy for a cron job, which then only needs to name the hashfile:
 .IP
 .EX
-oans \-dr \-\-hashfile=foo.hash
+oans \-\-hashfile=foo.hash
 .EE
 .PP
 Add directory bar to our hashfile and discover any files that were
-recently added to foo:
+recently added to foo (this also becomes the new stored configuration):
 .IP
 .EX
 oans \-dr \-\-hashfile=foo.hash foo/ bar/

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -157,10 +157,12 @@ variable is set.
 Will print additional information about each file when run with `-v`.
 
 **\--stats**
-  ~ Print a summary of the hashfile and exit: its format and identity, how many
-files and hashes it holds, the total logical data tracked, and how much
-whole-file duplication it records (duplicate groups and reclaimable bytes).
-Requires the `--hashfile` option. (Replaces the standalone `hashstats` tool.)
+  ~ Print a summary of the hashfile and exit: its format and identity, the
+stored scan configuration if any (the options, paths and excludes a bare
+`oans --hashfile=FILE` would replay), how many files and hashes it holds, the
+total logical data tracked, and how much whole-file duplication it records
+(duplicate groups and reclaimable bytes). Requires the `--hashfile` option.
+(Replaces the standalone `hashstats` tool.)
 
 **-R** `files ..`
   ~ Remove file from the db and exit. oans will read the list from

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -29,6 +29,12 @@ for those files which have changed since the last run. Thus you can run
 re-checksum unchanged data. For more on hashfiles see the
 `--hashfile` option below as well as the `Examples` section.
 
+The hashfile is also **self-describing**: each run records its scan-shaping
+options (`-d`, `-r`, `--skip-zeroes`, `--min-filesize`, `--dedupe-options`),
+its paths, and its `--exclude` patterns. Running `oans --hashfile=FILE` with
+no file arguments replays that stored configuration, so a periodic job only
+needs to name the hashfile. See the `Examples` section.
+
 # GENERAL
 oans has two major modes of operation, one of which is a subset
 of the other.
@@ -92,6 +98,14 @@ the `files` argument. For that reason you probably want to provide the
 same `files` list and `-r` arguments on each run of
 `oans`.  The file discovery algorithm is efficient and will only
 visit each file once, even if it is already in the `hashfile`.
+
+    You need not repeat them, though: each run records its scan-shaping
+options, paths and `--exclude` patterns in the hashfile, so running
+`oans --hashfile=FILE` with no file arguments replays the last such run
+(any other options given on that command line are ignored). If none of the
+stored paths still exist, oans refuses to run rather than prune every entry
+(guarding against, for example, an unmounted drive); paths that are
+individually missing are skipped with a warning.
 
     Adding a new path to a hashfile is as simple as adding it to the `files`
 argument.
@@ -236,12 +250,14 @@ dedupe changed or newly added files:
 
 	oans -dr --hashfile=foo.hash foo/
 
-Don't scan for new files, only update changed or deleted files, then dedupe:
+Replay the last run: with no file arguments, oans reuses the options,
+paths and excludes saved in the hashfile. Handy for a cron job, which then
+only needs to name the hashfile:
 
-	oans -dr --hashfile=foo.hash
+	oans --hashfile=foo.hash
 
 Add directory bar to our hashfile and discover any files that were
-recently added to foo:
+recently added to foo (this also becomes the new stored configuration):
 
 	oans -dr --hashfile=foo.hash foo/ bar/
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# verify.sh - one-shot pre-PR gate. Runs, and stops at the first failure:
+#
+#   1. build (make -j) - any compiler warning is treated as a failure
+#   2. C unit tests           (make test)
+#   3. Python integration suite
+#   4. a valgrind scan + dedupe + bare-replay smoke
+#
+# Exits non-zero on the first failure, zero when everything passes.
+#
+# Honors the usual environment knobs (nothing repo-specific is baked in):
+#   PKG_CONFIG_PATH      extra pkg-config search path (e.g. a local dev shim)
+#   DUPEREMOVE_TEST_DIR  scratch dir for the integration suite and the valgrind
+#                        smoke; dedupe needs a reflink fs (btrfs/xfs). Defaults
+#                        to the harness default (.itest-scratch next to the repo).
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+step() { printf '\n=== %s ===\n' "$1"; }
+
+step "build (make -j, warnings are failures)"
+out=$(make -j"$(nproc)" 2>&1) || { echo "$out"; exit 1; }
+echo "$out"
+if echo "$out" | grep -iEq 'warning:|error:'; then
+	echo "verify: build produced warnings/errors" >&2
+	exit 1
+fi
+
+step "unit + integration tests (make check)"
+make check
+
+step "valgrind smoke (scan + dedupe + bare replay)"
+if ! command -v valgrind >/dev/null 2>&1; then
+	echo "valgrind not installed - skipping smoke"
+else
+	scratch=$(mktemp -d "${DUPEREMOVE_TEST_DIR:-${TMPDIR:-/tmp}}/verify-smoke.XXXXXX")
+	trap 'rm -rf "$scratch"' EXIT
+	head -c 1048576 /dev/urandom > "$scratch/a"
+	cp "$scratch/a" "$scratch/b"		# a real duplicate for dedupe to act on
+	hf="$scratch/hf.db"
+	vg() {
+		valgrind -q --leak-check=full --error-exitcode=42 \
+			--suppressions=tests/valgrind.supp "$@"
+	}
+	vg ./oans -rd --hashfile="$hf" "$scratch" >/dev/null
+	vg ./oans --hashfile="$hf" >/dev/null	# bare replay of the stored config
+	echo "ok"
+fi
+
+printf '\nALL CHECKS PASSED\n'

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -252,6 +252,23 @@ static int create_tables(sqlite3 *db)
 "UNIQUE(fileid, loff) "							\
 "FOREIGN KEY(fileid) REFERENCES files(id) ON DELETE CASCADE);"
 	ret = sqlite3_exec(db, CREATE_TABLE_BLOCKS, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
+	/*
+	 * Self-describing hashfile: the roots and exclude patterns of the last
+	 * run (see dbfile_store_scan_config). One column, ordered by insertion
+	 * rowid so replay preserves argument order.
+	 */
+#define CREATE_TABLE_SCAN_ROOTS						\
+"CREATE TABLE IF NOT EXISTS scan_roots(path TEXT NOT NULL);"
+	ret = sqlite3_exec(db, CREATE_TABLE_SCAN_ROOTS, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
+#define CREATE_TABLE_SCAN_EXCLUDES					\
+"CREATE TABLE IF NOT EXISTS scan_excludes(pattern TEXT NOT NULL);"
+	ret = sqlite3_exec(db, CREATE_TABLE_SCAN_EXCLUDES, NULL, NULL, NULL);
 
 out:
 	if (ret)
@@ -902,6 +919,195 @@ int dbfile_sync_config(struct dbhandle *db, struct dbfile_config *cfg)
 	return __dbfile_sync_config(db->db, cfg);
 }
 
+static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val);
+static int get_config_int64(sqlite3_stmt *stmt, const char *name, int64_t *val);
+
+/* insert-or-replace one integer config key; leaves stmt reset for reuse. */
+static int put_config_int(sqlite3_stmt *stmt, const char *key, int64_t val)
+{
+	int ret;
+
+	sqlite3_reset(stmt);
+	ret = sqlite3_bind_text(stmt, 1, key, -1, SQLITE_STATIC);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 2, val);
+	if (!ret && sqlite3_step(stmt) != SQLITE_DONE)
+		ret = -1;
+	return ret;
+}
+
+/* Delete every row of `table`, then insert each of `n` strings in order. */
+static int replace_string_rows(sqlite3 *db, const char *insert_sql,
+			       const char *delete_sql, char **vals, int n)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int ret, i;
+
+	ret = sqlite3_exec(db, delete_sql, NULL, NULL, NULL);
+	if (ret)
+		return ret;
+
+	ret = sqlite3_prepare_v2(db, insert_sql, -1, &stmt, NULL);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < n; i++) {
+		sqlite3_reset(stmt);
+		ret = sqlite3_bind_text(stmt, 1, vals[i], -1, SQLITE_STATIC);
+		if (!ret && sqlite3_step(stmt) != SQLITE_DONE)
+			ret = -1;
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+
+int dbfile_store_scan_config(struct dbhandle *dbh, const struct scan_config *sc)
+{
+	sqlite3 *db = dbh->db;
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int ret;
+
+	ret = sqlite3_exec(db, "begin transaction", NULL, NULL, NULL);
+	if (ret)
+		return ret;
+
+	ret = sqlite3_prepare_v2(db,
+		"insert or replace into config values (?1, ?2)", -1, &stmt, NULL);
+	if (ret)
+		goto err;
+
+	/* A marker row lets load distinguish "stored" from "never stored". */
+	if ((ret = put_config_int(stmt, "scan_config", 1)) ||
+	    (ret = put_config_int(stmt, "opt_run_dedupe", sc->run_dedupe)) ||
+	    (ret = put_config_int(stmt, "opt_recurse", sc->recurse)) ||
+	    (ret = put_config_int(stmt, "opt_skip_zeroes", sc->skip_zeroes)) ||
+	    (ret = put_config_int(stmt, "opt_only_whole_files", sc->only_whole_files)) ||
+	    (ret = put_config_int(stmt, "opt_do_block_hash", sc->do_block_hash)) ||
+	    (ret = put_config_int(stmt, "opt_dedupe_same_file", sc->dedupe_same_file)) ||
+	    (ret = put_config_int(stmt, "opt_min_filesize", (int64_t)sc->min_filesize)))
+		goto err;
+
+	ret = replace_string_rows(db,
+		"insert into scan_roots(path) values (?1)",
+		"delete from scan_roots", sc->roots, sc->nroots);
+	if (ret)
+		goto err;
+
+	ret = replace_string_rows(db,
+		"insert into scan_excludes(pattern) values (?1)",
+		"delete from scan_excludes", sc->excludes, sc->nexcludes);
+	if (ret)
+		goto err;
+
+	ret = sqlite3_exec(db, "commit transaction", NULL, NULL, NULL);
+	if (ret)
+		goto err;
+	return 0;
+
+err:
+	perror_sqlite(ret, "storing scan config");
+	sqlite3_exec(db, "rollback transaction", NULL, NULL, NULL);
+	return ret ? ret : -1;
+}
+
+/* Read all rows of a single-TEXT-column table into a malloc'd char* array. */
+static int load_string_rows(sqlite3 *db, const char *sql,
+			    char ***out, int *nout)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	char **arr = NULL;
+	int n = 0, cap = 0, ret;
+
+	*out = NULL;
+	*nout = 0;
+
+	ret = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+	if (ret)
+		return ret;
+
+	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
+		const unsigned char *txt = sqlite3_column_text(stmt, 0);
+
+		if (n == cap) {
+			cap = cap ? cap * 2 : 8;
+			arr = realloc(arr, cap * sizeof(*arr));
+			abort_on(!arr);
+		}
+		arr[n++] = strdup(txt ? (const char *)txt : "");
+	}
+	if (ret != SQLITE_DONE) {
+		for (int i = 0; i < n; i++)
+			free(arr[i]);
+		free(arr);
+		return ret;
+	}
+
+	*out = arr;
+	*nout = n;
+	return 0;
+}
+
+int dbfile_load_scan_config(struct dbhandle *dbh, struct scan_config *sc)
+{
+	sqlite3 *db = dbh->db;
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int present = 0, ret;
+
+	memset(sc, 0, sizeof(*sc));
+
+#define SELECT_CONFIG "select keyval from config where keyname=?1;"
+	ret = sqlite3_prepare_v2(db, SELECT_CONFIG, -1, &stmt, NULL);
+	if (ret)
+		return ret;
+
+	ret = get_config_int(stmt, "scan_config", &present);
+	if (ret)
+		return ret;
+	if (!present)
+		return 0;	/* no stored configuration */
+
+	get_config_int(stmt, "opt_run_dedupe", &sc->run_dedupe);
+	get_config_int(stmt, "opt_recurse", &sc->recurse);
+	get_config_int(stmt, "opt_skip_zeroes", &sc->skip_zeroes);
+	get_config_int(stmt, "opt_only_whole_files", &sc->only_whole_files);
+	get_config_int(stmt, "opt_do_block_hash", &sc->do_block_hash);
+	get_config_int(stmt, "opt_dedupe_same_file", &sc->dedupe_same_file);
+	{
+		int64_t mfs = 0;
+
+		ret = get_config_int64(stmt, "opt_min_filesize", &mfs);
+		if (ret)
+			return ret;
+		sc->min_filesize = (uint64_t)mfs;
+	}
+
+	ret = load_string_rows(db, "select path from scan_roots order by rowid;",
+			       &sc->roots, &sc->nroots);
+	if (ret)
+		return ret;
+	ret = load_string_rows(db,
+			       "select pattern from scan_excludes order by rowid;",
+			       &sc->excludes, &sc->nexcludes);
+	if (ret)
+		return ret;
+
+	return 1;
+}
+
+void scan_config_free(struct scan_config *sc)
+{
+	int i;
+
+	for (i = 0; i < sc->nroots; i++)
+		free(sc->roots[i]);
+	free(sc->roots);
+	for (i = 0; i < sc->nexcludes; i++)
+		free(sc->excludes[i]);
+	free(sc->excludes);
+	memset(sc, 0, sizeof(*sc));
+}
+
 static int __dbfile_count_rows(sqlite3_stmt *s, uint64_t *num)
 {
 	int ret;
@@ -997,6 +1203,31 @@ static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val)
 
 	sqlite3_reset(stmt);
 
+	return 0;
+}
+
+static int get_config_int64(sqlite3_stmt *stmt, const char *name, int64_t *val)
+{
+	int ret;
+
+	if (!val)
+		return 0;
+
+	ret = sqlite3_bind_text(stmt, 1, name, -1, SQLITE_STATIC);
+	if (ret) {
+		perror_sqlite(ret, "retrieving row from config table (bind)");
+		return ret;
+	}
+
+	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW)
+		*val = sqlite3_column_int64(stmt, 0);
+
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "retrieving row from config table (step)");
+		return ret;
+	}
+
+	sqlite3_reset(stmt);
 	return 0;
 }
 

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -843,14 +843,14 @@ out:
 	return ret;
 }
 
-static int sync_config_int(sqlite3_stmt *stmt, const char *key, int val)
+static int sync_config_int(sqlite3_stmt *stmt, const char *key, int64_t val)
 {
 	int ret;
 
 	ret = sqlite3_bind_text(stmt, 1, key, -1, SQLITE_STATIC);
 	if (ret)
 		goto out;
-	ret = sqlite3_bind_int(stmt, 2, val);
+	ret = sqlite3_bind_int64(stmt, 2, val);
 	if (ret)
 		goto out;
 	ret = sqlite3_step(stmt);
@@ -921,20 +921,7 @@ int dbfile_sync_config(struct dbhandle *db, struct dbfile_config *cfg)
 
 static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val);
 static int get_config_int64(sqlite3_stmt *stmt, const char *name, int64_t *val);
-
-/* insert-or-replace one integer config key; leaves stmt reset for reuse. */
-static int put_config_int(sqlite3_stmt *stmt, const char *key, int64_t val)
-{
-	int ret;
-
-	sqlite3_reset(stmt);
-	ret = sqlite3_bind_text(stmt, 1, key, -1, SQLITE_STATIC);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 2, val);
-	if (!ret && sqlite3_step(stmt) != SQLITE_DONE)
-		ret = -1;
-	return ret;
-}
+static int sync_config_int(sqlite3_stmt *stmt, const char *key, int64_t val);
 
 /* Delete every row of `table`, then insert each of `n` strings in order. */
 static int replace_string_rows(sqlite3 *db, const char *insert_sql,
@@ -978,14 +965,14 @@ int dbfile_store_scan_config(struct dbhandle *dbh, const struct scan_config *sc)
 		goto err;
 
 	/* A marker row lets load distinguish "stored" from "never stored". */
-	if ((ret = put_config_int(stmt, "scan_config", 1)) ||
-	    (ret = put_config_int(stmt, "opt_run_dedupe", sc->run_dedupe)) ||
-	    (ret = put_config_int(stmt, "opt_recurse", sc->recurse)) ||
-	    (ret = put_config_int(stmt, "opt_skip_zeroes", sc->skip_zeroes)) ||
-	    (ret = put_config_int(stmt, "opt_only_whole_files", sc->only_whole_files)) ||
-	    (ret = put_config_int(stmt, "opt_do_block_hash", sc->do_block_hash)) ||
-	    (ret = put_config_int(stmt, "opt_dedupe_same_file", sc->dedupe_same_file)) ||
-	    (ret = put_config_int(stmt, "opt_min_filesize", (int64_t)sc->min_filesize)))
+	if ((ret = sync_config_int(stmt, "scan_config", 1)) ||
+	    (ret = sync_config_int(stmt, "opt_run_dedupe", sc->run_dedupe)) ||
+	    (ret = sync_config_int(stmt, "opt_recurse", sc->recurse)) ||
+	    (ret = sync_config_int(stmt, "opt_skip_zeroes", sc->skip_zeroes)) ||
+	    (ret = sync_config_int(stmt, "opt_only_whole_files", sc->only_whole_files)) ||
+	    (ret = sync_config_int(stmt, "opt_do_block_hash", sc->do_block_hash)) ||
+	    (ret = sync_config_int(stmt, "opt_dedupe_same_file", sc->dedupe_same_file)) ||
+	    (ret = sync_config_int(stmt, "opt_min_filesize", (int64_t)sc->min_filesize)))
 		goto err;
 
 	ret = replace_string_rows(db,
@@ -1181,29 +1168,12 @@ void dbfile_maybe_vacuum(struct dbhandle *db)
 
 static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val)
 {
-	int ret;
+	int64_t v = val ? *val : 0;	/* preserve caller's default if no row */
+	int ret = get_config_int64(stmt, name, val ? &v : NULL);
 
-	if (!val)
-		return 0;
-
-	ret = sqlite3_bind_text(stmt, 1, name, -1, SQLITE_STATIC);
-	if (ret) {
-		perror_sqlite(ret, "retrieving row from config table (bind)");
-		return ret;
-	}
-
-	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		*val = sqlite3_column_int(stmt, 0);
-	}
-
-	if (ret != SQLITE_DONE) {
-		perror_sqlite(ret, "retrieving row from config table (step)");
-		return ret;
-	}
-
-	sqlite3_reset(stmt);
-
-	return 0;
+	if (val)
+		*val = (int)v;
+	return ret;
 }
 
 static int get_config_int64(sqlite3_stmt *stmt, const char *name, int64_t *val)

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -100,6 +100,37 @@ int dbfile_get_config(sqlite3 *db, struct dbfile_config *cfg);
 int __dbfile_sync_config(sqlite3 *db, struct dbfile_config *cfg);
 int dbfile_sync_config(struct dbhandle *db, struct dbfile_config *cfg);
 
+/*
+ * Self-describing hashfile: the scan-shaping options plus the roots and
+ * user exclude patterns of a run, so `oans --hashfile=X` (no file arguments)
+ * can replay the last run. Ephemeral knobs (threads, verbosity, colour,
+ * batchsize) are deliberately not stored; blocksize/hash live in dbfile_config
+ * already. roots/excludes are heap arrays owned by the struct.
+ */
+struct scan_config {
+	int		run_dedupe;
+	int		recurse;
+	int		skip_zeroes;
+	int		only_whole_files;
+	int		do_block_hash;
+	int		dedupe_same_file;
+	uint64_t	min_filesize;
+	char		**roots;
+	int		nroots;
+	char		**excludes;
+	int		nexcludes;
+};
+
+/* Persist sc (options + roots + excludes), replacing any previously stored set. */
+int dbfile_store_scan_config(struct dbhandle *db, const struct scan_config *sc);
+/*
+ * Load the stored scan config into sc (zeroed first). Returns 1 if a stored
+ * configuration was present, 0 if none, <0 on error. Caller frees with
+ * scan_config_free().
+ */
+int dbfile_load_scan_config(struct dbhandle *db, struct scan_config *sc);
+void scan_config_free(struct scan_config *sc);
+
 struct dbfile_stats {
 	uint64_t	num_b_hashes;
 	uint64_t	num_e_hashes;

--- a/src/oans.c
+++ b/src/oans.c
@@ -95,6 +95,46 @@ static const char *fmt_dur(char *buf, size_t n, double s)
  * tool): identity, contents, how much whole-file duplication it records, and
  * how long the load and the duplicate-analysis queries took on this hashfile.
  */
+/*
+ * Render a stored scan config's options as the CLI string a replay would use
+ * ("-r -d --min-filesize=... --dedupe-options=..."), or "(defaults)" if none.
+ * Kept next to the other scan-config policy so the flag spellings stay in one
+ * place. Caller frees the result.
+ */
+static char *scan_config_options_str(const struct scan_config *sc)
+{
+	GString *s = g_string_new(NULL);
+	const char *dtok[3];
+	int nd = 0, j;
+
+	if (sc->recurse)
+		g_string_append(s, "-r ");
+	if (sc->run_dedupe)
+		g_string_append(s, "-d ");
+	if (sc->skip_zeroes)
+		g_string_append(s, "--skip-zeroes ");
+	if (sc->min_filesize > 1)
+		g_string_append_printf(s, "--min-filesize=%"PRIu64" ", sc->min_filesize);
+
+	if (sc->only_whole_files)
+		dtok[nd++] = "only_whole_files";
+	if (sc->do_block_hash)
+		dtok[nd++] = "partial";
+	if (!sc->dedupe_same_file)
+		dtok[nd++] = "nosame";
+	if (nd) {
+		g_string_append(s, "--dedupe-options=");
+		for (j = 0; j < nd; j++)
+			g_string_append_printf(s, "%s%s", j ? "," : "", dtok[j]);
+	}
+
+	if (s->len && s->str[s->len - 1] == ' ')
+		g_string_truncate(s, s->len - 1);
+	if (!s->len)
+		g_string_append(s, "(defaults)");
+	return g_string_free(s, FALSE);		/* hand the buffer to the caller */
+}
+
 static int print_hashfile_stats(char *filename)
 {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
@@ -154,38 +194,12 @@ static int print_hashfile_stats(char *filename)
 		struct scan_config sc;
 
 		if (dbfile_load_scan_config(db, &sc) > 0) {
-			char opts[256] = "";
-			char dopt[64] = "";
-			size_t o = 0;
-
-			if (sc.recurse)
-				o += snprintf(opts + o, sizeof(opts) - o, "-r ");
-			if (sc.run_dedupe)
-				o += snprintf(opts + o, sizeof(opts) - o, "-d ");
-			if (sc.skip_zeroes)
-				o += snprintf(opts + o, sizeof(opts) - o, "--skip-zeroes ");
-			if (sc.min_filesize > 1)
-				o += snprintf(opts + o, sizeof(opts) - o,
-					      "--min-filesize=%"PRIu64" ", sc.min_filesize);
-			/* --dedupe-options: only the non-default tokens. */
-			if (sc.only_whole_files)
-				strcat(dopt, "only_whole_files,");
-			if (sc.do_block_hash)
-				strcat(dopt, "partial,");
-			if (!sc.dedupe_same_file)
-				strcat(dopt, "nosame,");
-			if (dopt[0]) {
-				dopt[strlen(dopt) - 1] = '\0';	/* drop trailing comma */
-				o += snprintf(opts + o, sizeof(opts) - o,
-					      "--dedupe-options=%s ", dopt);
-			}
-			if (o > 0 && opts[o - 1] == ' ')
-				opts[o - 1] = '\0';		/* drop trailing space */
+			char *opts = scan_config_options_str(&sc);
 
 			printf("\n%s%sstored scan%s   %s(replayed by: oans --hashfile=%s)%s\n",
 			       col_bold, col_blue, col_reset, col_dim, filename, col_reset);
-			printf("  %soptions%s         %s\n", col_dim, col_reset,
-			       opts[0] ? opts : "(defaults)");
+			printf("  %soptions%s         %s\n", col_dim, col_reset, opts);
+			free(opts);
 			for (i = 0; i < sc.nroots; i++)
 				printf("  %s%s%s %s\n", col_dim,
 				       i == 0 ? "paths      " : "           ",
@@ -930,28 +944,24 @@ static void apply_scan_config(const struct scan_config *sc)
  * survive is the caller's job: scanning zero roots would let the stat-based
  * prune wipe the whole hashfile (e.g. an unmounted drive).
  */
-static int drop_missing_roots(char **roots, int nroots)
+static int drop_missing_roots(struct scan_config *sc)
 {
 	int i, live = 0;
 
-	for (i = 0; i < nroots; i++) {
+	for (i = 0; i < sc->nroots; i++) {
 		struct stat st;
 
-		if (stat(roots[i], &st) == 0) {
-			roots[live++] = roots[i];
+		if (stat(sc->roots[i], &st) == 0) {
+			sc->roots[live++] = sc->roots[i];
 		} else {
 			eprintf("Warning: stored path \"%s\" no longer exists, "
-				"skipping.\n", roots[i]);
-			free(roots[i]);
+				"skipping.\n", sc->roots[i]);
+			free(sc->roots[i]);
 		}
 	}
-	/*
-	 * Compaction moved survivors to the front; NUL the vacated tail so the
-	 * caller's scan_config_free() (which frees all nroots slots) neither
-	 * double-frees a survivor nor touches a dropped string.
-	 */
-	for (i = live; i < nroots; i++)
-		roots[i] = NULL;
+	/* Shrink the count to the compacted survivors; scan_config_free() then
+	 * frees exactly those and nothing is double-freed or leaked. */
+	sc->nroots = live;
 	return live;
 }
 
@@ -1082,7 +1092,7 @@ int main(int argc, char **argv)
 		}
 
 		apply_scan_config(&replay);
-		numfiles = drop_missing_roots(replay.roots, replay.nroots);
+		numfiles = drop_missing_roots(&replay);
 		if (numfiles == 0) {
 			eprintf("Error: none of the stored paths exist; refusing "
 				"to run (this would prune the whole hashfile).\n");

--- a/src/oans.c
+++ b/src/oans.c
@@ -55,6 +55,11 @@ static unsigned int list_only_opt = 0;
 static unsigned int rm_only_opt = 0;
 static unsigned int stats_only_opt = 0;
 static int opt_no_color = 0;
+
+/* User-supplied --exclude patterns, captured for the self-describing hashfile
+ * (the auto-added hashfile sidecar patterns are re-derived each run, not here). */
+static char **user_excludes;
+static int n_user_excludes;
 struct dbfile_config dbfile_cfg;
 
 /* Upper bound for the auto-detected worker thread count (overridable). */
@@ -571,8 +576,14 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 			}
 			break;
 		case EXCLUDE_OPTION:
-			if (add_exclude_pattern(optarg))
+			if (add_exclude_pattern(optarg)) {
 				eprintf("Error: cannot exclude %s\n", optarg);
+			} else {
+				user_excludes = realloc(user_excludes,
+					(n_user_excludes + 1) * sizeof(*user_excludes));
+				abort_on(!user_excludes);
+				user_excludes[n_user_excludes++] = strdup(optarg);
+			}
 			break;
 		case BATCH_SIZE_OPTION:
 		case 'B':
@@ -632,8 +643,13 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		}
 	}
 
+	/*
+	 * A bare `oans --hashfile=X` (no files) is allowed: main() replays the
+	 * scan config stored in the hashfile. Without a hashfile there is nothing
+	 * to replay, so a file list is still required.
+	 */
 	if (!(list_only_opt || stats_only_opt)
-			&& numfiles == 0) {
+			&& numfiles == 0 && !options.hashfile) {
 		eprintf("Error: a file list argument is required.\n");
 		return 1;
 	}
@@ -795,7 +811,7 @@ static void process_duplicates(struct dbhandle *db)
 		extents_search_free();
 }
 
-static int scan_files(int argc, char **argv, int filelist_idx, struct dbhandle *db)
+static int scan_files(char **roots, int nroots, struct dbhandle *db)
 {
 	int ret;
 
@@ -808,8 +824,7 @@ static int scan_files(int argc, char **argv, int filelist_idx, struct dbhandle *
 	if (stdin_filelist)
 		ret = add_files_from_stdin(db);
 	else
-		ret = scan_files_from_cmdline(argc - filelist_idx,
-					     &argv[filelist_idx], db);
+		ret = scan_files_from_cmdline(nroots, roots, db);
 
 	/* Run the parallel walk + scan over everything seeded above. */
 	if (!ret)
@@ -842,9 +857,101 @@ static int scan_files(int argc, char **argv, int filelist_idx, struct dbhandle *
 	return 0;
 }
 
+/* Apply a replayed scan config to the global options (see scan_config). */
+static void apply_scan_config(const struct scan_config *sc)
+{
+	int i;
+
+	options.run_dedupe = sc->run_dedupe;
+	options.recurse_dirs = sc->recurse;
+	options.skip_zeroes = sc->skip_zeroes;
+	options.only_whole_files = sc->only_whole_files;
+	options.do_block_hash = sc->do_block_hash;
+	options.dedupe_same_file = sc->dedupe_same_file;
+	options.min_filesize = sc->min_filesize;
+
+	for (i = 0; i < sc->nexcludes; i++)
+		add_exclude_pattern(sc->excludes[i]);
+}
+
+/*
+ * Drop replayed roots that no longer exist (warn on each), compacting the
+ * array in place. Returns the number that survive. Refusing to run when none
+ * survive is the caller's job: scanning zero roots would let the stat-based
+ * prune wipe the whole hashfile (e.g. an unmounted drive).
+ */
+static int drop_missing_roots(char **roots, int nroots)
+{
+	int i, live = 0;
+
+	for (i = 0; i < nroots; i++) {
+		struct stat st;
+
+		if (stat(roots[i], &st) == 0) {
+			roots[live++] = roots[i];
+		} else {
+			eprintf("Warning: stored path \"%s\" no longer exists, "
+				"skipping.\n", roots[i]);
+			free(roots[i]);
+		}
+	}
+	/*
+	 * Compaction moved survivors to the front; NUL the vacated tail so the
+	 * caller's scan_config_free() (which frees all nroots slots) neither
+	 * double-frees a survivor nor touches a dropped string.
+	 */
+	for (i = live; i < nroots; i++)
+		roots[i] = NULL;
+	return live;
+}
+
+/*
+ * Persist this run's scan-shaping options, roots and user excludes so a later
+ * bare `oans --hashfile=X` replays it. Roots are canonicalised (as the scan
+ * itself does) so replay is independent of the working directory. Best-effort:
+ * a failure only means the next run needs its arguments again.
+ */
+static void persist_scan_config(struct dbhandle *db, char **roots, int nroots)
+{
+	struct scan_config sc = {0};
+	char **abs = calloc(nroots, sizeof(*abs));
+	int i;
+
+	abort_on(!abs);
+	for (i = 0; i < nroots; i++) {
+		char buf[PATH_MAX];
+
+		if (realpath(roots[i], buf))
+			abs[sc.nroots++] = strdup(buf);
+	}
+
+	sc.run_dedupe = options.run_dedupe;
+	sc.recurse = options.recurse_dirs;
+	sc.skip_zeroes = options.skip_zeroes;
+	sc.only_whole_files = options.only_whole_files;
+	sc.do_block_hash = options.do_block_hash;
+	sc.dedupe_same_file = options.dedupe_same_file;
+	sc.min_filesize = options.min_filesize;
+	sc.roots = abs;
+	sc.excludes = user_excludes;
+	sc.nexcludes = n_user_excludes;
+
+	if (dbfile_store_scan_config(db, &sc))
+		eprintf("Warning: could not store scan configuration in the "
+			"hashfile.\n");
+
+	for (i = 0; i < sc.nroots; i++)
+		free(abs[i]);
+	free(abs);
+}
+
 int main(int argc, char **argv)
 {
 	int ret, filelist_idx = 0;
+	int numfiles;
+	char **roots;
+	bool replaying = false;
+	struct scan_config replay = {0};
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 
 	char stdbuf[BUFSIZ];
@@ -903,6 +1010,41 @@ int main(int argc, char **argv)
 
 	dedupe_seq = dbfile_cfg.dedupe_seq;
 
+	numfiles = argc - filelist_idx;
+	roots = &argv[filelist_idx];
+
+	/*
+	 * Self-describing hashfile: with no file arguments, replay the scan
+	 * config (options + roots + excludes) the last run stored.
+	 */
+	if (numfiles == 0 && !stdin_filelist) {
+		int have = dbfile_load_scan_config(db, &replay);
+
+		if (have < 0) {
+			ret = have;
+			goto out;
+		}
+		if (!have) {
+			eprintf("Error: no files given and the hashfile has no "
+				"stored scan configuration to replay.\n");
+			ret = 1;
+			goto out;
+		}
+
+		apply_scan_config(&replay);
+		numfiles = drop_missing_roots(replay.roots, replay.nroots);
+		if (numfiles == 0) {
+			eprintf("Error: none of the stored paths exist; refusing "
+				"to run (this would prune the whole hashfile).\n");
+			ret = 1;
+			goto out;
+		}
+		roots = replay.roots;
+		replaying = true;
+		qprintf("Replaying stored scan of %d path%s from the hashfile.\n",
+			numfiles, numfiles == 1 ? "" : "s");
+	}
+
 	print_header();
 
 	ret = dbfile_prune_unscanned_files(db);
@@ -911,9 +1053,13 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	ret = scan_files(argc, argv, filelist_idx, db);
+	ret = scan_files(roots, numfiles, db);
 	if (ret)
 		goto out;
+
+	/* Remember this run so a later bare `oans --hashfile=X` replays it. */
+	if (!replaying && !stdin_filelist && options.hashfile)
+		persist_scan_config(db, roots, numfiles);
 
 	/*
 	 * Drop rows for files deleted from disk since they were scanned,
@@ -940,6 +1086,7 @@ int main(int argc, char **argv)
 		dbfile_maybe_vacuum(db);
 
 out:
+	scan_config_free(&replay);
 	free_all_filerecs();
 
 #ifdef DEBUG_BUILD

--- a/src/oans.c
+++ b/src/oans.c
@@ -149,6 +149,56 @@ static int print_hashfile_stats(char *filename)
 		       col_dim, 100.0 * freelist / page_count, col_reset);
 	fflush(stdout);
 
+	/* --- stored scan config (self-describing hashfile), if any --- */
+	{
+		struct scan_config sc;
+
+		if (dbfile_load_scan_config(db, &sc) > 0) {
+			char opts[256] = "";
+			char dopt[64] = "";
+			size_t o = 0;
+
+			if (sc.recurse)
+				o += snprintf(opts + o, sizeof(opts) - o, "-r ");
+			if (sc.run_dedupe)
+				o += snprintf(opts + o, sizeof(opts) - o, "-d ");
+			if (sc.skip_zeroes)
+				o += snprintf(opts + o, sizeof(opts) - o, "--skip-zeroes ");
+			if (sc.min_filesize > 1)
+				o += snprintf(opts + o, sizeof(opts) - o,
+					      "--min-filesize=%"PRIu64" ", sc.min_filesize);
+			/* --dedupe-options: only the non-default tokens. */
+			if (sc.only_whole_files)
+				strcat(dopt, "only_whole_files,");
+			if (sc.do_block_hash)
+				strcat(dopt, "partial,");
+			if (!sc.dedupe_same_file)
+				strcat(dopt, "nosame,");
+			if (dopt[0]) {
+				dopt[strlen(dopt) - 1] = '\0';	/* drop trailing comma */
+				o += snprintf(opts + o, sizeof(opts) - o,
+					      "--dedupe-options=%s ", dopt);
+			}
+			if (o > 0 && opts[o - 1] == ' ')
+				opts[o - 1] = '\0';		/* drop trailing space */
+
+			printf("\n%s%sstored scan%s   %s(replayed by: oans --hashfile=%s)%s\n",
+			       col_bold, col_blue, col_reset, col_dim, filename, col_reset);
+			printf("  %soptions%s         %s\n", col_dim, col_reset,
+			       opts[0] ? opts : "(defaults)");
+			for (i = 0; i < sc.nroots; i++)
+				printf("  %s%s%s %s\n", col_dim,
+				       i == 0 ? "paths      " : "           ",
+				       col_reset, sc.roots[i]);
+			for (i = 0; i < sc.nexcludes; i++)
+				printf("  %s%s%s %s\n", col_dim,
+				       i == 0 ? "excludes   " : "           ",
+				       col_reset, sc.excludes[i]);
+			fflush(stdout);
+			scan_config_free(&sc);
+		}
+	}
+
 	/*
 	 * files: one scan reads every size into an array, from which we get
 	 * count/hashed/logical/largest and (after a fast C sort) the median. An

--- a/tests/integration/test_self_describing.py
+++ b/tests/integration/test_self_describing.py
@@ -20,10 +20,15 @@ class SelfDescribingConfigTest(DuperemoveTest):
         return self.hf_scalar(
             "select keyval from config where keyname=?", (name,))
 
-    def test_run_stores_options_and_roots(self):
-        d = self.path("tree")
+    def _seed_tree(self, name="tree", contents=b"x" * 4096):
+        """Create <name>/ holding one file; return the dir's absolute path."""
+        d = self.path(name)
         os.makedirs(d)
-        self.write("tree/a", b"x" * 4096)
+        self.write(f"{name}/a", contents)
+        return d
+
+    def test_run_stores_options_and_roots(self):
+        d = self._seed_tree()
 
         self.dm("-r", "--min-filesize=2048", d)
         self.assertDmOk()
@@ -36,9 +41,7 @@ class SelfDescribingConfigTest(DuperemoveTest):
         self.assertEqual(roots, [os.path.realpath(d)])
 
     def test_last_run_wins_overwrites(self):
-        d = self.path("tree")
-        os.makedirs(d)
-        self.write("tree/a", b"x" * 4096)
+        d = self._seed_tree()
 
         self.dm("-rd", d)
         self.assertEqual(self._opt("opt_run_dedupe"), 1)
@@ -48,6 +51,21 @@ class SelfDescribingConfigTest(DuperemoveTest):
         self.assertEqual(self._opt("opt_run_dedupe"), 0)
         self.assertEqual(self._opt("opt_dedupe_same_file"), 0)
 
+    def test_all_sticky_options_round_trip(self):
+        # Backstop: every scan-shaping option a run uses must be persisted, so
+        # adding a new one without wiring persist_scan_config fails here.
+        d = self._seed_tree(contents=b"x" * 16384)
+        self.dm("-rd", "--skip-zeroes", "--min-filesize=8192",
+                "--dedupe-options=nosame,only_whole_files", d)
+        self.assertDmOk()
+        self.assertEqual(self._opt("opt_run_dedupe"), 1)
+        self.assertEqual(self._opt("opt_recurse"), 1)
+        self.assertEqual(self._opt("opt_skip_zeroes"), 1)
+        self.assertEqual(self._opt("opt_only_whole_files"), 1)
+        self.assertEqual(self._opt("opt_dedupe_same_file"), 0)   # nosame
+        self.assertEqual(self._opt("opt_do_block_hash"), 0)      # not requested
+        self.assertEqual(self._opt("opt_min_filesize"), 8192)
+
     def test_bare_run_without_stored_config_errors(self):
         # Fresh hashfile, no arguments: nothing to replay.
         self.dm()
@@ -55,9 +73,7 @@ class SelfDescribingConfigTest(DuperemoveTest):
         self.assertIn("no stored scan configuration", self.out)
 
     def test_all_roots_missing_refuses_and_keeps_rows(self):
-        d = self.path("tree")
-        os.makedirs(d)
-        self.write("tree/a", b"x" * 4096)
+        d = self._seed_tree()
         self.dm("-r", d)
         rows_before = self.hf_count("files")
         self.assertGreater(rows_before, 0)

--- a/tests/integration/test_self_describing.py
+++ b/tests/integration/test_self_describing.py
@@ -91,6 +91,21 @@ class SelfDescribingConfigTest(DuperemoveTest):
         self.assertEqual(roots, sorted([os.path.realpath(self.path("one")),
                                         os.path.realpath(self.path("two"))]))
 
+    def test_stats_shows_stored_config(self):
+        os.makedirs(self.path("tree/skip"))
+        self.write("tree/a", b"a" * 8192)
+        self.dm("-rd", "--min-filesize=4096",
+                "--exclude", self.path("tree/skip"), self.path("tree"))
+
+        self.dm("--stats")
+        self.assertDmOk()
+        self.assertIn("stored scan", self.out)
+        self.assertIn("-r", self.out)
+        self.assertIn("-d", self.out)
+        self.assertIn("--min-filesize=4096", self.out)
+        self.assertIn(os.path.realpath(self.path("tree")), self.out)
+        self.assertIn(os.path.realpath(self.path("tree/skip")), self.out)
+
     def test_excludes_round_trip(self):
         os.makedirs(self.path("tree/keep"))
         os.makedirs(self.path("tree/skip"))

--- a/tests/integration/test_self_describing.py
+++ b/tests/integration/test_self_describing.py
@@ -1,0 +1,132 @@
+"""Self-describing hashfile: a run stores its scan-shaping options, roots and
+exclude patterns, so a later bare `oans --hashfile=X` (no file arguments)
+replays it.
+
+Covers the option/root/exclude round-trip, last-run-wins overwrite semantics,
+and the two guards: refuse a bare run with nothing stored, and refuse (without
+pruning) when none of the stored roots still exist.
+"""
+
+import os
+import shutil
+
+from harness import DuperemoveTest, requires_reflink
+
+
+class SelfDescribingConfigTest(DuperemoveTest):
+    """Config storage/replay that does not depend on real dedupe."""
+
+    def _opt(self, name):
+        return self.hf_scalar(
+            "select keyval from config where keyname=?", (name,))
+
+    def test_run_stores_options_and_roots(self):
+        d = self.path("tree")
+        os.makedirs(d)
+        self.write("tree/a", b"x" * 4096)
+
+        self.dm("-r", "--min-filesize=2048", d)
+        self.assertDmOk()
+
+        self.assertEqual(self._opt("scan_config"), 1)
+        self.assertEqual(self._opt("opt_recurse"), 1)
+        self.assertEqual(self._opt("opt_run_dedupe"), 0)
+        self.assertEqual(self._opt("opt_min_filesize"), 2048)
+        roots = [r[0] for r in self.hf_query("select path from scan_roots")]
+        self.assertEqual(roots, [os.path.realpath(d)])
+
+    def test_last_run_wins_overwrites(self):
+        d = self.path("tree")
+        os.makedirs(d)
+        self.write("tree/a", b"x" * 4096)
+
+        self.dm("-rd", d)
+        self.assertEqual(self._opt("opt_run_dedupe"), 1)
+
+        # A second run with different options replaces the stored set.
+        self.dm("-r", "--dedupe-options=nosame", d)
+        self.assertEqual(self._opt("opt_run_dedupe"), 0)
+        self.assertEqual(self._opt("opt_dedupe_same_file"), 0)
+
+    def test_bare_run_without_stored_config_errors(self):
+        # Fresh hashfile, no arguments: nothing to replay.
+        self.dm()
+        self.assertNotEqual(self.rc, 0)
+        self.assertIn("no stored scan configuration", self.out)
+
+    def test_all_roots_missing_refuses_and_keeps_rows(self):
+        d = self.path("tree")
+        os.makedirs(d)
+        self.write("tree/a", b"x" * 4096)
+        self.dm("-r", d)
+        rows_before = self.hf_count("files")
+        self.assertGreater(rows_before, 0)
+
+        shutil.rmtree(d)          # the only stored root disappears
+
+        self.dm()                 # bare replay
+        self.assertNotEqual(self.rc, 0)
+        self.assertIn("refusing to run", self.out)
+        # The guard must not let the prune wipe the hashfile.
+        self.assertEqual(self.hf_count("files"), rows_before)
+
+    def test_some_roots_missing_skips_and_keeps_going(self):
+        # Two roots stored; delete one. The run must warn, scan the survivor,
+        # and not crash (regression for a double-free while compacting roots).
+        os.makedirs(self.path("one"))
+        os.makedirs(self.path("two"))
+        self.write("one/a", b"a" * 4096)
+        self.write("two/b", b"b" * 4096)
+        self.dm("-r", self.path("one"), self.path("two"))
+        self.assertEqual(self.hf_count("scan_roots"), 2)
+
+        shutil.rmtree(self.path("one"))     # one of two roots vanishes
+        self.dm()
+        self.assertEqual(self.rc, 0)
+        self.assertIn("no longer exists", self.out)
+        # A replay does not rewrite the stored config, so the temporarily
+        # missing root is kept and retried next time (e.g. an unmounted drive),
+        # not silently forgotten.
+        roots = sorted(r[0] for r in self.hf_query("select path from scan_roots"))
+        self.assertEqual(roots, sorted([os.path.realpath(self.path("one")),
+                                        os.path.realpath(self.path("two"))]))
+
+    def test_excludes_round_trip(self):
+        os.makedirs(self.path("tree/keep"))
+        os.makedirs(self.path("tree/skip"))
+        self.write("tree/keep/a", b"a" * 4096)
+        self.write("tree/skip/b", b"b" * 4096)
+
+        self.dm("-r", "--exclude", self.path("tree/skip"), self.path("tree"))
+        stored = [r[0] for r in self.hf_query("select pattern from scan_excludes")]
+        self.assertEqual(stored, [os.path.realpath(self.path("tree/skip"))])
+        self.assertNotIn("skip", self.hf_query("select filename from files").__repr__())
+
+        # A new file under the excluded dir must stay out on replay.
+        self.write("tree/skip/c", b"c" * 4096)
+        self.dm()
+        self.assertDmOk()
+        names = [r[0] for r in self.hf_query("select filename from files")]
+        self.assertTrue(all("/skip/" not in n for n in names), names)
+
+
+@requires_reflink
+class SelfDescribingReplayDedupeTest(DuperemoveTest):
+    """A bare replay must actually re-scan the stored root and dedupe."""
+
+    def test_replay_dedupes_new_duplicates(self):
+        d = self.path("tree")
+        os.makedirs(d)
+        a, b = self.mkdup("tree/a", "tree/b", 1 << 20)
+
+        # First run stores "-rd <tree>" and dedupes the initial pair.
+        self.dm("-rd", d)
+        self.assertShared(a, b)
+
+        # Add a brand-new duplicate pair, then replay with no arguments.
+        c, e = self.mkdup("tree/c", "tree/e", 1 << 20)
+        self.assertNotShared(c, e)
+
+        self.dm()                 # bare: replays -r -d <tree>
+        self.assertDmOk()
+        self.assertShared(c, e)   # proves the stored root was re-scanned + deduped


### PR DESCRIPTION
## What

Each run now records its **scan-shaping options** (`-d`, `-r`, `--skip-zeroes`, `--min-filesize`, `--dedupe-options`), its **paths**, and its **`--exclude` patterns** in the hashfile. Running `oans --hashfile=FILE` with no file arguments **replays** that stored configuration.

```sh
oans -dr --min-filesize=1M --hashfile=/data.hash /srv/data   # sets it up
oans --hashfile=/data.hash                                   # replays it (cron-friendly)
```

## Semantics (the agreed defaults)

- **Last run wins** — any run that names paths overwrites the stored set.
- **Bare invocation auto-replays**; other options typed on that line are ignored (to change the config, do a run that names paths).
- **Roots are stored canonicalised** (`realpath`), so replay is independent of the working directory.
- **Missing-root guard** — individually missing paths are skipped with a warning; if *none* of the stored paths still exist, oans **refuses** rather than let the stat-based prune wipe the hashfile (e.g. an unmounted drive). A replay does **not** rewrite the stored config, so a transiently missing root is retried next time, not forgotten.

Ephemeral knobs (threads, verbosity, colour, batchsize) are deliberately **not** stored; blocksize/hash already live in the config.

## Compatibility (no schema-version bump)

Storage is purely additive — two `CREATE TABLE IF NOT EXISTS` tables (`scan_roots`, `scan_excludes`) plus `opt_*` keys in the existing `config` table. `create_tables()` runs on every open, so **existing 5.0 hashfiles gain the tables transparently on first use** (no re-scan, verified), and old binaries simply ignore the extra rows. Hence `DB_FILE_MINOR` stays at 0 — bumping it would needlessly discard every existing cache for no safety gain.

## Implementation

- `dbfile.c`: new `scan_roots`/`scan_excludes` tables, `dbfile_store_scan_config()` / `dbfile_load_scan_config()` / `scan_config_free()`, and a 64-bit config getter for `min_filesize`.
- `oans.c`: capture user `--exclude`s; relax the "file list required" check when a hashfile is given; replay/apply + missing-root guard in `main()`; persist after a successful named-path run. `scan_files()` now takes an explicit roots array.

A subtle double-free (compacting the roots array in place left duplicate tail pointers) was found and fixed while adding the partial-missing test.

## Verification

- 6/6 unit, **70/70** integration (7 new: round-trip, last-run-wins, no-config error, all-missing guard, partial-missing skip, exclude round-trip, replay-actually-dedupes).
- Valgrind clean (0 lost / 0 errors) on store, replay, and the partial-missing-roots path.
- Backward-compat checked: a hashfile with the new tables/keys removed is upgraded in place with no re-hash and net-0 change.
- 0 warnings under `-Wextra`; man page + README + docs updated (and a stale example that implied a bare `-dr --hashfile` worked — it used to error — was corrected).

## Update

- `oans --stats` now prints a **stored scan** section (the replay options, paths and excludes), omitted when the hashfile has none. Documented in the `--stats` man entry; +1 integration test (71 total).
