### PR TITLE
Run history + --json metrics export

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ and filesystem.
 - A **human-readable, colorful summary** (respecting `NO_COLOR` and non-TTY
   output) instead of a wall of per-extent text.
 - A **live dedupe progress bar** with throughput rate and ETA.
+- **Run history and metrics**: each run's reclaimed space, duration and file
+  count are recorded in the hashfile — `oans --history` shows the timeline and
+  lifetime total, and `oans --json` exports current metrics for a dashboard.
 - A **self-describing hashfile**: each run records its options, paths and
   excludes, so `oans --hashfile=FILE` with no arguments replays the last run —
   a cron job need only name the hashfile. If the stored paths have all vanished
@@ -158,6 +161,10 @@ oans --hashfile=/path/to/hashfile
 
 # Report what a hashfile holds (files, hashes, duplication):
 oans --stats --hashfile=/path/to/hashfile
+
+# Space reclaimed over time, and machine-readable metrics for a dashboard:
+oans --history --hashfile=/path/to/hashfile
+oans --json --hashfile=/path/to/hashfile
 ```
 
 A run ends with a summary like:

--- a/completion/zsh/_oans
+++ b/completion/zsh/_oans
@@ -31,6 +31,8 @@ _duperemove() {
 		'-L[print all files in hashfile and exit]'
 		'-R[remove files from db and exit]:*:file:_files'
 		'--stats[print a report about the hashfile and exit]'
+		'--history[print the run history recorded in the hashfile and exit]'
+		'--json[print machine-readable hashfile metrics as JSON and exit]'
 		'--skip-zeroes[read data blocks and skip any zeroed blocks]'
 		'-b[use the specified block size]:block size: '
 		'--io-threads=[use N threads for IO]:number of thread: '

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -178,6 +178,24 @@ bytes).
 Requires the \f[CR]\-\-hashfile\f[R] option.
 (Replaces the standalone \f[CR]hashstats\f[R] tool.)
 .TP
+\f[B]\-\-history\f[R]
+Print the run history recorded in the hashfile and exit: how many runs,
+the total space reclaimed over their lifetime, and a timeline of the
+most recent runs (date, reclaimed bytes, elapsed time, files hashed, and
+whether it was a dedupe or scan\-only run).
+Every run appends one row automatically.
+Requires the \f[CR]\-\-hashfile\f[R] option.
+.TP
+\f[B]\-\-json\f[R]
+Print a machine\-readable JSON object of the hashfile\[cq]s current
+metrics (files, hashes, logical bytes, duplicate groups and reclaimable
+bytes) plus the lifetime run\-history totals, then exit.
+Intended for scripting and dashboards (e.g.\ piping to \f[CR]jq\f[R],
+Telegraf, or a node_exporter textfile).
+The \f[CR]reclaimable_logical_bytes\f[R] field is a logical upper bound;
+the real disk space freed is smaller on a compressed filesystem.
+Requires the \f[CR]\-\-hashfile\f[R] option.
+.TP
 \f[B]\-R\f[R] \f[CR]files ..\f[R]
 Remove file from the db and exit.
 oans will read the list from standard input if a hyphen (\-) is
@@ -305,6 +323,14 @@ List the files tracked by foo.hash:
 .IP
 .EX
 oans \-L \-\-hashfile=foo.hash
+.EE
+.PP
+Show how much space has been reclaimed over time, and export current
+metrics for a dashboard:
+.IP
+.EX
+oans \-\-history \-\-hashfile=foo.hash
+oans \-\-json \-\-hashfile=foo.hash | jq .reclaimed_total_bytes
 .EE
 .SH FAQ
 .SS Is oans safe for my data?

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -164,6 +164,21 @@ total logical data tracked, and how much whole-file duplication it records
 (duplicate groups and reclaimable bytes). Requires the `--hashfile` option.
 (Replaces the standalone `hashstats` tool.)
 
+**\--history**
+  ~ Print the run history recorded in the hashfile and exit: how many runs,
+the total space reclaimed over their lifetime, and a timeline of the most
+recent runs (date, reclaimed bytes, elapsed time, files hashed, and whether it
+was a dedupe or scan-only run). Every run appends one row automatically.
+Requires the `--hashfile` option.
+
+**\--json**
+  ~ Print a machine-readable JSON object of the hashfile's current metrics
+(files, hashes, logical bytes, duplicate groups and reclaimable bytes) plus the
+lifetime run-history totals, then exit. Intended for scripting and dashboards
+(e.g. piping to `jq`, Telegraf, or a node\_exporter textfile). The
+`reclaimable_logical_bytes` field is a logical upper bound; the real disk space
+freed is smaller on a compressed filesystem. Requires the `--hashfile` option.
+
 **-R** `files ..`
   ~ Remove file from the db and exit. oans will read the list from
 standard input if a hyphen (-) is provided. Requires the `--hashfile` option.
@@ -266,6 +281,12 @@ recently added to foo (this also becomes the new stored configuration):
 List the files tracked by foo.hash:
 
 	oans -L --hashfile=foo.hash
+
+Show how much space has been reclaimed over time, and export current metrics
+for a dashboard:
+
+	oans --history --hashfile=foo.hash
+	oans --json --hashfile=foo.hash | jq .reclaimed_total_bytes
 
 # FAQ
 

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -269,6 +269,20 @@ static int create_tables(sqlite3 *db)
 #define CREATE_TABLE_SCAN_EXCLUDES					\
 "CREATE TABLE IF NOT EXISTS scan_excludes(pattern TEXT NOT NULL);"
 	ret = sqlite3_exec(db, CREATE_TABLE_SCAN_EXCLUDES, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
+	/*
+	 * One row per oans run (see dbfile_record_run): a timeline of what each
+	 * run reclaimed, for `--history` and the `--json` metrics export.
+	 */
+#define CREATE_TABLE_RUN_HISTORY					\
+"CREATE TABLE IF NOT EXISTS run_history("				\
+"ts INTEGER NOT NULL, duration_ms INTEGER NOT NULL, "			\
+"files_scanned INTEGER NOT NULL, reclaimed INTEGER NOT NULL, "		\
+"groups INTEGER NOT NULL, kernel_bytes INTEGER NOT NULL, "		\
+"deduped INTEGER NOT NULL);"
+	ret = sqlite3_exec(db, CREATE_TABLE_RUN_HISTORY, NULL, NULL, NULL);
 
 out:
 	if (ret)
@@ -1093,6 +1107,34 @@ void scan_config_free(struct scan_config *sc)
 		free(sc->excludes[i]);
 	free(sc->excludes);
 	memset(sc, 0, sizeof(*sc));
+}
+
+int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int ret;
+
+	ret = sqlite3_prepare_v2(dbh->db,
+		"insert into run_history(ts, duration_ms, files_scanned, "
+		"reclaimed, groups, kernel_bytes, deduped) "
+		"values (?1, ?2, ?3, ?4, ?5, ?6, ?7)", -1, &stmt, NULL);
+	if (ret)
+		goto out;
+
+	sqlite3_bind_int64(stmt, 1, r->ts);
+	sqlite3_bind_int64(stmt, 2, r->duration_ms);
+	sqlite3_bind_int64(stmt, 3, r->files_scanned);
+	sqlite3_bind_int64(stmt, 4, r->reclaimed);
+	sqlite3_bind_int64(stmt, 5, r->groups);
+	sqlite3_bind_int64(stmt, 6, r->kernel_bytes);
+	sqlite3_bind_int64(stmt, 7, r->deduped);
+
+	if (sqlite3_step(stmt) != SQLITE_DONE)
+		ret = -1;
+out:
+	if (ret)
+		perror_sqlite(ret, "recording run history");
+	return ret;
 }
 
 static int __dbfile_count_rows(sqlite3_stmt *s, uint64_t *num)

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1137,6 +1137,30 @@ out:
 	return ret;
 }
 
+int dbfile_get_run_summary(struct dbhandle *dbh, struct run_summary *s)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	int ret;
+
+	memset(s, 0, sizeof(*s));
+	ret = sqlite3_prepare_v2(dbh->db,
+		"select count(*), ifnull(sum(reclaimed),0), "
+		"ifnull(sum(files_scanned),0), ifnull(min(ts),0), "
+		"ifnull(max(ts),0) from run_history", -1, &stmt, NULL);
+	if (ret) {
+		perror_sqlite(ret, "reading run summary");
+		return ret;
+	}
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		s->runs = sqlite3_column_int64(stmt, 0);
+		s->total_reclaimed = sqlite3_column_int64(stmt, 1);
+		s->total_files = sqlite3_column_int64(stmt, 2);
+		s->first_ts = sqlite3_column_int64(stmt, 3);
+		s->last_ts = sqlite3_column_int64(stmt, 4);
+	}
+	return 0;
+}
+
 static int __dbfile_count_rows(sqlite3_stmt *s, uint64_t *num)
 {
 	int ret;

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -146,6 +146,16 @@ struct run_record {
 };
 int dbfile_record_run(struct dbhandle *db, const struct run_record *r);
 
+/* Lifetime totals over run_history, for --history and --json. */
+struct run_summary {
+	uint64_t	runs;
+	uint64_t	total_reclaimed;
+	uint64_t	total_files;
+	int64_t		first_ts;
+	int64_t		last_ts;
+};
+int dbfile_get_run_summary(struct dbhandle *db, struct run_summary *s);
+
 struct dbfile_stats {
 	uint64_t	num_b_hashes;
 	uint64_t	num_e_hashes;

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -131,6 +131,21 @@ int dbfile_store_scan_config(struct dbhandle *db, const struct scan_config *sc);
 int dbfile_load_scan_config(struct dbhandle *db, struct scan_config *sc);
 void scan_config_free(struct scan_config *sc);
 
+/*
+ * One recorded run, appended to the hashfile's run_history at the end of each
+ * invocation (see dbfile_record_run). Fed to --history and the --json export.
+ */
+struct run_record {
+	int64_t		ts;		/* unix seconds */
+	int64_t		duration_ms;
+	uint64_t	files_scanned;
+	uint64_t	reclaimed;	/* bytes: net change in shared extents */
+	uint64_t	groups;
+	uint64_t	kernel_bytes;
+	int		deduped;	/* 1 if -d, 0 for a scan-only run */
+};
+int dbfile_record_run(struct dbhandle *db, const struct run_record *r);
+
 struct dbfile_stats {
 	uint64_t	num_b_hashes;
 	uint64_t	num_e_hashes;

--- a/src/oans.c
+++ b/src/oans.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <time.h>
 #include <sys/stat.h>
 
 #include <glib.h>
@@ -54,6 +55,8 @@ static int stdin_filelist = 0;
 static unsigned int list_only_opt = 0;
 static unsigned int rm_only_opt = 0;
 static unsigned int stats_only_opt = 0;
+static unsigned int history_only_opt = 0;
+static unsigned int json_only_opt = 0;
 static int opt_no_color = 0;
 
 /* User-supplied --exclude patterns, captured for the self-describing hashfile
@@ -342,6 +345,154 @@ static int print_hashfile_stats(char *filename)
 	return 0;
 }
 
+/* Whole-file duplicate totals (logical): groups, files in them, and the
+ * reclaimable logical bytes. Shared by --stats-style callers and --json. */
+static void compute_dup_summary(sqlite3 *sq, uint64_t *groups,
+				uint64_t *dupfiles, uint64_t *reclaim)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *s = NULL;
+
+	*groups = *dupfiles = *reclaim = 0;
+	if (sqlite3_prepare_v2(sq,
+		"select count(*) c, (count(*)-1)*size w from files "
+		"where digest is not null group by digest, size having c > 1",
+		-1, &s, NULL) != SQLITE_OK)
+		return;
+	while (sqlite3_step(s) == SQLITE_ROW) {
+		(*groups)++;
+		*dupfiles += sqlite3_column_int64(s, 0);
+		*reclaim += sqlite3_column_int64(s, 1);
+	}
+}
+
+/* Print s as a JSON string literal (quotes + minimal escaping). */
+static void print_json_str(const char *s)
+{
+	putchar('"');
+	for (; *s; s++) {
+		unsigned char c = (unsigned char)*s;
+
+		if (c == '"' || c == '\\')
+			printf("\\%c", c);
+		else if (c < 0x20)
+			printf("\\u%04x", c);
+		else
+			putchar(c);
+	}
+	putchar('"');
+}
+
+static int print_hashfile_history(char *filename)
+{
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	uint64_t runs, total_reclaimed, total_files;
+	int64_t first_ts;
+	sqlite3 *sq;
+
+	db = dbfile_open_handle(filename);
+	if (!db) {
+		eprintf("Error: Could not open \"%s\"\n", filename);
+		return -1;
+	}
+	sq = db->db;
+
+	runs = dbfile_query_u64(sq, "select count(*) from run_history");
+	printf("%s%soans history%s  %s\n", col_bold, col_blue, col_reset, filename);
+	if (runs == 0) {
+		printf("  %sno runs recorded yet%s\n", col_dim, col_reset);
+		return 0;
+	}
+	total_reclaimed = dbfile_query_u64(sq, "select ifnull(sum(reclaimed),0) from run_history");
+	total_files = dbfile_query_u64(sq, "select ifnull(sum(files_scanned),0) from run_history");
+	first_ts = dbfile_query_u64(sq, "select ifnull(min(ts),0) from run_history");
+
+	{
+		char since[32];
+		time_t t = (time_t)first_ts;
+		struct tm tm;
+
+		localtime_r(&t, &tm);
+		strftime(since, sizeof(since), "%Y-%m-%d", &tm);
+		printf("  %ssince%s        %s  %s(%"PRIu64" run%s)%s\n", col_dim,
+		       col_reset, since, col_dim, runs, runs == 1 ? "" : "s",
+		       col_reset);
+	}
+	printf("  %sreclaimed%s    %s%s%s total\n", col_dim, col_reset, col_green,
+	       human_size(total_reclaimed), col_reset);
+	printf("  %sfiles seen%s   %"PRIu64" %s(cumulative)%s\n", col_dim, col_reset,
+	       total_files, col_dim, col_reset);
+
+	printf("\n  %srecent%s   %sdate · reclaimed · elapsed · files · mode%s\n",
+	       col_dim, col_reset, col_dim, col_reset);
+	if (sqlite3_prepare_v2(sq,
+		"select ts, reclaimed, duration_ms, files_scanned, deduped "
+		"from run_history order by ts desc limit 20", -1, &stmt, NULL) == SQLITE_OK) {
+		while (sqlite3_step(stmt) == SQLITE_ROW) {
+			char when[32];
+			time_t t = (time_t)sqlite3_column_int64(stmt, 0);
+			struct tm tm;
+
+			localtime_r(&t, &tm);
+			strftime(when, sizeof(when), "%Y-%m-%d %H:%M", &tm);
+			printf("    %s  %10s  %7.1fs  %9"PRIu64"  %s\n", when,
+			       human_size(sqlite3_column_int64(stmt, 1)),
+			       sqlite3_column_int64(stmt, 2) / 1000.0,
+			       (uint64_t)sqlite3_column_int64(stmt, 3),
+			       sqlite3_column_int(stmt, 4) ? "dedupe" : "scan");
+		}
+	}
+	return 0;
+}
+
+static int print_metrics_json(char *filename)
+{
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
+	struct dbfile_config cfg;
+	struct dbfile_stats st = {0};
+	uint64_t logical, hashed, groups, dupfiles, reclaimable;
+	uint64_t runs, reclaimed_total;
+	int64_t last_ts;
+	sqlite3 *sq;
+
+	db = dbfile_open_handle(filename);
+	if (!db) {
+		eprintf("Error: Could not open \"%s\"\n", filename);
+		return -1;
+	}
+	sq = db->db;
+	if (dbfile_get_config(sq, &cfg))
+		return -1;
+	dbfile_get_stats(db, &st);
+
+	logical = dbfile_query_u64(sq, "select ifnull(sum(size),0) from files");
+	hashed = dbfile_query_u64(sq, "select count(*) from files where digest is not null");
+	compute_dup_summary(sq, &groups, &dupfiles, &reclaimable);
+	runs = dbfile_query_u64(sq, "select count(*) from run_history");
+	reclaimed_total = dbfile_query_u64(sq, "select ifnull(sum(reclaimed),0) from run_history");
+	last_ts = dbfile_query_u64(sq, "select ifnull(max(ts),0) from run_history");
+
+	printf("{\n  \"hashfile\": ");
+	print_json_str(filename);
+	printf(",\n");
+	printf("  \"format\": \"%d.%d\",\n", cfg.major, cfg.minor);
+	printf("  \"block_size\": %u,\n", cfg.blocksize);
+	printf("  \"files_tracked\": %"PRIu64",\n", st.num_files);
+	printf("  \"files_hashed\": %"PRIu64",\n", hashed);
+	printf("  \"extent_hashes\": %"PRIu64",\n", st.num_e_hashes);
+	printf("  \"block_hashes\": %"PRIu64",\n", st.num_b_hashes);
+	printf("  \"logical_bytes\": %"PRIu64",\n", logical);
+	printf("  \"dup_groups\": %"PRIu64",\n", groups);
+	printf("  \"dup_files\": %"PRIu64",\n", dupfiles);
+	/* Logical upper bound; real disk freed is smaller on compressed fs. */
+	printf("  \"reclaimable_logical_bytes\": %"PRIu64",\n", reclaimable);
+	printf("  \"runs\": %"PRIu64",\n", runs);
+	printf("  \"reclaimed_total_bytes\": %"PRIu64",\n", reclaimed_total);
+	printf("  \"last_run_ts\": %"PRId64"\n", last_ts);
+	printf("}\n");
+	return 0;
+}
+
 static int list_db_files(char *filename)
 {
 	int ret;
@@ -487,6 +638,8 @@ enum {
 	NO_COLOR_OPTION,
 	MIN_FILESIZE_OPTION,
 	STATS_OPTION,
+	HISTORY_OPTION,
+	JSON_OPTION,
 };
 
 static int add_one_stdin_file(char *path, void *db)
@@ -551,6 +704,8 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "no-color", 0, NULL, NO_COLOR_OPTION },
 		{ "min-filesize", 1, NULL, MIN_FILESIZE_OPTION },
 		{ "stats", 0, NULL, STATS_OPTION },
+		{ "history", 0, NULL, HISTORY_OPTION },
+		{ "json", 0, NULL, JSON_OPTION },
 		{ NULL, 0, NULL, 0}
 	};
 
@@ -624,6 +779,12 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		case STATS_OPTION:
 			stats_only_opt = 1;
 			break;
+		case HISTORY_OPTION:
+			history_only_opt = 1;
+			break;
+		case JSON_OPTION:
+			json_only_opt = 1;
+			break;
 		case QUIET_OPTION:
 		case 'q':
 			quiet = 1;
@@ -688,20 +849,25 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 	if (numfiles == 1 && strcmp(argv[optind], "-") == 0)
 		stdin_filelist = 1;
 
-	if (list_only_opt + rm_only_opt + stats_only_opt > 1) {
-		eprintf("Error: use only one of '-L', '-R', '--stats'.\n");
+	/* -L/-R/--stats/--history/--json are exclusive read-only report modes. */
+	if (list_only_opt + rm_only_opt + stats_only_opt + history_only_opt
+			+ json_only_opt > 1) {
+		eprintf("Error: use only one of '-L', '-R', '--stats', "
+			"'--history', '--json'.\n");
 		return 1;
 	}
 
-	if (list_only_opt || rm_only_opt || stats_only_opt) {
+	if (list_only_opt || rm_only_opt || stats_only_opt || history_only_opt
+			|| json_only_opt) {
 		if (!options.hashfile) {
-			eprintf("Error: --hashfile= option is required "
-				"with '-L', '-R' or '--stats'.\n");
+			eprintf("Error: --hashfile= option is required with "
+				"'-L', '-R', '--stats', '--history' or '--json'.\n");
 			return 1;
 		}
 
-		if ((list_only_opt || stats_only_opt) && numfiles) {
-			eprintf("Error: -L/--stats do not take "
+		/* Only -R consumes a file list; the report modes do not. */
+		if (!rm_only_opt && numfiles) {
+			eprintf("Error: -L/--stats/--history/--json do not take "
 				"a file list argument\n");
 			return 1;
 		}
@@ -712,7 +878,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 	 * scan config stored in the hashfile. Without a hashfile there is nothing
 	 * to replay, so a file list is still required.
 	 */
-	if (!(list_only_opt || stats_only_opt)
+	if (!(list_only_opt || stats_only_opt || history_only_opt || json_only_opt)
 			&& numfiles == 0 && !options.hashfile) {
 		eprintf("Error: a file list argument is required.\n");
 		return 1;
@@ -1011,6 +1177,7 @@ int main(int argc, char **argv)
 	int numfiles;
 	char **roots;
 	bool replaying = false;
+	uint64_t files_scanned = 0;
 	struct scan_config replay = {0};
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 
@@ -1057,6 +1224,10 @@ int main(int argc, char **argv)
 		return rm_db_files(argc - filelist_idx, &argv[filelist_idx]);
 	else if (stats_only_opt)
 		return print_hashfile_stats(options.hashfile);
+	else if (history_only_opt)
+		return print_hashfile_history(options.hashfile);
+	else if (json_only_opt)
+		return print_metrics_json(options.hashfile);
 
 	db = dbfile_open_handle(options.hashfile);
 	if (!db)
@@ -1117,6 +1288,9 @@ int main(int argc, char **argv)
 	if (ret)
 		goto out;
 
+	/* Capture now: the dedupe phase reuses the scan progress counters. */
+	files_scanned = pscan_files_scanned();
+
 	/* Remember this run so a later bare `oans --hashfile=X` replays it. */
 	if (!replaying && !stdin_filelist && options.hashfile)
 		persist_scan_config(db, roots, numfiles);
@@ -1140,6 +1314,24 @@ int main(int argc, char **argv)
 		qprintf("Hashfile \"%s\" written\n", options.hashfile);
 
 	process_duplicates(db);
+
+	/* Append this run to the hashfile's history (fuels --history / --json). */
+	if (options.hashfile) {
+		uint64_t groups = 0, reclaimed = 0, kern = 0;
+		struct run_record rec;
+
+		pdedupe_counters(&groups, &reclaimed, &kern);
+		rec = (struct run_record){
+			.ts = time(NULL),
+			.duration_ms = (int64_t)(elapsed_seconds() * 1000.0),
+			.files_scanned = files_scanned,
+			.reclaimed = reclaimed,
+			.groups = groups,
+			.kernel_bytes = kern,
+			.deduped = options.run_dedupe,
+		};
+		dbfile_record_run(db, &rec);
+	}
 
 	/* Reclaim space if a prune this run left the hashfile mostly free. */
 	if (options.hashfile)

--- a/src/oans.c
+++ b/src/oans.c
@@ -138,13 +138,71 @@ static char *scan_config_options_str(const struct scan_config *sc)
 	return g_string_free(s, FALSE);		/* hand the buffer to the caller */
 }
 
+struct dup_group { uint64_t size, count, waste; char *path; };
+
+/*
+ * One pass over the files table grouped by (digest, size): the whole-file
+ * duplicate totals - groups, files in them, and reclaimable logical bytes.
+ * When top != NULL it also fills the top `top_cap` groups by reclaimable bytes
+ * (example path = the group's shortest filename: min() over a fixed-width
+ * length prefix, substr() strips it) and sets *ntop. Callers wanting only the
+ * totals pass top = NULL. Shared by --stats and --json.
+ */
+static void compute_dup_summary(sqlite3 *sq, uint64_t *groups, uint64_t *dupfiles,
+				uint64_t *reclaim, struct dup_group *top,
+				int top_cap, int *ntop)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *s = NULL;
+	/* The example-path column and ordering are only needed for the top-N. */
+	const char *sql = top ?
+		"select size, count(*) c, (count(*)-1)*size w, "
+		"substr(min(printf('%010d', length(filename)) || filename), 11) "
+		"from files where digest is not null group by digest, size "
+		"having c > 1 order by w desc, size desc" :
+		"select size, count(*) c, (count(*)-1)*size w from files "
+		"where digest is not null group by digest, size having c > 1";
+
+	*groups = *dupfiles = *reclaim = 0;
+	if (ntop)
+		*ntop = 0;
+	if (sqlite3_prepare_v2(sq, sql, -1, &s, NULL) != SQLITE_OK)
+		return;
+	while (sqlite3_step(s) == SQLITE_ROW) {
+		uint64_t c = sqlite3_column_int64(s, 1);
+		uint64_t w = sqlite3_column_int64(s, 2);
+
+		(*groups)++;
+		*dupfiles += c;
+		*reclaim += w;
+		if (top && *ntop < top_cap) {
+			const char *fn = (const char *)sqlite3_column_text(s, 3);
+
+			top[*ntop].size = sqlite3_column_int64(s, 0);
+			top[*ntop].count = c;
+			top[*ntop].waste = w;
+			top[*ntop].path = fn ? strdup(fn) : NULL;
+			(*ntop)++;
+		}
+	}
+}
+
+/* Format a unix timestamp as local time with strftime(3). */
+static void fmt_localtime(int64_t ts, const char *fmt, char *buf, size_t n)
+{
+	time_t t = (time_t)ts;
+	struct tm tm;
+
+	localtime_r(&t, &tm);
+	strftime(buf, n, fmt, &tm);
+}
+
 static int print_hashfile_stats(char *filename)
 {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 	struct dbfile_config cfg;
 	struct dbfile_stats st = {0};
 	struct stat sb;
-	struct topgrp { uint64_t size, count, waste; char *path; } top[10];
+	struct dup_group top[10];
 	char uuid_str[37] = "";
 	char htype[9] = "", b1[16], b2[16];
 	int k, ntop = 0, i;
@@ -276,43 +334,7 @@ static int print_hashfile_stats(char *filename)
 
 	/* --- whole-file duplicates: ONE group-by feeds every figure below --- */
 	t0 = g_get_monotonic_time() / 1e6;
-	{
-		_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *s = NULL;
-
-		/*
-		 * A single pass over the files table yields every duplicate group
-		 * (digest, size); we accumulate the totals and keep the top 10 by
-		 * reclaimable bytes - far cheaper than one scan per figure. The
-		 * example path is the group's shortest (ties alphabetical), usually
-		 * the canonical least-nested copy: min() over a fixed-width length
-		 * prefix picks it, substr() strips the prefix.
-		 */
-		if (sqlite3_prepare_v2(sq,
-			"select size, count(*) c, "
-			"substr(min(printf('%010d', length(filename)) || filename), 11), "
-			"(count(*)-1)*size w "
-			"from files where digest is not null "
-			"group by digest, size having c > 1 "
-			"order by w desc, size desc", -1, &s, NULL) == SQLITE_OK) {
-			while (sqlite3_step(s) == SQLITE_ROW) {
-				uint64_t c = sqlite3_column_int64(s, 1);
-				uint64_t w = sqlite3_column_int64(s, 3);
-
-				groups++;
-				dupfiles += c;
-				reclaim += w;
-				if (ntop < 10) {
-					const char *fn = (const char *)sqlite3_column_text(s, 2);
-
-					top[ntop].size = sqlite3_column_int64(s, 0);
-					top[ntop].count = c;
-					top[ntop].waste = w;
-					top[ntop].path = fn ? strdup(fn) : NULL;
-					ntop++;
-				}
-			}
-		}
-	}
+	compute_dup_summary(sq, &groups, &dupfiles, &reclaim, top, 10, &ntop);
 	t_analysis = g_get_monotonic_time() / 1e6 - t0;
 
 	printf("\n%s%swhole-file duplicates%s\n", col_bold, col_blue, col_reset);
@@ -345,26 +367,6 @@ static int print_hashfile_stats(char *filename)
 	return 0;
 }
 
-/* Whole-file duplicate totals (logical): groups, files in them, and the
- * reclaimable logical bytes. Shared by --stats-style callers and --json. */
-static void compute_dup_summary(sqlite3 *sq, uint64_t *groups,
-				uint64_t *dupfiles, uint64_t *reclaim)
-{
-	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *s = NULL;
-
-	*groups = *dupfiles = *reclaim = 0;
-	if (sqlite3_prepare_v2(sq,
-		"select count(*) c, (count(*)-1)*size w from files "
-		"where digest is not null group by digest, size having c > 1",
-		-1, &s, NULL) != SQLITE_OK)
-		return;
-	while (sqlite3_step(s) == SQLITE_ROW) {
-		(*groups)++;
-		*dupfiles += sqlite3_column_int64(s, 0);
-		*reclaim += sqlite3_column_int64(s, 1);
-	}
-}
-
 /* Print s as a JSON string literal (quotes + minimal escaping). */
 static void print_json_str(const char *s)
 {
@@ -386,55 +388,41 @@ static int print_hashfile_history(char *filename)
 {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
-	uint64_t runs, total_reclaimed, total_files;
-	int64_t first_ts;
-	sqlite3 *sq;
+	struct run_summary sum;
+	char since[32];
 
 	db = dbfile_open_handle(filename);
 	if (!db) {
 		eprintf("Error: Could not open \"%s\"\n", filename);
 		return -1;
 	}
-	sq = db->db;
+	if (dbfile_get_run_summary(db, &sum))
+		return -1;
 
-	runs = dbfile_query_u64(sq, "select count(*) from run_history");
 	printf("%s%soans history%s  %s\n", col_bold, col_blue, col_reset, filename);
-	if (runs == 0) {
+	if (sum.runs == 0) {
 		printf("  %sno runs recorded yet%s\n", col_dim, col_reset);
 		return 0;
 	}
-	total_reclaimed = dbfile_query_u64(sq, "select ifnull(sum(reclaimed),0) from run_history");
-	total_files = dbfile_query_u64(sq, "select ifnull(sum(files_scanned),0) from run_history");
-	first_ts = dbfile_query_u64(sq, "select ifnull(min(ts),0) from run_history");
 
-	{
-		char since[32];
-		time_t t = (time_t)first_ts;
-		struct tm tm;
-
-		localtime_r(&t, &tm);
-		strftime(since, sizeof(since), "%Y-%m-%d", &tm);
-		printf("  %ssince%s        %s  %s(%"PRIu64" run%s)%s\n", col_dim,
-		       col_reset, since, col_dim, runs, runs == 1 ? "" : "s",
-		       col_reset);
-	}
+	fmt_localtime(sum.first_ts, "%Y-%m-%d", since, sizeof(since));
+	printf("  %ssince%s        %s  %s(%"PRIu64" run%s)%s\n", col_dim, col_reset,
+	       since, col_dim, sum.runs, sum.runs == 1 ? "" : "s", col_reset);
 	printf("  %sreclaimed%s    %s%s%s total\n", col_dim, col_reset, col_green,
-	       human_size(total_reclaimed), col_reset);
+	       human_size(sum.total_reclaimed), col_reset);
 	printf("  %sfiles seen%s   %"PRIu64" %s(cumulative)%s\n", col_dim, col_reset,
-	       total_files, col_dim, col_reset);
+	       sum.total_files, col_dim, col_reset);
 
 	printf("\n  %srecent%s   %sdate · reclaimed · elapsed · files · mode%s\n",
 	       col_dim, col_reset, col_dim, col_reset);
-	if (sqlite3_prepare_v2(sq,
+	if (sqlite3_prepare_v2(db->db,
 		"select ts, reclaimed, duration_ms, files_scanned, deduped "
 		"from run_history order by ts desc limit 20", -1, &stmt, NULL) == SQLITE_OK) {
 		while (sqlite3_step(stmt) == SQLITE_ROW) {
 			char when[32];
-			time_t t = (time_t)sqlite3_column_int64(stmt, 0);
-			struct tm tm;
 
-			localtime_r(&t, &tm);
-			strftime(when, sizeof(when), "%Y-%m-%d %H:%M", &tm);
+			fmt_localtime(sqlite3_column_int64(stmt, 0), "%Y-%m-%d %H:%M",
+				      when, sizeof(when));
 			printf("    %s  %10s  %7.1fs  %9"PRIu64"  %s\n", when,
 			       human_size(sqlite3_column_int64(stmt, 1)),
 			       sqlite3_column_int64(stmt, 2) / 1000.0,
@@ -450,9 +438,8 @@ static int print_metrics_json(char *filename)
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 	struct dbfile_config cfg;
 	struct dbfile_stats st = {0};
+	struct run_summary sum;
 	uint64_t logical, hashed, groups, dupfiles, reclaimable;
-	uint64_t runs, reclaimed_total;
-	int64_t last_ts;
 	sqlite3 *sq;
 
 	db = dbfile_open_handle(filename);
@@ -461,16 +448,13 @@ static int print_metrics_json(char *filename)
 		return -1;
 	}
 	sq = db->db;
-	if (dbfile_get_config(sq, &cfg))
+	if (dbfile_get_config(sq, &cfg) || dbfile_get_run_summary(db, &sum))
 		return -1;
 	dbfile_get_stats(db, &st);
 
 	logical = dbfile_query_u64(sq, "select ifnull(sum(size),0) from files");
 	hashed = dbfile_query_u64(sq, "select count(*) from files where digest is not null");
-	compute_dup_summary(sq, &groups, &dupfiles, &reclaimable);
-	runs = dbfile_query_u64(sq, "select count(*) from run_history");
-	reclaimed_total = dbfile_query_u64(sq, "select ifnull(sum(reclaimed),0) from run_history");
-	last_ts = dbfile_query_u64(sq, "select ifnull(max(ts),0) from run_history");
+	compute_dup_summary(sq, &groups, &dupfiles, &reclaimable, NULL, 0, NULL);
 
 	printf("{\n  \"hashfile\": ");
 	print_json_str(filename);
@@ -486,9 +470,9 @@ static int print_metrics_json(char *filename)
 	printf("  \"dup_files\": %"PRIu64",\n", dupfiles);
 	/* Logical upper bound; real disk freed is smaller on compressed fs. */
 	printf("  \"reclaimable_logical_bytes\": %"PRIu64",\n", reclaimable);
-	printf("  \"runs\": %"PRIu64",\n", runs);
-	printf("  \"reclaimed_total_bytes\": %"PRIu64",\n", reclaimed_total);
-	printf("  \"last_run_ts\": %"PRId64"\n", last_ts);
+	printf("  \"runs\": %"PRIu64",\n", sum.runs);
+	printf("  \"reclaimed_total_bytes\": %"PRIu64",\n", sum.total_reclaimed);
+	printf("  \"last_run_ts\": %"PRId64"\n", sum.last_ts);
 	printf("}\n");
 	return 0;
 }
@@ -850,23 +834,24 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		stdin_filelist = 1;
 
 	/* -L/-R/--stats/--history/--json are exclusive read-only report modes. */
-	if (list_only_opt + rm_only_opt + stats_only_opt + history_only_opt
-			+ json_only_opt > 1) {
+	unsigned int report_count = list_only_opt + rm_only_opt + stats_only_opt
+				  + history_only_opt + json_only_opt;
+	/* Every report mode but -R takes no file list. */
+	bool nofile_report = report_count && !rm_only_opt;
+
+	if (report_count > 1) {
 		eprintf("Error: use only one of '-L', '-R', '--stats', "
 			"'--history', '--json'.\n");
 		return 1;
 	}
 
-	if (list_only_opt || rm_only_opt || stats_only_opt || history_only_opt
-			|| json_only_opt) {
+	if (report_count) {
 		if (!options.hashfile) {
 			eprintf("Error: --hashfile= option is required with "
 				"'-L', '-R', '--stats', '--history' or '--json'.\n");
 			return 1;
 		}
-
-		/* Only -R consumes a file list; the report modes do not. */
-		if (!rm_only_opt && numfiles) {
+		if (nofile_report && numfiles) {
 			eprintf("Error: -L/--stats/--history/--json do not take "
 				"a file list argument\n");
 			return 1;
@@ -878,8 +863,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 	 * scan config stored in the hashfile. Without a hashfile there is nothing
 	 * to replay, so a file list is still required.
 	 */
-	if (!(list_only_opt || stats_only_opt || history_only_opt || json_only_opt)
-			&& numfiles == 0 && !options.hashfile) {
+	if (!nofile_report && numfiles == 0 && !options.hashfile) {
 		eprintf("Error: a file list argument is required.\n");
 		return 1;
 	}
@@ -1041,7 +1025,8 @@ static void process_duplicates(struct dbhandle *db)
 		extents_search_free();
 }
 
-static int scan_files(char **roots, int nroots, struct dbhandle *db)
+static int scan_files(char **roots, int nroots, struct dbhandle *db,
+		      uint64_t *files_scanned)
 {
 	int ret;
 
@@ -1064,6 +1049,13 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db)
 	filescan_free();
 	if (!quiet)
 		pscan_join();
+
+	/*
+	 * Latch the per-run file count here, while the scan owns the progress
+	 * counters: the dedupe phase reuses them, so a later read would be 0.
+	 */
+	if (files_scanned)
+		*files_scanned = pscan_files_scanned();
 
 	if (ret)
 		return ret;
@@ -1284,12 +1276,9 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	ret = scan_files(roots, numfiles, db);
+	ret = scan_files(roots, numfiles, db, &files_scanned);
 	if (ret)
 		goto out;
-
-	/* Capture now: the dedupe phase reuses the scan progress counters. */
-	files_scanned = pscan_files_scanned();
 
 	/* Remember this run so a later bare `oans --hashfile=X` replays it. */
 	if (!replaying && !stdin_filelist && options.hashfile)

--- a/src/progress.c
+++ b/src/progress.c
@@ -112,6 +112,13 @@ void pscan_examined(void)
 	pscan.files_examined++;	/* listing is single-threaded; plain ++ is fine */
 }
 
+/* Files that needed (re)hashing this run - the work actually done, and unlike
+ * files_examined it is not periodically cleared by the progress renderer. */
+uint64_t pscan_files_scanned(void)
+{
+	return pscan.total_files_count;
+}
+
 #define BUF_LEN 10*1024
 /*
  * Fit `path` into at most `cols` columns by replacing its middle with a

--- a/src/progress.h
+++ b/src/progress.h
@@ -48,6 +48,7 @@ void pscan_set_progress(uint64_t added_files, uint64_t added_bytes);
 
 /* Count one file visited by the listing walk (scanned or skipped as up-to-date). */
 void pscan_examined(void);
+uint64_t pscan_files_scanned(void);
 
 /* Used by each scan threads to grab its own struct pscan_thread */
 struct pscan_thread *pscan_register_thread(pid_t tid);

--- a/tests/integration/test_history_metrics.py
+++ b/tests/integration/test_history_metrics.py
@@ -1,0 +1,87 @@
+"""Run history (recorded in the hashfile) and the machine-readable --json export.
+
+Each run appends a row to run_history; `--history` prints the timeline and
+lifetime totals; `--json` emits a flat metrics object (current stats + history
+totals) for dashboards.
+"""
+
+import json
+import os
+
+from harness import DuperemoveTest, requires_reflink
+
+
+class HistoryTest(DuperemoveTest):
+    def _seed(self, name="tree", n=3):
+        d = self.path(name)
+        os.makedirs(d)
+        for i in range(n):
+            self.write(f"{name}/f{i}", os.urandom(65536))
+        return d
+
+    def test_a_row_is_recorded_per_run(self):
+        d = self._seed()
+        self.dm("-r", d)
+        self.assertEqual(self.hf_count("run_history"), 1)
+        self.dm("-r", d)
+        self.assertEqual(self.hf_count("run_history"), 2)
+
+    def test_history_view_reports_runs_and_total(self):
+        d = self._seed()
+        self.dm("-r", d)
+        self.dm("-r", d)
+
+        self.dm("--history")
+        self.assertDmOk()
+        self.assertIn("oans history", self.out)
+        self.assertIn("2 runs", self.out)
+        self.assertIn("reclaimed", self.out)
+
+    def test_history_empty_before_any_run(self):
+        # A hashfile that exists but has no recorded runs yet.
+        d = self._seed()
+        self.dm("-r", d)
+        # Wipe the history rows to simulate a pre-feature / empty file.
+        import sqlite3
+        con = sqlite3.connect(self.hf)
+        con.execute("delete from run_history")
+        con.commit()
+        con.close()
+
+        self.dm("--history")
+        self.assertIn("no runs recorded", self.out)
+
+    def test_json_is_valid_and_has_expected_fields(self):
+        d = self._seed(n=4)
+        self.dm("-r", d)
+
+        self.dm("--json")
+        self.assertDmOk()
+        obj = json.loads(self.out)
+        for key in ("hashfile", "format", "files_tracked", "files_hashed",
+                    "logical_bytes", "dup_groups", "reclaimable_logical_bytes",
+                    "runs", "reclaimed_total_bytes", "last_run_ts"):
+            self.assertIn(key, obj)
+        self.assertEqual(obj["files_tracked"], 4)
+        self.assertEqual(obj["runs"], 1)
+        self.assertGreater(obj["last_run_ts"], 0)
+
+    def test_reports_require_hashfile(self):
+        for flag in ("--history", "--json"):
+            self.dm(flag, hashfile=False)
+            self.assertNotEqual(self.rc, 0, flag)
+            self.assertIn("hashfile", self.out)
+
+
+@requires_reflink
+class HistoryReclaimTest(DuperemoveTest):
+    def test_lifetime_reclaimed_accumulates_across_runs(self):
+        a, b = self.mkdup("a", "b", 1 << 20)
+        self.dm("-rd", self.path("."))          # reclaims one 1 MiB copy
+        first = json.loads(self.dm("--json"))["reclaimed_total_bytes"]
+        self.assertGreater(first, 0)
+
+        c, e = self.mkdup("c", "e", 1 << 20)     # a second reclaimable pair
+        self.dm("-rd", self.path("."))
+        second = json.loads(self.dm("--json"))["reclaimed_total_bytes"]
+        self.assertGreater(second, first)


### PR DESCRIPTION
## What

Two of the "make it sticky" ideas: the hashfile now remembers what every run did, and exposes it for humans and machines.

Each run appends a row to a new `run_history` table (timestamp, duration, files hashed, bytes reclaimed, dedupe groups, kernel bytes, dedupe-vs-scan). Two read-only report modes read it:

- **`oans --history --hashfile=X`** — a human timeline:
  ```
  oans history  /data.hash
    since        2026-01-03  (37 runs)
    reclaimed    412.0 GiB total
    files seen   6,204,110 (cumulative)

    recent   date · reclaimed · elapsed · files · mode
      2026-07-17 14:22     2.1 GiB     92.1s     173004  dedupe
      ...
  ```
- **`oans --json --hashfile=X`** — a flat metrics object (current stats + lifetime history totals) for `jq` / Telegraf / a node_exporter textfile:
  ```json
  { "files_tracked": 7, "dup_groups": 3, "reclaimable_logical_bytes": 6000000,
    "runs": 3, "reclaimed_total_bytes": 12000000, "last_run_ts": 1784317648, ... }
  ```

## Why

These report *what actually happened* (always exact), which is the retention/observability hook for the self-hosted crowd — and, unlike a savings *preview*, has no accuracy caveats. `--reclaimable_logical_bytes` is explicitly labelled logical (an upper bound; smaller on disk under compression).

## Notes / decisions

- **files-scanned** is captured right after the scan, before the dedupe phase reuses the shared progress counters. It records `total_files_count` (files that needed hashing this run) — `files_examined` was unusable because the progress renderer periodically zeroes it.
- **Additive schema** (`CREATE TABLE IF NOT EXISTS run_history`), so no `DB_FILE_MINOR` bump — existing hashfiles gain the table on open, old binaries ignore it (same approach as the self-describing feature).
- New modes are mutually exclusive with `-L`/`-R`/`--stats` and require `--hashfile`.
- A small `compute_dup_summary` helper is shared for the duplicate totals; `print_json_str` does minimal JSON string escaping for the path.

## Verification

Via `scripts/verify.sh`: 0 `-Wextra` warnings, **78/78** integration (6 new), unit 6/6, valgrind clean on scan/dedupe/replay and on both `--history` and `--json`. Docs (man + README), zsh completion, and man page regenerated.