### PR TITLE
tests: gate least-fragmented-target test on btrfs so it skips on xfs

### DIFF
--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -144,6 +144,26 @@ requires_reflink = unittest.skipUnless(
 
 
 # --------------------------------------------------------------------------
+# Filesystem type probe
+# --------------------------------------------------------------------------
+
+def scratch_fstype(directory=TEST_ROOT):
+    """Filesystem type of the scratch dir, per `stat -f` (e.g. 'btrfs', 'xfs')."""
+    os.makedirs(directory, exist_ok=True)
+    return subprocess.run(["stat", "-f", "-c", "%T", directory],
+                          capture_output=True, text=True).stdout.strip()
+
+
+# btrfs is copy-on-write, so an in-place overwrite of alternate blocks splits a
+# file into many physical extents. xfs (even with reflink) overwrites in place
+# and stays one extent, so tests that need to *build* a fragmented file can only
+# run on btrfs. (btrfs is reflink-capable, so this implies @requires_reflink.)
+BTRFS = scratch_fstype() == "btrfs"
+requires_btrfs = unittest.skipUnless(
+    BTRFS, "test needs btrfs (copy-on-write fragmentation)")
+
+
+# --------------------------------------------------------------------------
 # Base test case
 # --------------------------------------------------------------------------
 

--- a/tests/integration/test_least_fragmented_target.py
+++ b/tests/integration/test_least_fragmented_target.py
@@ -1,16 +1,17 @@
 """Whole-file dedupe should target the least-fragmented copy, so the other
 copies don't inherit a bad on-disk layout (and the dedupe stays cheap).
 
-Requires a reflink-capable filesystem.
+Requires btrfs: the setup builds a fragmented file by overwriting alternate
+blocks in place, which only splits into many extents under copy-on-write.
 """
 
 import os
-from harness import DuperemoveTest, requires_reflink, fiemap_extents
+from harness import DuperemoveTest, requires_btrfs, fiemap_extents
 
 MiB = 1 << 20
 
 
-@requires_reflink
+@requires_btrfs
 class LeastFragmentedTargetTest(DuperemoveTest):
     def _fragment(self, rel, content):
         """Write content, then rewrite alternate 4K blocks in place (COW) so the


### PR DESCRIPTION
## Problem

`test_dedupe_prefers_contiguous_target` builds a fragmented file by overwriting alternate 4K blocks in place, relying on the result splitting into >100 physical extents. That only happens under **copy-on-write (btrfs)**. On xfs (even with reflink) the overwrite is in place and the file stays a single extent, so the test's own setup assertion fails:

```
FAIL: test_dedupe_prefers_contiguous_target
  AssertionError: 1 not greater than 100 : setup: frag is fragmented
```

The test was decorated `@requires_reflink`, which xfs satisfies, so it **ran and failed** on xfs instead of skipping. (On btrfs it passes — CI is btrfs-backed, so this never showed up there.)

## Fix

- Add a `scratch_fstype()` probe and a `@requires_btrfs` decorator to `harness.py`, mirroring the existing `@requires_reflink` (btrfs is reflink-capable, so `requires_btrfs` implies `requires_reflink`).
- Gate `LeastFragmentedTargetTest` on `@requires_btrfs`, with a docstring explaining the COW dependency.

Now the test runs on btrfs and **skips cleanly** on non-btrfs reflink filesystems (e.g. xfs).

## Verification

On an xfs reflink loopback the test previously failed; it now reports `OK (skipped=1)`, both in isolation and in the full suite. On btrfs it still runs normally (`stat -f` reports `btrfs`). No production code is touched — this is test-harness robustness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdsR67KuzzTDY53GB3u9i7)_