### PR TITLE
systemd timer templates for scheduled deduplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ uninstall:
 # Optional: the systemd@ template units for scheduled dedupe (see
 # systemd/README.md). Not part of `install` so it never assumes systemd.
 # ExecStart is rewritten to the real install path ($(BINDIR)/oans).
-.PHONY: install-systemd
 install-systemd:
 	install -d $(DESTDIR)$(UNITDIR)
 	sed 's|/usr/bin/oans|$(BINDIR)/oans|' systemd/oans@.service \

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ PREFIX  ?= /usr/local
 BINDIR  = $(PREFIX)/bin
 MANDIR  = $(PREFIX)/share/man/man8
 ZSHDIR  = $(PREFIX)/share/zsh/site-functions
+UNITDIR ?= $(PREFIX)/lib/systemd/system
 
 all: oans
 
@@ -92,6 +93,19 @@ uninstall:
 	rm -f $(DESTDIR)$(MANDIR)/oans.8 $(DESTDIR)$(MANDIR)/duperemove.8
 	rm -f $(DESTDIR)$(ZSHDIR)/_oans
 
+# Optional: the systemd@ template units for scheduled dedupe (see
+# systemd/README.md). Not part of `install` so it never assumes systemd.
+# ExecStart is rewritten to the real install path ($(BINDIR)/oans).
+.PHONY: install-systemd
+install-systemd:
+	install -d $(DESTDIR)$(UNITDIR)
+	sed 's|/usr/bin/oans|$(BINDIR)/oans|' systemd/oans@.service \
+		> $(DESTDIR)$(UNITDIR)/oans@.service
+	install -m 0644 systemd/oans@.timer $(DESTDIR)$(UNITDIR)/oans@.timer
+
+uninstall-systemd:
+	rm -f $(DESTDIR)$(UNITDIR)/oans@.service $(DESTDIR)$(UNITDIR)/oans@.timer
+
 # The man page is committed, so building and installing never need pandoc;
 # `make doc` regenerates it from the markdown source (for maintainers).
 .PHONY: doc
@@ -101,7 +115,8 @@ doc:
 DIST         = oans-$(VERSION)
 DIST_TARBALL = $(VERSION).tar.gz
 DIST_SOURCES = $(CFILES) $(sort $(wildcard src/*.h)) LICENSE Makefile \
-	README.md docs/man/oans.md $(MANPAGE) $(COMPLETION)
+	README.md docs/man/oans.md $(MANPAGE) $(COMPLETION) \
+	systemd/oans@.service systemd/oans@.timer systemd/README.md
 
 # Source tarball with the resolved version embedded, so tarball builds (no
 # .git) still report it. --parents keeps the src/, docs/, completion/ layout.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ and filesystem.
   excludes, so `oans --hashfile=FILE` with no arguments replays the last run —
   a cron job need only name the hashfile. If the stored paths have all vanished
   (e.g. an unmounted drive) it refuses rather than pruning the hashfile.
+- **systemd timer templates** for set-and-forget scheduled dedupe: set a job up
+  once, `systemctl enable --now oans@<name>.timer`, and it re-deduplicates that
+  tree weekly. See [`systemd/`](systemd/README.md).
 
 ### Testing
 
@@ -131,11 +134,12 @@ reclaimed space, compare `compsize` **Disk Usage** before and after a run;
 ```sh
 make            # build oans
 make check      # C unit tests + Python integration suite
-sudo make install   # installs oans + a duperemove compat symlink
+sudo make install           # installs oans + a duperemove compat symlink
+sudo make install-systemd   # optional: the oans@ timer/service templates
 ```
 
 Sources live under `src/`; man page sources under `docs/man/`; the integration
-suite under `tests/`.
+suite under `tests/`; the systemd units under `systemd/`.
 
 ## Usage
 

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -332,6 +332,22 @@ metrics for a dashboard:
 oans \-\-history \-\-hashfile=foo.hash
 oans \-\-json \-\-hashfile=foo.hash | jq .reclaimed_total_bytes
 .EE
+.SS Scheduled deduplication
+Because a hashfile is self\-describing, a scheduled run only needs to
+name it.
+oans ships systemd template units (\f[CR]oans\[at].service\f[R] /
+\f[CR]oans\[at].timer\f[R], installed by
+\f[CR]make install\-systemd\f[R]) for exactly this.
+Set a job up once, then enable its timer:
+.IP
+.EX
+oans \-dr \-\-hashfile=/var/cache/oans/media.hash /srv/media
+systemctl enable \-\-now oans\[at]media.timer
+.EE
+.PP
+The timer re\-deduplicates \f[CR]/srv/media\f[R] weekly, hashing only
+what changed.
+See \f[CR]systemd/README.md\f[R] in the source tree for the full guide.
 .SH FAQ
 .SS Is oans safe for my data?
 Yes.

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -288,6 +288,19 @@ for a dashboard:
 	oans --history --hashfile=foo.hash
 	oans --json --hashfile=foo.hash | jq .reclaimed_total_bytes
 
+## Scheduled deduplication
+
+Because a hashfile is self-describing, a scheduled run only needs to name it.
+oans ships systemd template units (`oans@.service` / `oans@.timer`, installed
+by `make install-systemd`) for exactly this. Set a job up once, then enable its
+timer:
+
+	oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
+	systemctl enable --now oans@media.timer
+
+The timer re-deduplicates `/srv/media` weekly, hashing only what changed. See
+`systemd/README.md` in the source tree for the full guide.
+
 # FAQ
 
 ## Is oans safe for my data?

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,80 @@
+# Running oans on a schedule (systemd)
+
+These two template units turn oans into a set-and-forget background job: pick a
+directory tree once, then let a timer re-deduplicate it (weekly by default),
+picking up only what changed since last time.
+
+They lean on the **self-describing hashfile** — a normal run records its
+options, paths and excludes in the hashfile, so the scheduled run only needs to
+name that file (`oans --hashfile=FILE`).
+
+- `oans@.service` — a `oneshot` service; instance `%i` maps to
+  `/var/cache/oans/%i.hash`.
+- `oans@.timer` — the matching weekly trigger.
+
+## Install
+
+If you built from source:
+
+```sh
+sudo make install-systemd          # installs both units (see the note on paths)
+```
+
+Or copy them by hand into your system unit directory (usually
+`/usr/lib/systemd/system` or `/etc/systemd/system`) and run
+`sudo systemctl daemon-reload`.
+
+> The unit ships with `ExecStart=/usr/bin/oans …`. `make install-systemd`
+> rewrites that to wherever the binary actually lands (`$(PREFIX)/bin/oans`).
+> If you install the units by hand and oans is elsewhere, edit `ExecStart`.
+
+## Set up a job
+
+Give the job a short name (here `media`) and do the first run yourself, naming
+the tree and any options you want — this creates the hashfile **and** records
+the configuration the timer will replay:
+
+```sh
+sudo install -d -m 0755 /var/cache/oans
+sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
+```
+
+Then enable the timer for that job:
+
+```sh
+sudo systemctl enable --now oans@media.timer
+```
+
+That's it. Every week oans re-scans `/srv/media`, hashes only changed/new
+files, and deduplicates. To change what a job does, just re-run the setup
+command with new paths/options — the hashfile remembers the latest.
+
+## Operate
+
+```sh
+systemctl list-timers 'oans@*'            # when each job next runs
+systemctl start oans@media.service        # run one now, out of band
+journalctl -u oans@media.service          # see what a run did
+oans --history --hashfile=/var/cache/oans/media.hash   # reclaimed-over-time
+```
+
+## Tuning
+
+- **Frequency**: `sudo systemctl edit oans@media.timer` and override
+  `OnCalendar=` (e.g. `daily`, `Mon *-*-* 03:00:00`). Per-job overrides work
+  because each instance is its own unit.
+- **Politeness**: the service already runs at `Nice=19` / `IOSchedulingClass=idle`
+  so it yields to interactive work. Override with `systemctl edit` if needed.
+- **Read-only report instead of dedupe**: set the job up without `-d`
+  (`oans -r --hashfile=…`) and the scheduled runs will only refresh hashes and
+  report, never change data.
+
+## Notes
+
+- The service runs as **root** so it can read and re-extent files anywhere in
+  the configured tree. It does no path sandboxing for that reason.
+- Deduplication only ever adjusts extent sharing through the kernel's
+  byte-verified `FIDEDUPERANGE` ioctl, so an interrupted run can waste work but
+  never corrupt data.
+- The hashfile under `/var/cache/oans` is just a cache; deleting it only forces
+  the next run to re-hash from scratch.

--- a/systemd/oans@.service
+++ b/systemd/oans@.service
@@ -1,0 +1,32 @@
+# oans deduplication for one hashfile "job".
+#
+# The instance name %i selects the hashfile /var/cache/oans/%i.hash. Set that
+# hashfile up once with a normal run naming the paths to dedupe, then enable the
+# matching timer - see systemd/README.md. Because the hashfile is
+# self-describing, this unit needs no arguments beyond it: `oans --hashfile=FILE`
+# replays the options, paths and excludes of that first run.
+#
+# Example: `systemctl start oans@media` deduplicates using
+# /var/cache/oans/media.hash.
+
+[Unit]
+Description=oans deduplication (%i)
+Documentation=man:oans(8) https://github.com/martinus/oans
+# Nothing to do until the hashfile has been set up (skip cleanly, don't fail).
+ConditionPathExists=/var/cache/oans/%i.hash
+
+[Service]
+Type=oneshot
+# Background maintenance: yield CPU and disk to everything interactive.
+Nice=19
+IOSchedulingClass=idle
+# Manage /var/cache/oans (created 0755, owned by this unit's user - root).
+CacheDirectory=oans
+# Replays the stored scan (self-describing hashfile); --quiet keeps the journal
+# to a short summary. Runs as root so it can read and re-extent the configured
+# tree wherever it lives.
+ExecStart=/usr/bin/oans --quiet --hashfile=/var/cache/oans/%i.hash
+# Deduplication only ever rewrites extent sharing via the byte-verified
+# FIDEDUPERANGE ioctl, so an interrupted run is safe; allow a clean stop.
+TimeoutStopSec=30
+NoNewPrivileges=true

--- a/systemd/oans@.timer
+++ b/systemd/oans@.timer
@@ -1,0 +1,16 @@
+# Periodic trigger for oans@%i.service. Enable one per hashfile "job", e.g.
+# `systemctl enable --now oans@media.timer`. See systemd/README.md.
+
+[Unit]
+Description=Weekly oans deduplication (%i)
+Documentation=man:oans(8) https://github.com/martinus/oans
+
+[Timer]
+OnCalendar=weekly
+# Catch up on the next boot if the machine was off when it was due.
+Persistent=true
+# Spread the load a little so several jobs don't all fire at once.
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

`oans@.service` + `oans@.timer` template units so a hashfile can be re-deduplicated on a schedule without bespoke cron scripting — the last of the "set-and-forget" ideas, and the natural payoff of the self-describing hashfile.

The instance name is the job: `oans@media` uses `/var/cache/oans/media.hash`. Since the hashfile records its own options and paths, the service just runs `oans --hashfile=FILE` and replays them.

```sh
sudo install -d -m 0755 /var/cache/oans
sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media   # set up once
sudo systemctl enable --now oans@media.timer                     # weekly from here
```

## Details

- **`oans@.service`** — `Type=oneshot`, `Nice=19` / `IOSchedulingClass=idle` (background citizen), `CacheDirectory=oans`, `ConditionPathExists=/var/cache/oans/%i.hash` so a not-yet-set-up job skips cleanly instead of failing weekly. Runs as root (it must read and re-extent the configured tree) and does no path sandboxing for that reason.
- **`oans@.timer`** — `OnCalendar=weekly`, `Persistent=true`, `RandomizedDelaySec=30min`. Per-job frequency overrides via `systemctl edit oans@<name>.timer`.
- **`make install-systemd`** installs both (kept *out* of `make install` so the default install never assumes systemd) and rewrites `ExecStart` to the real `$(BINDIR)/oans`.
- **`systemd/README.md`** — setup / operate / tuning guide (including a read-only "report, don't dedupe" variant and `--history` for reclaimed-over-time).
- Units added to the dist tarball; feature documented in README + man page.

## Verification

- `systemd-analyze verify` passes on an instance of each unit (only the expected "binary/man not installed on this dev box" warnings).
- `make install-systemd` output checked for both `PREFIX=/usr` (→ `/usr/bin/oans`) and `/usr/local` (→ `/usr/local/bin/oans`).
- The exact `ExecStart` command (`oans --quiet --hashfile=…`) smoke-tested end to end: one-time setup dedupes, the replay nets 0 and exits 0, and `--history` shows both runs.
- No source changed; the C test suite (78/78) still passes and the tarball includes `systemd/`.