### PR TITLE
docs: NAS quick-start guide + consolidate CLAUDE.md working notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,30 @@ under `docs/man/`. The binary is `oans`; `make install` adds a `duperemove`
 compat symlink. Some identifiers keep the old name on purpose: the
 `DUPEREMOVE*` env vars and the `DuperemoveTest` python test base class.
 
+## Repo layout & workflow (read first)
+
+- **This checkout is a git *worktree*.** The default branch `master` is checked
+  out in a *sibling* worktree (`../duperemove-master`), so `git checkout master`
+  here fails ("already used by worktree"). To sync/branch from latest master:
+  `git fetch origin && git checkout --detach origin/master`, then
+  `git checkout -b <branch> origin/master`. After a branch is merged+deleted,
+  park this worktree with `git checkout --detach origin/master`.
+- **GitHub is a fork.** All `gh` commands need `--repo martinus/oans`
+  (`gh pr create --repo martinus/oans …`); a bare `gh pr create` fails.
+- **Never merge a PR without the user explicitly saying so** ("merge it"). The
+  established rhythm is: build on a branch → open a PR → wait. The user often
+  asks for a `/simplify` pass on the branch before merging.
+- **`scripts/verify.sh`** is the one-shot pre-PR gate: build (warnings = failure),
+  `make check`, and a valgrind scan+dedupe+replay smoke. Run it as
+  `PKG_CONFIG_PATH=/tmp/devroot/pc DUPEREMOVE_TEST_DIR=/home/martinus/.itest-scratch bash scripts/verify.sh`.
+- **`make doc`** (regenerate the man page from `docs/man/oans.md`) needs
+  `pandoc`, which isn't always installed; a static build was fetched to
+  `/tmp/pandoc-3.6.4/bin` (ephemeral — re-fetch if `/tmp` was cleared) and run as
+  `PATH=/tmp/pandoc-3.6.4/bin:$PATH make doc`. roff escapes `-` as `\-`, so grep
+  the generated `.8` accordingly.
+- Confirm you are testing *this* build (`./oans`), not a system-installed
+  `duperemove`, before diagnosing any runtime behaviour.
+
 ## Build & test
 
 ```sh
@@ -20,7 +44,15 @@ DUPEREMOVE=./oans python3 tests/run.py           # integration suite only
 Integration tests are Python stdlib `unittest` (no extra deps); they drive the
 built binary against a scratch tree and assert on the hashfile and on-disk
 sharing. Dedupe cases need a reflink-capable fs — override with
-`DUPEREMOVE_TEST_DIR=/mnt/btrfs`. Keep tests in `tests/`; don't add shell tests.
+`DUPEREMOVE_TEST_DIR=/mnt/btrfs` (this box: `/home/martinus/.itest-scratch`, on
+btrfs). Keep tests in `tests/`; don't add shell tests.
+
+- **Don't run scans/benchmarks out of `/tmp` — it's tmpfs**, which is not
+  reflink-capable and which `is_fs_supported()` rejects, so a scan there stores
+  **0 files silently** and dedupe is a no-op. Always point test data and
+  `DUPEREMOVE_TEST_DIR` at real btrfs/xfs, and verify a non-zero file count
+  before trusting any before/after comparison. (The `~/git` tree, ~174k files on
+  btrfs, is the usual real-data benchmark target.)
 
 ### Building on Fedora
 
@@ -134,6 +166,70 @@ site.
   throughput numbers are pure process-startup noise. The *mechanism* still
   runs; real numbers need a btrfs/xfs target.
 
+## Self-describing hashfile, history & scheduling (fork features)
+
+These are the fork's user-facing additions on top of upstream; a fresh session
+should know they exist before touching option parsing or `dbfile`.
+
+- **Self-describing hashfile.** Every run stores its scan-shaping options
+  (`-d`, `-r`, `--skip-zeroes`, `--min-filesize`, `--dedupe-options`), its roots
+  (canonicalised via `realpath`), and its `--exclude` patterns — options as
+  `opt_*` keys in `config`, roots/excludes in the `scan_roots`/`scan_excludes`
+  tables (`dbfile_store_scan_config`/`dbfile_load_scan_config`). A bare
+  `oans --hashfile=FILE` (no file args) **replays** the last run
+  (`apply_scan_config` + `drop_missing_roots` in `oans.c`). Semantics:
+  last-run-wins; other options on a bare-replay line are ignored; if a stored
+  root is missing it's skipped with a warning, and if *all* are gone oans
+  refuses (so the stat-based prune can't wipe the hashfile — e.g. an unmounted
+  drive); a replay does not re-persist (a transiently-missing root is retried
+  next time). Pinned by `test_self_describing.py`.
+- **Run history & metrics.** Each run appends a row to `run_history`
+  (`dbfile_record_run`, called from `main()` after `process_duplicates`).
+  `--history` prints a human timeline + lifetime totals; `--json` prints a flat
+  metrics object (current stats + history totals) for jq/Telegraf/node_exporter.
+  Totals go through `dbfile_get_run_summary`. Gotcha: capture the per-run
+  file count via `pscan_files_scanned()` **inside `scan_files`** (an out-param) —
+  the dedupe phase reuses the progress counters, and `pscan.files_examined` is
+  cleared ~10×/s by the renderer so it is *not* a usable total. Pinned by
+  `test_history_metrics.py`.
+- **`--stats`** prints the hashfile report (identity, stored scan config, file
+  and duplicate counts). `-L` lists files; `-R` removes paths. `-L`/`-R`/
+  `--stats`/`--history`/`--json`/`--autotune` are mutually-exclusive report
+  modes (collapsed into one `report_count` check in `parse_options`).
+- **Scheduling.** `systemd/oans@.service` + `oans@.timer` (installed by
+  `make install-systemd`, kept out of `make install`) run
+  `oans --hashfile=/var/cache/oans/%i.hash` on a timer, replaying the stored
+  config. User guide: `docs/nas-quickstart.md`.
+- The `fdupes` mode was **removed** (redundant with the core scan+dedupe); don't
+  reintroduce it.
+
+## Measured dead-ends — don't re-attempt without new evidence
+
+Each of these was investigated/measured and rejected; re-deriving them wastes a
+session (see the profiling rules above — measure, don't guess):
+
+- **Warm rescan is single-consumer pipeline-latency-bound**, not
+  CPU/query-bound. A no-op rescan of ~174k files is ~2s wall / ~0.9s CPU,
+  invariant to `--io-threads` (1..16) and CPU count — the serial consumer
+  (`__scan_file`: queue handoff + per-file `dbfile_describe_file`) sets the
+  floor. `dbfile_describe_file` is only ~0.12s of CPU.
+- **Bulk in-memory change-detection cache** (preload the `files` table into a
+  hash to skip the per-file `describe_file` query) was prototyped and
+  **measured a regression** (2.0s→3.1s): the query isn't the bottleneck, and the
+  upfront load adds ~1s. Rejected.
+- **statx-relative-to-dir-fd** (avoid re-resolving the absolute path per file)
+  gave ~5-8% less scan *CPU* but **zero wall-clock** change (walk isn't the
+  wall bottleneck); PR was closed as not worth it.
+- **A savings "preview"/dry-run is not worth building.** You can't predict real
+  reclaimed disk without doing the dedupe (compression, extent alignment, the
+  kernel declining a dedupe, and especially snapshot/external refcounts), and
+  dedupe is already safe + self-reporting, so "just run it" wins. `--stats`
+  already reports the logical upper bound.
+- **"Biggest-savings-first" dedupe order already exists**: `push_extents`
+  (`run_dedupe.c`) qsorts groups by `cmp_dext_work` = `de_len*(de_num_dupes-1)`
+  (reclaimable bytes, descending) before dispatching to the pool. Only caveat is
+  it's per generation-pass, not global — not worth changing.
+
 ## dedupe_seq (incremental dedup)
 
 Scan assigns `seq = config+1`, bumped every `--batchsize`/`-B` files (default
@@ -179,8 +275,18 @@ OANS_APP_ID` ("oans" in ASCII) and `dbfile_check()` **strictly** refuses any fil
 that doesn't carry the brand — foreign, or a pre-brand/duperemove file. A
 brand-new empty file (`dbfile_config_empty()`) is stamped *before* the check, so
 a fresh scan doesn't recreate-loop; existing files must already carry the brand.
-A failed check unlinks and recreates the hashfile (it's only a cache). Bump
-`DB_FILE_MINOR` on any schema change.
+A failed check unlinks and recreates the hashfile (it's only a cache).
+
+**On schema changes and `DB_FILE_MINOR`:** `dbfile_check()` rejects a file whose
+`minor` differs, which *discards and rebuilds* it — so a bump forces every
+existing hashfile to be re-scanned from scratch. Therefore bump `DB_FILE_MINOR`
+**only** for a change an old binary could misread; do **not** bump for a purely
+*additive* change (a new `CREATE TABLE IF NOT EXISTS`, or a new optional key in
+the `config` table). `create_tables()` runs on every open, so additive tables
+appear on old files automatically and old binaries just ignore the extra
+rows/keys. The self-describing (`scan_roots`/`scan_excludes`), run-history
+(`run_history`), and autotune (`autotune_io_threads` config key) features were
+all added this way and left `DB_FILE_MINOR` at `5.0` on purpose.
 
 A from-scratch build (new hashfile or a recreated one) sets `hashfile_rebuilt`,
 which makes `dbfile_maybe_vacuum()` force a one-off `VACUUM` at the end: a fresh
@@ -194,3 +300,9 @@ still only VACUUM once ≥25% of the file is free.
   on process kill. Only power loss risks the hashfile (due to `synchronous=OFF`).
 - A no-op rescan must net **0** changes and leave row counts identical. Use this
   as a smoke test after any scan-path change.
+- **The "Deduplicated" figure is logical, not disk.** On a compressed btrfs
+  (e.g. `zstd`), dedupe frees *compressed* blocks but the reported number is the
+  *logical* (uncompressed) amount, so real disk reclaimed is ~ratio smaller. To
+  verify actual space freed, compare `compsize` **Disk Usage** before/after (not
+  `df`); `Referenced` staying constant proves nothing was lost. `--json`'s
+  `reclaimable_logical_bytes` is likewise a logical upper bound.

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ doc:
 DIST         = oans-$(VERSION)
 DIST_TARBALL = $(VERSION).tar.gz
 DIST_SOURCES = $(CFILES) $(sort $(wildcard src/*.h)) LICENSE Makefile \
-	README.md docs/man/oans.md $(MANPAGE) $(COMPLETION) \
+	README.md docs/man/oans.md docs/nas-quickstart.md $(MANPAGE) $(COMPLETION) \
 	systemd/oans@.service systemd/oans@.timer systemd/README.md
 
 # Source tarball with the resolved version embedded, so tarball builds (no

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Licensed under the **GNU General Public License, version 2** — see
 
 ## Links
 
+- [NAS quick start](docs/nas-quickstart.md) — set up scheduled dedupe on a NAS/server
 - [oans man page](docs/man/oans.md) — full reference
 - [Upstream duperemove](https://github.com/markfasheh/duperemove) — the original project
 - [Upstream wiki](https://github.com/markfasheh/duperemove/wiki) — design & performance notes

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -1,0 +1,111 @@
+# oans on a NAS — quick start
+
+A practical, copy-pasteable path to running oans as a scheduled deduplication
+job on a NAS or home server. It uses two features that make this painless: the
+**self-describing hashfile** (a run remembers its own options and paths) and
+**`--autotune`** (measures the fastest thread count for your disks).
+
+Throughout, replace `/srv/media` with your data directory and `media` with a
+short name for the job.
+
+## Step 0 — Check your filesystem (the dealbreaker)
+
+Deduplication only works on **btrfs** or **xfs**:
+
+```sh
+findmnt -no FSTYPE /srv/media      # or: stat -f -c %T /srv/media
+```
+
+- **btrfs / xfs** → you're good. (Most Synology volumes are btrfs.)
+- **zfs** → stop. oans cannot dedupe ZFS; use ZFS's own deduplication instead.
+  (This rules out a stock TrueNAS SCALE pool.)
+- **ext4 / other** → oans will scan and report, but cannot deduplicate.
+
+## Step 1 — Build and install
+
+There is no binary package yet, so build from source. You need a C toolchain
+(`gcc`, `make`, `pkg-config`) and development headers for glib2, sqlite3,
+libxxhash (≥ 0.8), util-linux (libuuid/libmount/libblkid) and libbsd.
+
+```sh
+make
+sudo make install            # installs the oans binary (+ duperemove symlink)
+sudo make install-systemd    # installs the oans@ timer/service templates
+```
+
+## Step 2 — Autotune the thread count for your disks
+
+Give the job a name and tune into the hashfile the timer will later use
+(`/var/cache/oans/<name>.hash`), so the measured value is reused by every run:
+
+```sh
+sudo install -d -m 0755 /var/cache/oans
+sudo oans --autotune --hashfile=/var/cache/oans/media.hash /srv/media
+```
+
+Run it **as root** — autotune drops the page cache between trials to get honest
+cold-read numbers, which matters a lot on spinning disks and RAID. It reads only
+a bounded sample (quick, not a full scan), prints a throughput-vs-threads table,
+and stores the winning `--io-threads` value in the hashfile. This is the
+reliable way to size threads for a NAS; without it, oans falls back to a
+storage-type heuristic whose HDD/RAID numbers are only educated guesses.
+
+## Step 3 — The first run (the slow one)
+
+```sh
+sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
+```
+
+This is the expensive pass: it hashes everything and deduplicates. It
+
+- reuses the thread count autotune stored in Step 2,
+- **records its options and paths** in the hashfile (this is what makes the
+  scheduled runs need no arguments), and
+- is safe to interrupt — the kernel does each dedupe atomically and
+  byte-verified, so Ctrl+C can only waste work, never corrupt data.
+
+Add `-v` once if you want to see the detected storage and the chosen thread
+count. Check the result:
+
+```sh
+oans --stats --hashfile=/var/cache/oans/media.hash
+```
+
+## Step 4 — Schedule it
+
+```sh
+sudo systemctl enable --now oans@media.timer
+```
+
+Done. Weekly from here, oans re-scans `/srv/media`, hashes only what changed,
+and deduplicates — with no arguments, because the hashfile remembers everything.
+To change the frequency, override `OnCalendar=`:
+
+```sh
+sudo systemctl edit oans@media.timer     # e.g. OnCalendar=daily
+```
+
+## Step 5 — Monitor
+
+```sh
+systemctl list-timers 'oans@*'                          # when it next runs
+journalctl -u oans@media.service                        # what the last run did
+oans --history --hashfile=/var/cache/oans/media.hash    # reclaimed over time
+oans --json    --hashfile=/var/cache/oans/media.hash    # metrics for a dashboard
+```
+
+## Notes for NAS users
+
+- **Run as root** so oans can read and re-extent every file in the tree.
+- **Multiple datasets:** repeat Steps 2–4 with different names (`oans@photos`,
+  `oans@backups`, …). Each is an independent timer you can schedule separately.
+- **Report-only mode:** set the job up with `-r` instead of `-dr` and the
+  scheduled runs will only refresh hashes and report, never change data.
+- **The hashfile is just a cache** (under `/var/cache/oans`). Deleting it only
+  forces the next run to re-hash from scratch; it can live on your system SSD,
+  separate from the data pool.
+- **Compressed btrfs:** the reported "Deduplicated" figure is *logical* — the
+  real disk space freed is smaller (roughly the compression ratio times that).
+  Compare `compsize` before and after for the true reclaimed amount.
+- **First run is slow, later runs are fast:** only changed/new files are
+  re-hashed, and files whose extents are already shared are skipped.


### PR DESCRIPTION
## What

- **`docs/nas-quickstart.md`** — a practical, copy-pasteable guide to running oans as a scheduled dedupe job on a NAS/server: check the filesystem (btrfs/xfs, not ZFS), build/install, `--autotune` the thread count, do the first run, enable the `oans@` timer, and monitor with `--history`/`--json`. Linked from the README and shipped in the source tarball.
- **CLAUDE.md** — folds the project's accumulated operating knowledge into the working-notes file so a fresh session starts effectively without rediscovering it: the git-worktree layout gotcha, `gh --repo` requirement, `scripts/verify.sh`, `make doc`/pandoc, the `/tmp`-is-tmpfs benchmark trap, a reconciled `DB_FILE_MINOR` rule (additive tables must **not** bump — it would discard every existing hashfile), a map of the fork features (self-describing hashfile, `--history`/`--json`, systemd scheduling), and the measured dead-ends not to re-attempt.

Docs/notes only — no source or behavior change. Build still succeeds and the tarball includes the new guide.