### PR TITLE
docs: list build dependencies with dnf/apt install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,29 @@ reclaimed space, compare `compsize` **Disk Usage** before and after a run;
 ## Requirements & building
 
 - Linux kernel 3.13 or later
-- GNU make, pkg-config
+- GNU make, a C compiler, pkg-config
 - glib2, sqlite3
-- libxxhash 0.8.0 or later (`libxxhash-dev` on Debian)
+- libxxhash 0.8.0 or later
 - util-linux (libuuid, libmount, libblkid)
-- libbsd (`libbsd-dev` on Debian)
+- libbsd
+
+Install the build dependencies:
+
+```sh
+# Fedora / RHEL
+sudo dnf install gcc make pkgconf-pkg-config \
+    glib2-devel sqlite-devel xxhash-devel \
+    libuuid-devel libmount-devel libblkid-devel libbsd-devel
+```
+
+```sh
+# Debian / Ubuntu
+sudo apt install build-essential pkg-config \
+    libglib2.0-dev libsqlite3-dev libxxhash-dev \
+    uuid-dev libmount-dev libblkid-dev libbsd-dev
+```
+
+Then build and install:
 
 ```sh
 make            # build oans

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -23,9 +23,24 @@ findmnt -no FSTYPE /srv/media      # or: stat -f -c %T /srv/media
 
 ## Step 1 — Build and install
 
-There is no binary package yet, so build from source. You need a C toolchain
-(`gcc`, `make`, `pkg-config`) and development headers for glib2, sqlite3,
-libxxhash (≥ 0.8), util-linux (libuuid/libmount/libblkid) and libbsd.
+There is no binary package yet, so build from source. Install the build
+dependencies first:
+
+```sh
+# Fedora / RHEL
+sudo dnf install gcc make pkgconf-pkg-config \
+    glib2-devel sqlite-devel xxhash-devel \
+    libuuid-devel libmount-devel libblkid-devel libbsd-devel
+```
+
+```sh
+# Debian / Ubuntu
+sudo apt install build-essential pkg-config \
+    libglib2.0-dev libsqlite3-dev libxxhash-dev \
+    uuid-dev libmount-dev libblkid-dev libbsd-dev
+```
+
+Then build and install:
 
 ```sh
 make


### PR DESCRIPTION
Adds copy-pasteable install commands for the build dependencies to the README's *Requirements & building* section and to `docs/nas-quickstart.md`, instead of only naming the libraries.

```sh
# Fedora / RHEL
sudo dnf install gcc make pkgconf-pkg-config \
    glib2-devel sqlite-devel xxhash-devel \
    libuuid-devel libmount-devel libblkid-devel libbsd-devel
```

```sh
# Debian / Ubuntu
sudo apt install build-essential pkg-config \
    libglib2.0-dev libsqlite3-dev libxxhash-dev \
    uuid-dev libmount-dev libblkid-dev libbsd-dev
```

Docs only — no code change. The Fedora list is the one confirmed working on a real build.