### PR TITLE
Fix autotune/replay/progress UX from NAS feedback

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -197,17 +197,23 @@ the real disk space freed is smaller on a compressed filesystem.
 Requires the \f[CR]\-\-hashfile\f[R] option.
 .TP
 \f[B]\-\-autotune\f[R] \f[CR]files/dirs ..\f[R]
-Measure the fastest \f[CR]\-\-io\-threads\f[R] for this machine and exit.
-oans reads and hashes a bounded sample of the given tree at several thread
-counts, dropping the page cache between trials (run as root for meaningful
-cold\-read numbers on spinning disks), and prints a throughput table with the
-best value.
-When \f[CR]\-\-hashfile\f[R] is given the winner is stored in that hashfile, so
-later runs against it use that thread count automatically unless you pass an
-explicit \f[CR]\-\-io\-threads\f[R].
-This is the hardware\-measured counterpart to the automatic storage heuristic
-(see \f[CR]\-\-io\-threads\f[R]); it is the reliable way to find the optimum for
-a NAS or multi\-disk array.
+Measure the fastest \f[CR]\-\-io\-threads\f[R] for this machine and
+exit.
+oans reads and hashes a bounded sample of the given tree at several
+thread counts, dropping the page cache between trials (run as root for
+meaningful cold\-read numbers on spinning disks), printing each trial as
+it runs and then a throughput table with the best value.
+Directories are always sampled recursively (the sample is about the
+storage, not the \f[CR]\-r\f[R] flag).
+When \f[CR]\-\-hashfile\f[R] is given the winner is stored in that
+hashfile, so later runs against it use that thread count automatically
+unless you pass an explicit \f[CR]\-\-io\-threads\f[R]; the scan
+configuration (paths and any \f[CR]\-d\f[R]/\f[CR]\-r\f[R]/\&...
+you passed) is stored too, so autotune doubles as setup \[em] a later
+bare \f[CR]oans \-\-hashfile=FILE\f[R] replays it.
+This is the hardware\-measured counterpart to the automatic storage
+heuristic (see \f[CR]\-\-io\-threads\f[R]); it is the reliable way to
+find the optimum for a NAS or multi\-disk array.
 The sample bounds can be tuned with the
 \f[CR]DUPEREMOVE_AUTOTUNE_MAX_FILES\f[R],
 \f[CR]DUPEREMOVE_AUTOTUNE_MAX_BYTES\f[R] and
@@ -236,14 +242,17 @@ Defaults to 128K.
 \f[B]\-\-io\-threads\f[R]=\f[CR]N\f[R]
 Use N threads for I/O.
 This is used by the file hashing and dedupe stages.
-By default oans inspects the backing storage of the scan target and picks
-a value automatically: the number of host cpus (capped at 8) on
-non\-rotational disks (SSD/NVMe) or when the media is unknown; fewer on a
-single spinning disk, which is seek\-bound; and roughly two per device on a
-multi\-device btrfs pool, still capped at 8.
-Run \f[CR]oans \-v\f[R] to see the detected storage and the chosen value.
-An explicit \f[CR]N\f[R] disables the auto\-detection and is used verbatim.
-Use \f[CR]\-\-autotune\f[R] to measure the real optimum on your hardware.
+By default oans inspects the backing storage of the scan target and
+picks a value automatically: the number of host cpus (capped at 8) on
+non\-rotational disks (SSD/NVMe) or when the media is unknown; fewer on
+a single spinning disk, which is seek\-bound; and roughly two per device
+on a multi\-device btrfs pool, still capped at 8.
+Run \f[CR]oans \-v\f[R] to see the detected storage and the chosen
+value.
+An explicit \f[CR]N\f[R] disables the auto\-detection and is used
+verbatim.
+Use \f[CR]\-\-autotune\f[R] to measure the real optimum on your
+hardware.
 .TP
 \f[B]\-\-cpu\-threads\f[R]=\f[CR]N\f[R]
 Use N threads for CPU bound tasks.

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -183,13 +183,17 @@ freed is smaller on a compressed filesystem. Requires the `--hashfile` option.
   ~ Measure the fastest `--io-threads` for this machine and exit. oans reads
 and hashes a bounded sample of the given tree at several thread counts,
 dropping the page cache between trials (run as root for meaningful cold-read
-numbers on spinning disks), and prints a throughput table with the best value.
-When `--hashfile` is given the winner is stored in that hashfile, so later runs
+numbers on spinning disks), printing each trial as it runs and then a
+throughput table with the best value. Directories are always sampled
+recursively (the sample is about the storage, not the `-r` flag). When
+`--hashfile` is given the winner is stored in that hashfile, so later runs
 against it use that thread count automatically unless you pass an explicit
-`--io-threads`. This is the hardware-measured counterpart to the automatic
-storage heuristic (see `--io-threads`); it is the reliable way to find the
-optimum for a NAS or multi-disk array. The sample bounds can be tuned with the
-`DUPEREMOVE_AUTOTUNE_MAX_FILES`, `DUPEREMOVE_AUTOTUNE_MAX_BYTES` and
+`--io-threads`; the scan configuration (paths and any `-d`/`-r`/… you passed)
+is stored too, so autotune doubles as setup — a later bare
+`oans --hashfile=FILE` replays it. This is the hardware-measured counterpart to
+the automatic storage heuristic (see `--io-threads`); it is the reliable way to
+find the optimum for a NAS or multi-disk array. The sample bounds can be tuned
+with the `DUPEREMOVE_AUTOTUNE_MAX_FILES`, `DUPEREMOVE_AUTOTUNE_MAX_BYTES` and
 `DUPEREMOVE_AUTOTUNE_ROUNDS` environment variables.
 
 **-R** `files ..`

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -36,19 +36,23 @@ sudo make install-systemd    # installs the oans@ timer/service templates
 ## Step 2 — Autotune the thread count for your disks
 
 Give the job a name and tune into the hashfile the timer will later use
-(`/var/cache/oans/<name>.hash`), so the measured value is reused by every run:
+(`/var/cache/oans/<name>.hash`). Pass the same `-dr` and path you'll dedupe
+with — autotune records them too, so this one command both measures the
+threads **and** sets up the job:
 
 ```sh
 sudo install -d -m 0755 /var/cache/oans
-sudo oans --autotune --hashfile=/var/cache/oans/media.hash /srv/media
+sudo oans --autotune -dr --hashfile=/var/cache/oans/media.hash /srv/media
 ```
 
 Run it **as root** — autotune drops the page cache between trials to get honest
 cold-read numbers, which matters a lot on spinning disks and RAID. It reads only
-a bounded sample (quick, not a full scan), prints a throughput-vs-threads table,
-and stores the winning `--io-threads` value in the hashfile. This is the
-reliable way to size threads for a NAS; without it, oans falls back to a
-storage-type heuristic whose HDD/RAID numbers are only educated guesses.
+a bounded sample (quick relative to a full scan, though on a big cold tree the
+trials still take a few minutes; it prints each one as it goes), then prints a
+throughput-vs-threads table and stores the winning `--io-threads` value plus the
+scan configuration in the hashfile. This is the reliable way to size threads for
+a NAS; without it, oans falls back to a storage-type heuristic whose HDD/RAID
+numbers are only educated guesses.
 
 ## Step 3 — The first run (the slow one)
 
@@ -59,8 +63,7 @@ sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
 This is the expensive pass: it hashes everything and deduplicates. It
 
 - reuses the thread count autotune stored in Step 2,
-- **records its options and paths** in the hashfile (this is what makes the
-  scheduled runs need no arguments), and
+- re-confirms the stored options and paths (already recorded by Step 2), and
 - is safe to interrupt — the kernel does each dedupe atomically and
   byte-verified, so Ctrl+C can only waste work, never corrupt data.
 

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -82,8 +82,10 @@ static void collect_dir(struct sample *s, const char *dir)
 			continue;
 
 		if (S_ISDIR(st.st_mode)) {
-			if (options.recurse_dirs)
-				collect_dir(s, child);
+			/* Always recurse: sampling a tree to measure throughput
+			 * should look inside subdirectories regardless of -r
+			 * (which governs the real run, not this measurement). */
+			collect_dir(s, child);
 		} else if (S_ISREG(st.st_mode)) {
 			if ((uint64_t)st.st_size < options.min_filesize)
 				continue;
@@ -311,15 +313,26 @@ int autotune_run(char **roots, int nroots)
 		for (unsigned int i = 0; i < ncand; i++) {
 			double t;
 
+			/* Each trial reads the whole (cold) sample, so it can
+			 * take a while - report progress as we go. */
+			printf("  round %u/%u  threads %-3u ", r + 1, rounds,
+			       cand[i]);
+			fflush(stdout);
+
 			if (cold)
 				drop_caches();
 			t = run_trial(self, listpath, cand[i]);
-			if (t < 0)
+			if (t < 0) {
+				printf("failed\n");
 				continue;
+			}
+			printf("%-8s %s/s\n", human_duration(t),
+			       human_size((uint64_t)(s.total_bytes / t)));
 			if (best[i] == 0 || t < best[i])
 				best[i] = t;
 		}
 	}
+	printf("\n");
 
 	/* Find the fastest candidate, then print every row in candidate order. */
 	for (unsigned int i = 0; i < ncand; i++)

--- a/src/oans.c
+++ b/src/oans.c
@@ -1272,8 +1272,25 @@ int main(int argc, char **argv)
 		return print_hashfile_history(options.hashfile);
 	else if (json_only_opt)
 		return print_metrics_json(options.hashfile);
-	else if (autotune_opt)
-		return autotune_run(&argv[filelist_idx], argc - filelist_idx);
+	else if (autotune_opt) {
+		int nroots = argc - filelist_idx;
+
+		ret = autotune_run(&argv[filelist_idx], nroots);
+		/*
+		 * Record the scan config too, so autotune doubles as setup: a
+		 * later bare `oans --hashfile=X` (or the systemd timer) replays
+		 * these paths and options. Uses whatever -d/-r/... were passed.
+		 */
+		if (ret == 0 && options.hashfile && nroots > 0) {
+			struct dbhandle *adb = dbfile_open_handle(options.hashfile);
+
+			if (adb) {
+				persist_scan_config(adb, &argv[filelist_idx], nroots);
+				dbfile_close_handle(adb);
+			}
+		}
+		return ret;
+	}
 
 	db = dbfile_open_handle(options.hashfile);
 	if (!db)
@@ -1303,7 +1320,10 @@ int main(int argc, char **argv)
 		}
 		if (!have) {
 			eprintf("Error: no files given and the hashfile has no "
-				"stored scan configuration to replay.\n");
+				"stored scan configuration to replay.\n"
+				"Run once with the paths to record it, e.g.:\n"
+				"  oans -dr --hashfile=%s <dir>...\n",
+				options.hashfile);
 			ret = 1;
 			goto out;
 		}

--- a/src/progress.c
+++ b/src/progress.c
@@ -178,11 +178,16 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 	/*
 	 * The numbers on the right must stay visible: give the path whatever
 	 * width remains and shorten its middle, never the suffix.
+	 *
+	 * When the terminal width is unknown (some SSH ptys report 0 columns),
+	 * fall back to 80 rather than not truncating at all: an untruncated long
+	 * path wraps onto a second physical row, which desyncs the fixed-height
+	 * progress area (the cursor moves up N rows but N+ were drawn) and leaves
+	 * the top lines frozen. 80 never over-estimates a real terminal, so the
+	 * line can't wrap.
 	 */
-	if (w_col == UINT_MAX)
-		avail = INT_MAX;
-	else
-		avail = (int)w_col - (int)strlen(prefix) - (int)strlen(suffix);
+	avail = (int)(w_col == UINT_MAX ? 80 : w_col)
+		- (int)strlen(prefix) - (int)strlen(suffix);
 	/* Never emit raw control bytes from a filename to the terminal (#353). */
 	sanitize_ctrl(tprogress->file_path, clean, sizeof(clean));
 	ellipsize_path(clean, path, sizeof(path), avail);

--- a/tests/integration/test_autotune.py
+++ b/tests/integration/test_autotune.py
@@ -65,6 +65,31 @@ class AutotuneTest(DuperemoveTest):
         self.assertEqual(rc, 0, out)
         self.assertNotIn("autotuned", out)
 
+    def test_samples_recursively_even_without_r(self):
+        # Files live only in a nested subdir; autotune samples a tree by
+        # recursing regardless of -r (which governs the real run).
+        for i in range(4):
+            self.mkrand(f"tree/sub/deep/f{i}.bin", 64 * 1024)
+        rc, out = self._run("--autotune", "--hashfile", self.hf,
+                            self.path("tree"), env=self.ENV)
+        self.assertEqual(rc, 0, out)
+        self.assertNotIn("no regular files", out)
+        self.assertIn("Recommended:", out)
+
+    def test_persists_scan_config_for_replay(self):
+        tree = self._make_tree()
+        rc, out = self._run("--autotune", "-dr", "--hashfile", self.hf, tree,
+                            env=self.ENV)
+        self.assertEqual(rc, 0, out)
+        # autotune doubles as setup: the scan config is recorded, so a bare
+        # invocation replays it instead of erroring.
+        roots = [r[0] for r in self.hf_query("select path from scan_roots")]
+        self.assertEqual(roots, [os.path.realpath(tree)])
+        self.assertEqual(self.hf_scalar(
+            "select keyval from config where keyname='opt_run_dedupe'"), 1)
+        rc, out = self._run("--hashfile", self.hf)
+        self.assertEqual(rc, 0, out)
+
     def test_requires_a_path(self):
         rc, out = self._run("--autotune", "--hashfile", self.hf)
         self.assertNotEqual(rc, 0)


### PR DESCRIPTION
Fixes several rough edges surfaced by running the NAS quick-start guide on a real NAS.

## Fixes

1. **`--autotune` samples recursively.** `oans --autotune /data` reported *"found no regular files to measure with"* because `collect_dir` only recursed with `-r`. The sample is about the storage, not the run's recursion flag, so it now always recurses into directories. (This is what the guide's Step 2 command hit.)
2. **`--autotune` prints per-trial progress.** On a big cold tree the trials take minutes; it now prints each `round R/N threads K → time throughput` line as it runs, instead of sitting silent until the final table.
3. **`--autotune` records the scan config.** After `--autotune -dr --hashfile=X /data`, a bare `oans --hashfile=X` used to error *"no stored scan configuration"*. Autotune now persists the paths + options, so it doubles as setup and the self-describing replay / systemd timer work right after it.
4. **Actionable bare-replay error** — when nothing is stored it now prints the exact `oans -dr --hashfile=… <dir>` command to record a config.
5. **Progress display no longer desyncs over SSH.** When the terminal reports 0 columns (some ptys) the renderer skipped truncation, so long media paths wrapped to a second row and the fixed-height progress area drifted — the top lines froze and looked like "extra" entries. It now falls back to 80 columns so lines never wrap. (The thread count was always correct: 8 threads = 8 rows; the surplus rows were wrapped continuations.)

## Docs & tests

- NAS guide + man page updated: Step 2 uses `--autotune -dr` (measure **and** set up in one command), and the `--autotune` entry documents recursive sampling, per-trial output, and config persistence.
- +2 integration tests: recursive sampling without `-r`, and scan-config persistence enabling bare replay.

Verified via `scripts/verify.sh`: 0 warnings, 84 tests, valgrind clean including the autotune path.

Note: overlaps in spirit with the still-open #60 (build-deps docs) but touches different sections; no file conflict expected.