### PR TITLE
Open the hashfile read-only for report modes (safe concurrent --stats)

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -474,6 +474,15 @@ oans \-\-stats \-\-hashfile=foo.hash
 Deduplication is currently only supported by the \f[CR]btrfs\f[R] and
 \f[CR]xfs\f[R] filesystem.
 .PP
+The report modes (\f[CR]\-\-stats\f[R], \f[CR]\-\-history\f[R],
+\f[CR]\-\-json\f[R], \f[CR]\-L\f[R]) open the hashfile read\-only, so
+they are safe to run against a hashfile that another oans process is
+actively scanning or deduping; they show a consistent snapshot and never
+write to it.
+Running two \f[I]writing\f[R] invocations (e.g.\ two \f[CR]\-d\f[R]
+runs, or \f[CR]\-R\f[R]) on the same hashfile at once is not supported
+and may corrupt it.
+.PP
 The oans project page can be found on \c
 .UR https://github.com/martinus/oans
 github

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -420,6 +420,12 @@ duplication it records - run:
 # NOTES
 Deduplication is currently only supported by the `btrfs` and `xfs` filesystem.
 
+The report modes (`--stats`, `--history`, `--json`, `-L`) open the hashfile
+read-only, so they are safe to run against a hashfile that another oans process
+is actively scanning or deduping; they show a consistent snapshot and never
+write to it. Running two *writing* invocations (e.g. two `-d` runs, or `-R`) on
+the same hashfile at once is not supported and may corrupt it.
+
 The oans project page can be found on [github](https://github.com/martinus/oans).
 oans is a fork of [duperemove](https://github.com/markfasheh/duperemove).
 

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -127,3 +127,13 @@ oans --json    --hashfile=/var/cache/oans/media.hash    # metrics for a dashboar
   Compare `compsize` before and after for the true reclaimed amount.
 - **First run is slow, later runs are fast:** only changed/new files are
   re-hashed, and files whose extents are already shared are skipped.
+- **Querying while a run is in progress is safe.** The report commands
+  (`--stats`, `--history`, `--json`, `-L`) open the hashfile read-only, so you
+  can run them against a hashfile that a scheduled or manual run is actively
+  using — they show a consistent point-in-time snapshot and can't disturb the
+  run or the file. What you should *not* do is start a second *writing* run
+  (another `oans -dr`, or `-R`) on the same hashfile at the same time; the
+  single-writer design assumes one writer. Note the systemd timer won't start a
+  second `oans@<name>.service` while one is active, but a manual `oans` run is
+  invisible to that — so avoid kicking off a manual dedupe when the timer might
+  fire on the same hashfile.

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -25,7 +25,8 @@
 
 static struct dbhandle *gdb = NULL;
 
-static sqlite3 *__dbfile_open_handle(char *filename, bool force_create);
+static sqlite3 *__dbfile_open_handle(char *filename, bool force_create,
+				     bool readonly);
 
 static GMutex io_mutex; /* Locks db writes */
 
@@ -420,11 +421,24 @@ static int dbfile_set_modes(sqlite3 *db)
  */
 static bool hashfile_rebuilt;
 
-static int dbfile_prepare(sqlite3 *db)
+static int dbfile_prepare(sqlite3 *db, bool readonly)
 {
 	struct dbfile_config cfg;
 	int ret;
 	char dbpath[PATH_MAX + 1];
+
+	/*
+	 * Read-only open (report modes: --stats/--history/--json/-L): verify the
+	 * file is an oans hashfile but issue no writes at all - no table/index
+	 * DDL, no config sync, no recreate-on-mismatch. This is what makes those
+	 * commands safe to run while another oans is deduping: they never contend
+	 * for the WAL write lock (and never clobber a foreign file).
+	 */
+	if (readonly) {
+		if (dbfile_get_config(db, &cfg))
+			return -1;
+		return dbfile_check(db, &cfg);
+	}
 
 	ret = create_tables(db);
 	if (ret) {
@@ -479,8 +493,8 @@ static int dbfile_prepare(sqlite3 *db)
 			return ret;
 		}
 
-		db = __dbfile_open_handle(dbpath, false);
-		return dbfile_prepare(db);
+		db = __dbfile_open_handle(dbpath, false, false);
+		return dbfile_prepare(db, false);
 	}
 
 	/* May store the default config, if fields were missing
@@ -499,7 +513,8 @@ static int dbfile_prepare(sqlite3 *db)
 #define MEMDB_FILENAME		"file::memory:?cache=shared"
 #define OPEN_FLAGS		(SQLITE_OPEN_READWRITE|SQLITE_OPEN_NOMUTEX|SQLITE_OPEN_URI)
 #define OPEN_FLAGS_CREATE	(OPEN_FLAGS|SQLITE_OPEN_CREATE)
-static sqlite3 *__dbfile_open_handle(char *filename, bool force_create)
+static sqlite3 *__dbfile_open_handle(char *filename, bool force_create,
+				     bool readonly)
 {
 	int ret;
 	sqlite3 *db;
@@ -514,10 +529,11 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create)
 	else
 		ret = sqlite3_open_v2(filename, &db, OPEN_FLAGS, NULL);
 
-	if (ret == SQLITE_CANTOPEN && !force_create) {
+	/* A read-only report must not conjure a hashfile that isn't there. */
+	if (ret == SQLITE_CANTOPEN && !force_create && !readonly) {
 		vprintf("Cannot open an existing hashfile, retrying in create mode\n");
 		sqlite3_close(db);
-		return __dbfile_open_handle(filename, true);
+		return __dbfile_open_handle(filename, true, false);
 	}
 
 	if (ret) {
@@ -532,7 +548,7 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create)
 		return NULL;
 	}
 
-	ret = dbfile_prepare(db);
+	ret = dbfile_prepare(db, readonly);
 	if (ret) {
 		sqlite3_close(db);
 		return NULL;
@@ -549,10 +565,10 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create)
 	}											\
 } while (0)
 
-struct dbhandle *dbfile_open_handle(char *filename)
+static struct dbhandle *open_handle(char *filename, bool readonly)
 {
 	struct dbhandle *result = calloc(1, sizeof(struct dbhandle));
-	result->db = __dbfile_open_handle(filename, false);
+	result->db = __dbfile_open_handle(filename, false, readonly);
 
 	if (!result->db)
 		goto err;
@@ -730,6 +746,22 @@ struct dbhandle *dbfile_open_handle(char *filename)
 err:
 	dbfile_close_handle(result);
 	return NULL;
+}
+
+struct dbhandle *dbfile_open_handle(char *filename)
+{
+	return open_handle(filename, false);
+}
+
+/*
+ * Open a hashfile for a read-only report. Issues no writes, so it is safe to
+ * run concurrently with a deduping oans (no WAL write-lock contention) and
+ * never modifies or recreates the file. Returns NULL if the file is missing or
+ * is not an oans hashfile.
+ */
+struct dbhandle *dbfile_open_handle_ro(char *filename)
+{
+	return open_handle(filename, true);
 }
 
 void dbfile_close_handle(struct dbhandle *db)

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -77,6 +77,9 @@ struct file {
 };
 
 struct dbhandle *dbfile_open_handle(char *filename);
+/* Read-only open for report modes: no writes, safe to run while another oans
+ * is deduping the same hashfile. NULL if missing or not an oans hashfile. */
+struct dbhandle *dbfile_open_handle_ro(char *filename);
 void dbfile_close_handle(struct dbhandle *db);
 
 /*

--- a/src/oans.c
+++ b/src/oans.c
@@ -212,7 +212,7 @@ static int print_hashfile_stats(char *filename)
 	double t0, t_load, t_analysis;
 	sqlite3 *sq;
 
-	db = dbfile_open_handle(filename);
+	db = dbfile_open_handle_ro(filename);
 	if (!db) {
 		eprintf("Error: Could not open \"%s\"\n", filename);
 		return -1;
@@ -391,7 +391,7 @@ static int print_hashfile_history(char *filename)
 	struct run_summary sum;
 	char since[32];
 
-	db = dbfile_open_handle(filename);
+	db = dbfile_open_handle_ro(filename);
 	if (!db) {
 		eprintf("Error: Could not open \"%s\"\n", filename);
 		return -1;
@@ -442,7 +442,7 @@ static int print_metrics_json(char *filename)
 	uint64_t logical, hashed, groups, dupfiles, reclaimable;
 	sqlite3 *sq;
 
-	db = dbfile_open_handle(filename);
+	db = dbfile_open_handle_ro(filename);
 	if (!db) {
 		eprintf("Error: Could not open \"%s\"\n", filename);
 		return -1;
@@ -481,7 +481,7 @@ static int list_db_files(char *filename)
 {
 	int ret;
 
-	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = dbfile_open_handle(filename);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = dbfile_open_handle_ro(filename);
 	if (!db) {
 		eprintf("Error: Could not open \"%s\"\n", filename);
 		return -1;

--- a/tests/integration/test_readonly_reports.py
+++ b/tests/integration/test_readonly_reports.py
@@ -1,0 +1,56 @@
+"""Report modes (--stats/--history/--json/-L) open the hashfile read-only.
+
+They must (a) never write to it - so they are safe to run while another oans is
+deduping the same hashfile and can't corrupt it - and (b) never recreate a file
+that isn't a valid oans hashfile.
+"""
+
+import os
+import sqlite3
+
+from harness import DuperemoveTest
+
+
+class ReadonlyReportsTest(DuperemoveTest):
+    def _seed_hashfile(self):
+        d = self.path("tree")
+        os.makedirs(d)
+        for i in range(3):
+            self.write(f"tree/f{i}", os.urandom(4096))
+        self.dm("-r", d)          # populate the hashfile (scan only, no reflink needed)
+
+    def test_stats_works_while_hashfile_write_locked(self):
+        # Deterministically hold the WAL write lock, then run a report: the old
+        # code did a config-sync write on open and failed with "database is
+        # locked"; a read-only open must succeed regardless.
+        self._seed_hashfile()
+        con = sqlite3.connect(self.hf, timeout=1)
+        con.execute("BEGIN IMMEDIATE")          # acquire the write lock
+        con.execute(
+            "INSERT OR REPLACE INTO config VALUES ('probe', 1)")
+        try:
+            for flag in ("--stats", "--history", "--json", "-L"):
+                self.dm(flag)
+                self.assertEqual(self.rc, 0,
+                                 f"{flag} failed under a held write lock:\n{self.out}")
+                self.assertNotIn("locked", self.out)
+        finally:
+            con.rollback()
+            con.close()
+
+    def test_report_does_not_recreate_a_foreign_file(self):
+        # A non-oans file must be refused, not silently clobbered/recreated.
+        with open(self.hf, "w") as f:
+            f.write("not an oans hashfile")
+        self.dm("--stats")
+        self.assertNotEqual(self.rc, 0)
+        with open(self.hf) as f:
+            self.assertEqual(f.read(), "not an oans hashfile")
+
+    def test_stats_does_not_modify_the_hashfile(self):
+        self._seed_hashfile()
+        before = os.stat(self.hf).st_mtime_ns
+        self.dm("--stats")
+        self.assertEqual(self.rc, 0)
+        # A read-only report leaves the main db file untouched.
+        self.assertEqual(os.stat(self.hf).st_mtime_ns, before)


### PR DESCRIPTION
## The bug (reported from a NAS)

Running `oans --stats` while a `-dr` run was deduping the same hashfile failed hard:

```
__dbfile_sync_config()/…: Database error 5 while binding: database is locked
dbfile_prepare()/…: Database error 5 while sync db config: database is locked
Error: Could not open "/var/cache/oans/data.hash"
```

The report modes went through the normal open path (`dbfile_prepare`), which **writes** on open — `create_tables`, a config sync, and even a destructive recreate-on-mismatch. So a read-only report tried to take the WAL write lock the running dedupe was holding, and failed.

## Fix

A read-only open, `dbfile_open_handle_ro()`: it verifies the file is an oans hashfile (config read + brand/version check) and issues **no writes** — no DDL, no config sync, no recreate. The four report modes (`--stats`, `--history`, `--json`, `-L`) use it. SQLite WAL already allows a reader alongside the single writer, so reports now run concurrently against a live hashfile and show a consistent snapshot.

Bonus: a non-oans file is now **refused** by a report instead of being silently recreated/clobbered.

Kept the connection read-**write** (not `SQLITE_OPEN_READONLY`) on purpose: a truly read-only connection can fail to open an *idle* WAL hashfile whose `-shm` doesn't exist yet. The connection simply never issues a write.

## Verification

- **40/40 concurrent `--stats`** against an active `-dr` writer, zero "database is locked" failures (was failing every time before).
- +3 integration tests: succeeds under a deterministically-held write lock, a foreign file isn't recreated, and `--stats` leaves the file byte-untouched.
- 87 integration tests pass, 0 `-Wextra` warnings, valgrind clean on the report path.
- Docs (NAS guide + man `NOTES`) now state reports are safe during a run, and that two *writing* runs on one hashfile are not.