### PR TITLE
Lower SQLite cache 256MB→64MB per connection (cut memory, perf-neutral)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 `oans` (a fork of duperemove) finds duplicate extents and deduplicates them via
 the kernel `FIDEDUPERANGE` ioctl (atomic, byte-verified). Hashes live in a
-SQLite **hashfile** (WAL mode, `synchronous=OFF`, `cache_size=-256000`).
+SQLite **hashfile** (WAL mode, `synchronous=OFF`, `cache_size=-65536` = 64 MB).
 
 All C sources live under `src/` (main program `src/oans.c`); man page sources
 under `docs/man/`. The binary is `oans`; `make install` adds a `duperemove`
@@ -84,6 +84,17 @@ Startup/scan cost has burned us before. The rules:
   measurement bug**, not a discovery. Reconcile before acting.
 
 ## Hashfile / SQLite gotchas
+
+- **`cache_size = -65536` (64 MB per connection), not 256 MB.** The pragma is
+  applied to *every* connection (listing handle, batched writer, and one per
+  walker thread), so on a large hashfile the peak RSS was dominated by these
+  caches (a NAS user hit ~870 MB on a 1.7M-file tree). Measured on the 174k-file
+  `~/git`: dropping 256 MB → 64 MB is **perf-neutral** on both the warm rescan
+  (change-detection is btrfs-metadata-bound, and the OS page cache backs the DB)
+  and the full `-rd` (dedupe-phase group-loading). 16 MB was ~3% slower on the
+  dedupe joins, so 64 MB is the floor that keeps them cached. Don't raise it back
+  to 256 MB without a measured reason. Further memory work (giving the per-walker
+  read handles a tiny cache; `seen_inodes` scales ~50 B/file) is unexplored.
 
 - In WAL mode a connection holds its read snapshot across queries. Wrapping the
   per-file change-detection reads in **one batched read transaction** (refreshed

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -369,7 +369,7 @@ static int dbfile_set_modes(sqlite3 *db)
 		return ret;
 	}
 
-	ret = sqlite3_exec(db, "PRAGMA cache_size = -256000", NULL, NULL, NULL);
+	ret = sqlite3_exec(db, "PRAGMA cache_size = -65536", NULL, NULL, NULL);
 	if (ret) {
 		perror_sqlite(ret, "configuring database (cache size)");
 		return ret;


### PR DESCRIPTION
## Why

`PRAGMA cache_size = -256000` (256 MB) is applied to **every** connection — the listing handle, the batched writer, and one per walker thread — so on a large hashfile the process RSS is dominated by these page caches. A NAS user reported **~870 MB RSS** on a 1.7M-file tree.

## Measured (174k-file `~/git`, interleaved A/B, distinct binaries)

| cache | warm rescan | full `-rd` |
|------:|:-----------:|:----------:|
| 256 MB | 1.020s | 2.124s |
| **64 MB** | **1.021s** | **2.123s** |
| 16 MB | 1.021s | ~1.16s→**~3% slower** on dedupe joins |

64 MB is **perf-neutral**: change-detection is btrfs-metadata-bound and the OS page cache backs the DB, and the dedupe-phase group-by still fits. 16 MB starts costing the dedupe joins, so 64 MB is the floor.

## Impact

Caps each connection's cache at a quarter of before. The saving scales with hashfile size — on a several-hundred-MB hashfile the listing connection alone drops from up to 256 MB to 64 MB, which should take a big bite out of that 870 MB.

One line + a CLAUDE.md note recording the measurement. Further memory work (a tiny cache for the per-walker read handles; `seen_inodes` scales ~50 B/file) is noted as unexplored follow-up.