### PR TITLE
Report honest reclaimed space, not net change in shared extents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,9 +311,12 @@ still only VACUUM once ≥25% of the file is free.
   on process kill. Only power loss risks the hashfile (due to `synchronous=OFF`).
 - A no-op rescan must net **0** changes and leave row counts identical. Use this
   as a smoke test after any scan-path change.
-- **The "Deduplicated" figure is logical, not disk.** On a compressed btrfs
-  (e.g. `zstd`), dedupe frees *compressed* blocks but the reported number is the
-  *logical* (uncompressed) amount, so real disk reclaimed is ~ratio smaller. To
+- **The "Reclaimed" figure is logical, not disk.** It counts the honest bytes
+  freed (kernel-deduped = one physical copy kept per group), but on a compressed
+  btrfs (e.g. `zstd`) dedupe frees *compressed* blocks while the number is the
+  *logical* (uncompressed) amount, so real disk reclaimed is ~ratio smaller. The
+  piped/`-q` "net change in shared extents" line is a separate fiemap diagnostic
+  that counts the surviving copy as shared too (~2x for pairs). To
   verify actual space freed, compare `compsize` **Disk Usage** before/after (not
   `df`); `Referenced` staying constant proves nothing was lost. `--json`'s
   `reclaimable_logical_bytes` is likewise a logical upper bound.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ redundant work** and
   generation passes; a group whose copies span many passes used to be reloaded
   and re-checked in every pass. It now loads only what's new per pass plus one
   stable target, so large duplicate groups are handled once. This also fixes an
-  inflated "Deduplicated" figure and keeps copies converging onto a single
+  inflated reclaimed-space figure and keeps copies converging onto a single
   physical extent.
 - **Batched hashfile transactions.** Per-file SQLite read/write transactions
   are batched on a ~10s cadence, collapsing a lock storm (hundreds of thousands
@@ -113,7 +113,7 @@ and filesystem.
 
 ## A note on compressed filesystems
 
-If your btrfs uses compression (e.g. zstd), read the `Deduplicated` figure as a
+If your btrfs uses compression (e.g. zstd), read the `Reclaimed` figure as a
 **logical/uncompressed** amount — the actual disk space you get back is
 smaller, roughly the compression ratio times that number, because dedupe
 operates on logical extents but frees compressed blocks. To see the true
@@ -193,11 +193,15 @@ A run ends with a summary like:
 
 ```
 Summary
-  Deduplicated   134.8 GiB across 164872 groups
-  Kernel scanned 994.7 MiB
+  Reclaimed      133.1 GiB across 164872 groups
   Elapsed        92.1s
   Already shared 350708 files skipped (no work needed)
 ```
+
+`Reclaimed` is the disk space actually freed (one physical copy kept per
+duplicate group). Piped or under `-q`, oans also prints a stable
+`net change in shared extents` line — a fiemap diagnostic that counts every
+copy as shared, so for pairs it is about twice the reclaimed figure.
 
 For the complete set of options and examples, see the
 [oans man page](docs/man/oans.md).

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -122,7 +122,7 @@ oans --json    --hashfile=/var/cache/oans/media.hash    # metrics for a dashboar
 - **The hashfile is just a cache** (under `/var/cache/oans`). Deleting it only
   forces the next run to re-hash from scratch; it can live on your system SSD,
   separate from the data pool.
-- **Compressed btrfs:** the reported "Deduplicated" figure is *logical* — the
+- **Compressed btrfs:** the reported "Reclaimed" figure is *logical* — the
   real disk space freed is smaller (roughly the compression ratio times that).
   Compare `compsize` before and after for the true reclaimed amount.
 - **First run is slow, later runs are fast:** only changed/new files are

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1173,7 +1173,8 @@ int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
 	sqlite3_bind_int64(stmt, 3, r->files_scanned);
 	sqlite3_bind_int64(stmt, 4, r->reclaimed);
 	sqlite3_bind_int64(stmt, 5, r->groups);
-	sqlite3_bind_int64(stmt, 6, r->kernel_bytes);
+	/* Legacy NOT NULL column, no longer read; mirror reclaimed to satisfy it. */
+	sqlite3_bind_int64(stmt, 6, r->reclaimed);
 	sqlite3_bind_int64(stmt, 7, r->deduped);
 
 	if (sqlite3_step(stmt) != SQLITE_DONE)

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -154,9 +154,8 @@ struct run_record {
 	int64_t		ts;		/* unix seconds */
 	int64_t		duration_ms;
 	uint64_t	files_scanned;
-	uint64_t	reclaimed;	/* bytes: net change in shared extents */
+	uint64_t	reclaimed;	/* bytes: space reclaimed (kernel-deduped) */
 	uint64_t	groups;
-	uint64_t	kernel_bytes;
 	int		deduped;	/* 1 if -d, 0 for a scan-only run */
 };
 int dbfile_record_run(struct dbhandle *db, const struct run_record *r);

--- a/src/oans.c
+++ b/src/oans.c
@@ -1383,17 +1383,16 @@ int main(int argc, char **argv)
 
 	/* Append this run to the hashfile's history (fuels --history / --json). */
 	if (options.hashfile) {
-		uint64_t groups = 0, reclaimed = 0, kern = 0;
+		uint64_t groups = 0, reclaimed = 0;
 		struct run_record rec;
 
-		pdedupe_counters(&groups, &reclaimed, &kern);
+		pdedupe_counters(&groups, &reclaimed, NULL);
 		rec = (struct run_record){
 			.ts = time(NULL),
 			.duration_ms = (int64_t)(elapsed_seconds() * 1000.0),
 			.files_scanned = files_scanned,
 			.reclaimed = reclaimed,
 			.groups = groups,
-			.kernel_bytes = kern,
 			.deduped = options.run_dedupe,
 		};
 		dbfile_record_run(db, &rec);

--- a/src/progress.c
+++ b/src/progress.c
@@ -94,7 +94,10 @@ static struct {
 	uint64_t		estimate;	/* fuzzy total, see dbfile */
 	unsigned int		batch, batches;
 	const char		*activity;	/* static string */
-	_Atomic uint64_t	reclaimed, kern;
+	/* reclaimed: honest disk freed (kernel-deduped bytes). net_shared: fiemap
+	 * "net change in shared extents", a diagnostic for the machine-readable
+	 * line only (it counts the surviving copy as shared too, so ~2x for pairs). */
+	_Atomic uint64_t	reclaimed, net_shared;
 } pdd;
 
 #define s_printf(args...) do { if (tty) printf("\33[K"); printf(args); } while (0)
@@ -288,8 +291,7 @@ static unsigned int print_dedupe_progress(void)
 		printf(" · batch %u/%u", pdd.batch, pdd.batches);
 	printf("\n");
 
-	s_printf("\tSpace reclaimed: %s · kernel verified: %s\n",
-		 human_size(pdd.reclaimed), human_size(pdd.kern));
+	s_printf("\tSpace reclaimed: %s\n", human_size(pdd.reclaimed));
 
 	s_printf("\tStatus: %s", pdd.activity ? pdd.activity : "working");
 	if (st)
@@ -515,7 +517,7 @@ void pdedupe_begin(uint64_t estimated_groups, unsigned int batches)
 	pdd.done = 0;
 	pdd.queued = 0;
 	pdd.reclaimed = 0;
-	pdd.kern = 0;
+	pdd.net_shared = 0;
 	pdd.estimate = estimated_groups;
 	pdd.batches = batches;
 	pdd.batch = batches ? 1 : 0;
@@ -572,18 +574,19 @@ void pdedupe_add_queued(uint64_t ngroups)
 	atomic_fetch_add(&pdd.queued, ngroups);
 }
 
-void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes)
+void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t net_shared_bytes)
 {
 	atomic_fetch_add(&pdd.done, 1);
 	atomic_fetch_add(&pdd.reclaimed, reclaimed_bytes);
-	atomic_fetch_add(&pdd.kern, kern_bytes);
+	atomic_fetch_add(&pdd.net_shared, net_shared_bytes);
 }
 
-void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *kern)
+void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *net_shared)
 {
 	*groups = pdd.done;
 	*reclaimed = pdd.reclaimed;
-	*kern = pdd.kern;
+	if (net_shared)
+		*net_shared = pdd.net_shared;
 }
 
 static void *psearch_progress_thread(void * p)

--- a/src/progress.h
+++ b/src/progress.h
@@ -109,7 +109,7 @@ void pdedupe_set_activity(const char *activity);
 
 /* A group was pushed to / finished by the dedupe pool. */
 void pdedupe_add_queued(uint64_t ngroups);
-void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes);
+void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t net_shared_bytes);
 
 /*
  * Claim a per-thread display line for one unit of work (file scan / dedupe
@@ -121,8 +121,12 @@ void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t kern_bytes);
 struct pscan_thread *pscan_claim_slot(pid_t tid,
 				      enum pscan_thread_status status);
 
-/* Read back the accumulated totals (for the end-of-run summary). */
-void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *kern);
+/*
+ * Read back the accumulated totals (for the end-of-run summary). reclaimed is
+ * the honest disk-freed amount (kernel-deduped bytes); net_shared is the fiemap
+ * "net change in shared extents" diagnostic and may be NULL if not needed.
+ */
+void pdedupe_counters(uint64_t *groups, uint64_t *reclaimed, uint64_t *net_shared);
 
 /*
  * Start the "extent search" progress thread

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -52,6 +52,13 @@ static volatile unsigned long long total_dedupe_passes;
 static volatile unsigned long long curr_dedupe_pass;
 static unsigned int leading_spaces;
 static bool whole_file_dedup;
+/*
+ * Whether to measure the fiemap "net change in shared extents". It feeds only
+ * the machine-readable line (non-tty or -q; see dedupe_end), so on an
+ * interactive run the per-group post-dedupe FIEMAP is pure waste. Set once when
+ * the phase starts, from the same condition that governs that line.
+ */
+static bool report_net_shared;
 
 void print_dupes_table(struct results_tree *res, bool whole_file)
 {
@@ -382,10 +389,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	}
 
 	/*
-	 * Do this after clean_deduped as we may have removed some
-	 * extents.
+	 * Do this after clean_deduped as we may have removed some extents.
+	 * Skipped unless we'll actually report net_shared (see report_net_shared).
 	 */
-	add_shared_extents(dext, &shared_prev);
+	if (report_net_shared)
+		add_shared_extents(dext, &shared_prev);
 
 	/*
 	 * Prefer the least-fragmented copy as the dedupe target so the others
@@ -601,7 +609,8 @@ close_files:
 	abort_on(ctxt != NULL);
 	abort_on(!RB_EMPTY_ROOT(&open_files.root));
 
-	add_shared_extents_post(dext, &shared_post);
+	if (report_net_shared)
+		add_shared_extents_post(dext, &shared_post);
 
 	/*
 	 * It's entirely possible that some other process is
@@ -706,7 +715,13 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 
 	extent_dedupe_worker(dext, slot, &fiemap_bytes, &kern_bytes);
 
-	pdedupe_group_done(fiemap_bytes, kern_bytes);
+	/*
+	 * Space reclaimed = kernel-deduped bytes (each deduped copy frees its
+	 * length). The fiemap delta counts the surviving copy as newly shared
+	 * too (~2x for pairs), so it is reported only as the "net change in
+	 * shared extents" diagnostic, not as space reclaimed.
+	 */
+	pdedupe_group_done(kern_bytes, fiemap_bytes);
 }
 
 static GThreadPool *dedupe_pool = NULL;
@@ -782,10 +797,10 @@ static int push_extents(struct results_tree *res)
  */
 void dedupe_end(void)
 {
-	uint64_t groups, reclaimed, kern;
+	uint64_t groups, reclaimed, net_shared;
 
 	pdedupe_end();
-	pdedupe_counters(&groups, &reclaimed, &kern);
+	pdedupe_counters(&groups, &reclaimed, &net_shared);
 
 	/* Human summary: skipped by -q. */
 	if (!quiet) {
@@ -793,13 +808,10 @@ void dedupe_end(void)
 			printf("%sNothing to deduplicate.%s\n", col_dim, col_reset);
 		} else {
 			printf("%s%sSummary%s\n", col_bold, col_blue, col_reset);
-			printf("  %sDeduplicated%s   %s%s%s across %lu group%s\n",
+			printf("  %sReclaimed%s      %s%s%s across %lu group%s\n",
 			       col_dim, col_reset, col_green,
 			       human_size(reclaimed), col_reset,
 			       groups, groups == 1 ? "" : "s");
-			if (kern)
-				printf("  %sKernel scanned%s %s\n", col_dim,
-				       col_reset, human_size(kern));
 			printf("  %sElapsed%s        %.1fs\n",
 			       col_dim, col_reset, elapsed_seconds());
 		}
@@ -823,7 +835,7 @@ void dedupe_end(void)
 	 */
 	if (!isatty(STDOUT_FILENO) || quiet)
 		printf("Comparison of extent info shows a net change in "
-		       "shared extents of: %s\n", pretty_size(reclaimed));
+		       "shared extents of: %s\n", pretty_size(net_shared));
 }
 
 void dedupe_results(struct results_tree *res, bool whole_file)
@@ -838,6 +850,7 @@ void dedupe_results(struct results_tree *res, bool whole_file)
 	results_tree = res;
 
 	whole_file_dedup = whole_file;
+	report_net_shared = !isatty(STDOUT_FILENO) || quiet;
 
 	/* The pre-dedupe listing is a wall of text; show it only with -v. */
 	if (verbose)

--- a/tests/integration/test_history_metrics.py
+++ b/tests/integration/test_history_metrics.py
@@ -76,12 +76,15 @@ class HistoryTest(DuperemoveTest):
 @requires_reflink
 class HistoryReclaimTest(DuperemoveTest):
     def test_lifetime_reclaimed_accumulates_across_runs(self):
-        a, b = self.mkdup("a", "b", 1 << 20)
+        MiB = 1 << 20
+        a, b = self.mkdup("a", "b", MiB)
         self.dm("-rd", self.path("."))          # reclaims one 1 MiB copy
         first = json.loads(self.dm("--json"))["reclaimed_total_bytes"]
-        self.assertGreater(first, 0)
+        # Honest accounting: deduping a pair frees exactly ONE copy, not two.
+        # (The fiemap "net change in shared extents" is 2 MiB; that is not it.)
+        self.assertEqual(MiB, first, "one reclaimed copy for a 1 MiB pair")
 
-        c, e = self.mkdup("c", "e", 1 << 20)     # a second reclaimable pair
+        c, e = self.mkdup("c", "e", MiB)         # a second reclaimable pair
         self.dm("-rd", self.path("."))
         second = json.loads(self.dm("--json"))["reclaimed_total_bytes"]
-        self.assertGreater(second, first)
+        self.assertEqual(2 * MiB, second, "two lifetime pairs = two copies freed")


### PR DESCRIPTION
## Problem

The dedupe summary headline ("Deduplicated" / live "Space reclaimed") was fed the fiemap **net change in shared extents**. For a group of N identical copies of length L that is `N*L`, because after dedupe FIEMAP marks *all* N copies as shared — but only `(N-1)*L` is actually freed on disk (one physical copy is kept). For pairs (the common case) it's exactly **double**: a real run showed `Space reclaimed: 267.5 GiB` when only ~133 GiB was freed.

## Fix

Report the honest disk-freed amount — the bytes the kernel actually deduped (`= (N-1)*L`). The fiemap number is kept only for the precisely-labeled, script-facing `net change in shared extents` line (printed on non-tty / `-q`), and the tests that pin it are unchanged.

- **progress.c/.h**: pdd counter `kern` → `net_shared`; `Space reclaimed` shows the honest number; `pdedupe_counters()`'s `net_shared` out-param is optional.
- **run_dedupe.c**: summary label → `Reclaimed` (honest value); machine line uses `net_shared`. Also skip the per-group post-dedupe FIEMAP entirely on interactive runs, where `net_shared` is never printed — saves an open/close + ~2 FIEMAP ioctls per group member on the common tty path.
- **oans.c / dbfile.***: `run_history.reclaimed` (hence `--json reclaimed_total_bytes` and `--history`) now record the honest number; dropped the redundant `kernel_bytes` struct field (legacy NOT NULL column now mirrors `reclaimed`).
- **tests**: tightened the history test to pin "a pair frees one copy, not two".
- **docs**: README / nas-quickstart / CLAUDE terminology → `Reclaimed`.

## Verification

- Two identical 200 MiB files → summary `Reclaimed 200.0 MiB`, `--json reclaimed_total_bytes = 209715200` (one copy); machine line still `net change ... 419430400` (fiemap, 2×).
- `scripts/verify.sh`: 87 integration tests + valgrind smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)