### PR TITLE
docs: explain the oans@<name> timer → hashfile mapping

### DIFF
--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -95,6 +95,12 @@ oans --stats --hashfile=/var/cache/oans/media.hash
 sudo systemctl enable --now oans@media.timer
 ```
 
+The name after `@` is the **basename of your hashfile** in `/var/cache/oans/`:
+`oans@media` runs `--hashfile=/var/cache/oans/media.hash`. So match it to the
+hashfile you created in Steps 2–3 — if yours is
+`/var/cache/oans/data.hash`, enable `oans@data.timer` instead. (The unit skips
+cleanly until that hashfile exists, so set it up first.)
+
 Done. Weekly from here, oans re-scans `/srv/media`, hashes only what changed,
 and deduplicates — with no arguments, because the hashfile remembers everything.
 To change the frequency, override `OnCalendar=`:


### PR DESCRIPTION
NAS quickstart Step 4 said to run `sudo systemctl enable --now oans@media.timer` without explaining that the instance name after `@` is the **basename of the hashfile** in `/var/cache/oans/` (the unit runs `--hashfile=/var/cache/oans/%i.hash`).

A user with `/var/cache/oans/data.hash` reasonably wasn't sure whether to use `oans@data.timer`. This adds a short note: `oans@NAME` → `.../NAME.hash`, match it to the hashfile you created (e.g. `oans@data`), and it stays dormant until that hashfile exists (`ConditionPathExists`).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)