### PR TITLE
Add scripts/release.sh + assertReclaimed test helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,20 +36,27 @@ compat symlink. Some identifiers keep the old name on purpose: the
 ## Releasing
 
 The version string comes from `git describe --tags` (Makefile), so **a release
-is just a git tag** — there is no committed `VERSION` file to bump. Convention
-(latest: `v1.2.0`, 2026-07-18):
+is just a git tag** — there is no committed `VERSION` file to bump. Use
+**`scripts/release.sh`**, which encodes the whole convention (latest: `v1.2.0`,
+2026-07-18). It's two phases because merging the bump PR is a human decision:
 
-1. Branch `release/vX.Y.Z` off `origin/master`. Bump the version in **both** man
-   pages — `docs/man/oans.8` (`.TH "oans" "8" "<Month Year>" "oans X.Y.Z" …`) and
-   `docs/man/oans.md` (`footer: oans X.Y.Z`). These are the only two spots.
-2. Run `scripts/verify.sh`, then open a PR titled `Bump version to X.Y.Z` and
-   merge it (with the user's OK, as always).
-3. Annotated tag on the merged master HEAD, then push it:
-   `git tag -a vX.Y.Z -m "oans X.Y.Z\n\n<one-paragraph summary>"` and
-   `git push origin vX.Y.Z`.
-4. `gh release create vX.Y.Z --repo martinus/oans --title "oans vX.Y.Z" --notes …`
-   with notes grouped by theme (Features / Performance / Correctness / Housekeeping).
-   Releases attach **no** build artifacts — source only.
+```sh
+scripts/release.sh prepare X.Y.Z          # bump both man pages, run verify.sh, open the PR
+#   → review & merge the "Bump version to X.Y.Z" PR (with the user's OK, as always)
+scripts/release.sh publish X.Y.Z [NOTES]  # tag the merged master + create the GH release
+```
+
+- `prepare` branches `release/vX.Y.Z` off `origin/master`, bumps the version in
+  the **only two spots** — `docs/man/oans.8` (`.TH … "oans X.Y.Z" …`) and
+  `docs/man/oans.md` (`footer: oans X.Y.Z`) — runs the full `verify.sh` gate,
+  then pushes and opens the PR. It refuses on a dirty tree or an existing tag.
+- `publish` refuses until that bump is on `origin/master` (i.e. the PR merged),
+  then makes the annotated tag and the GitHub release. With no `NOTES` file it
+  seeds the body from the commit log since the previous tag (edit on GitHub
+  after); pass a file for grouped notes (Features / Performance / Correctness /
+  Housekeeping). Releases attach **no** build artifacts — source only.
+- It honors `PKG_CONFIG_PATH` / `DUPEREMOVE_TEST_DIR` like `verify.sh`, so on
+  this box run it with `PKG_CONFIG_PATH=/tmp/devroot/pc scripts/release.sh …`.
 
 - **Versioning is incremental semver.** The CLI is a superset of duperemove's and
   hashfiles auto-rebuild, so feature batches are backward-compatible → **minor**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,10 @@ scripts/release.sh prepare X.Y.Z          # bump both man pages, run verify.sh, 
 scripts/release.sh publish X.Y.Z [NOTES]  # tag the merged master + create the GH release
 ```
 
-- `prepare` branches `release/vX.Y.Z` off `origin/master`, bumps the version in
-  the **only two spots** — `docs/man/oans.8` (`.TH … "oans X.Y.Z" …`) and
-  `docs/man/oans.md` (`footer: oans X.Y.Z`) — runs the full `verify.sh` gate,
-  then pushes and opens the PR. It refuses on a dirty tree or an existing tag.
+- `prepare` branches `release/vX.Y.Z` off `origin/master`, bumps the committed
+  man-page version strings (the script owns the exact files and sed patterns),
+  runs the full `verify.sh` gate, then pushes and opens the PR. It refuses on a
+  dirty tree or an existing tag.
 - `publish` refuses until that bump is on `origin/master` (i.e. the PR merged),
   then makes the annotated tag and the GitHub release. With no `NOTES` file it
   seeds the body from the commit log since the previous tag (edit on GitHub

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# release.sh - cut an oans release, following the convention in CLAUDE.md.
+#
+# The version lives only in git tags (the Makefile derives it from
+# `git describe`), plus a human-facing string in the two man pages. A release is
+# therefore: bump those two strings, land them on master via a PR, then tag
+# master and publish a GitHub release. Merging a PR is a human decision, so this
+# is two phases:
+#
+#   scripts/release.sh prepare X.Y.Z        # bump man pages, verify, open the PR
+#   <review & merge the "Bump version to X.Y.Z" PR>
+#   scripts/release.sh publish X.Y.Z [NOTES_FILE]   # tag master, create the release
+#
+# publish refuses to run until that PR is on master. With no NOTES_FILE it seeds
+# the release body from the commit log since the previous tag (edit on GitHub
+# after); pass a file to supply your own grouped notes.
+#
+# Honors PKG_CONFIG_PATH / DUPEREMOVE_TEST_DIR just like verify.sh (nothing
+# machine-specific is baked in). Needs: git, an authenticated gh, and the build
+# toolchain. gh always targets the fork (see $REPO).
+set -euo pipefail
+
+REPO=martinus/oans
+MAN8=docs/man/oans.8
+MANMD=docs/man/oans.md
+
+cd "$(dirname "$0")/.."
+die() { echo "release: $*" >&2; exit 1; }
+
+# Accept X.Y.Z or vX.Y.Z, always print the bare X.Y.Z; reject anything else.
+normalize_version() {
+	local v=${1#v}
+	[[ $v =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be X.Y.Z (got '$1')"
+	printf '%s' "$v"
+}
+
+cmd=${1:-}
+case "$cmd" in
+prepare)
+	[[ $# -eq 2 ]] || die "usage: release.sh prepare X.Y.Z"
+	ver=$(normalize_version "$2")
+
+	[[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
+	git fetch -q origin
+	git rev-parse -q --verify "refs/tags/v$ver" >/dev/null 2>&1 \
+		&& die "tag v$ver already exists"
+
+	git checkout -q -B "release/v$ver" origin/master
+
+	# Bump the two man-page version strings. Fail loudly if the expected
+	# pattern is missing (format drift) rather than silently producing no change.
+	grep -Eq '"oans [0-9]+\.[0-9]+\.[0-9]+"' "$MAN8" || die "no version string in $MAN8"
+	grep -Eq '^footer: oans [0-9]+\.[0-9]+\.[0-9]+' "$MANMD" || die "no footer version in $MANMD"
+	sed -i -E "s/\"oans [0-9]+\.[0-9]+\.[0-9]+\"/\"oans $ver\"/" "$MAN8"
+	sed -i -E "s/^footer: oans [0-9]+\.[0-9]+\.[0-9]+/footer: oans $ver/" "$MANMD"
+	git diff --quiet -- "$MAN8" "$MANMD" \
+		&& die "man pages are already at $ver - nothing to bump"
+
+	echo "==> verifying (build + tests + valgrind smoke)"
+	bash scripts/verify.sh
+
+	git commit -q -m "Bump version to $ver" -- "$MAN8" "$MANMD"
+	git push -q -u origin "release/v$ver"
+	gh pr create --repo "$REPO" --base master --head "release/v$ver" \
+		--title "Bump version to $ver" \
+		--body "Release prep for oans $ver. Bumps the man-page version string; full notes go on the GitHub release."
+	echo
+	echo "Prepared v$ver. Review & merge the PR above, then:"
+	echo "    scripts/release.sh publish $ver [NOTES_FILE]"
+	;;
+publish)
+	[[ $# -ge 2 && $# -le 3 ]] || die "usage: release.sh publish X.Y.Z [NOTES_FILE]"
+	ver=$(normalize_version "$2")
+	notes_file=${3:-}
+	[[ -z "$notes_file" || -f "$notes_file" ]] || die "notes file '$notes_file' not found"
+
+	git fetch -q origin
+	git rev-parse -q --verify "refs/tags/v$ver" >/dev/null 2>&1 \
+		&& die "tag v$ver already exists"
+	# The bump must already be on master, i.e. the prepare PR was merged.
+	git show "origin/master:$MANMD" | grep -q "^footer: oans $ver$" \
+		|| die "origin/master is not at $ver yet - merge the 'Bump version to $ver' PR first"
+
+	git checkout -q --detach origin/master
+
+	# Annotate the tag with the notes (or just the version line if none given).
+	if [[ -n "$notes_file" ]]; then
+		git tag -a "v$ver" -F <(printf 'oans %s\n\n' "$ver"; cat "$notes_file")
+	else
+		git tag -a "v$ver" -m "oans $ver"
+	fi
+	git push -q origin "v$ver"
+
+	# Release notes: the supplied file, else a skeleton from the commit log.
+	tmp_notes=""
+	if [[ -z "$notes_file" ]]; then
+		tmp_notes=$(mktemp)
+		trap 'rm -f "$tmp_notes"' EXIT
+		prev=$(git describe --tags --abbrev=0 "v$ver^" 2>/dev/null || true)
+		{ echo "## Changes"; echo
+		  git log --no-merges --pretty='- %s' "${prev:+$prev..}v$ver"; } > "$tmp_notes"
+		notes_file=$tmp_notes
+	fi
+	gh release create "v$ver" --repo "$REPO" --title "oans v$ver" --notes-file "$notes_file"
+	echo "Published https://github.com/$REPO/releases/tag/v$ver"
+	;;
+*)
+	die "usage: release.sh {prepare|publish} X.Y.Z [NOTES_FILE]"
+	;;
+esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -84,24 +84,20 @@ publish)
 
 	git checkout -q --detach origin/master
 
-	# Annotate the tag with the notes (or just the version line if none given).
-	if [[ -n "$notes_file" ]]; then
-		git tag -a "v$ver" -F <(printf 'oans %s\n\n' "$ver"; cat "$notes_file")
-	else
-		git tag -a "v$ver" -m "oans $ver"
-	fi
-	git push -q origin "v$ver"
-
-	# Release notes: the supplied file, else a skeleton from the commit log.
-	tmp_notes=""
+	# Resolve the notes body once (the supplied file, or a skeleton from the
+	# commit log since the previous tag); the tag annotation and the GitHub
+	# release share it. HEAD is the commit v$ver will point at, and the tag
+	# doesn't exist yet, so `git describe HEAD` finds the previous release.
 	if [[ -z "$notes_file" ]]; then
-		tmp_notes=$(mktemp)
-		trap 'rm -f "$tmp_notes"' EXIT
-		prev=$(git describe --tags --abbrev=0 "v$ver^" 2>/dev/null || true)
+		notes_file=$(mktemp)
+		trap 'rm -f "$notes_file"' EXIT
+		prev=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)
 		{ echo "## Changes"; echo
-		  git log --no-merges --pretty='- %s' "${prev:+$prev..}v$ver"; } > "$tmp_notes"
-		notes_file=$tmp_notes
+		  git log --no-merges --pretty='- %s' "${prev:+$prev..}HEAD"; } > "$notes_file"
 	fi
+
+	git tag -a "v$ver" -F <(printf 'oans %s\n\n' "$ver"; cat "$notes_file")
+	git push -q origin "v$ver"
 	gh release create "v$ver" --repo "$REPO" --title "oans v$ver" --notes-file "$notes_file"
 	echo "Published https://github.com/$REPO/releases/tag/v$ver"
 	;;

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -43,6 +43,10 @@ _ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 _NET_CHANGE_RE = re.compile(r"net change in shared extents of:\s*(\d+)")
+# The human summary line, e.g. "  Reclaimed      1.0 MiB across 1 group".
+# The size is human_size()-rendered ("1.0 MiB", "512 B"), so assert on the
+# rendered string; for exact bytes use --json's reclaimed_total_bytes instead.
+_RECLAIMED_RE = re.compile(r"Reclaimed\s+([\d.]+ [A-Za-z]+)\s+across\s+(\d+)\s+group")
 
 
 # --------------------------------------------------------------------------
@@ -187,13 +191,17 @@ class DuperemoveTest(unittest.TestCase):
 
     # -- running oans ------------------------------------------------
 
-    def dm(self, *args, hashfile=True, stdin=None, env=None):
+    def dm(self, *args, hashfile=True, stdin=None, env=None, quiet=True):
         """Run oans; capture combined output in self.out and code in self.rc.
 
         Pass stdin=<str> to feed the process on standard input (e.g. a "-"
         file list), or env={...} to add environment variables for this run.
+        Runs with -q by default (terse output); pass quiet=False to get the
+        full human summary block (e.g. to assert on the 'Reclaimed' line).
         """
-        cmd = [DUPEREMOVE, "-q", "--io-threads=4"]
+        cmd = [DUPEREMOVE, "--io-threads=4"]
+        if quiet:
+            cmd.insert(1, "-q")
         if hashfile:
             cmd += ["--hashfile", self.hf]
         cmd += list(args)
@@ -231,6 +239,21 @@ class DuperemoveTest(unittest.TestCase):
         """The last dedupe added no sharing (explicit 0, or no line at all)."""
         nc = self.net_change()
         self.assertIn(nc, (None, 0), f"expected no new sharing, got {nc}")
+
+    def reclaimed_summary(self):
+        """`(size_str, groups)` from the human 'Reclaimed' summary line, or None.
+
+        size_str is the rendered human figure (e.g. '1.0 MiB') — the honest
+        disk-freed amount, one physical copy kept per group. oans omits the
+        whole summary block under -q or when there was nothing to dedupe. For
+        exact byte assertions use the --json `reclaimed_total_bytes` field.
+        """
+        m = _RECLAIMED_RE.search(self.out)
+        return (m.group(1), int(m.group(2))) if m else None
+
+    def assertReclaimed(self, size_str, groups, msg=None):
+        """Assert the summary reported `size_str` reclaimed across `groups`."""
+        self.assertEqual((size_str, groups), self.reclaimed_summary(), msg)
 
     # -- hashfile (SQLite) inspection --------------------------------------
 

--- a/tests/integration/test_dedupe.py
+++ b/tests/integration/test_dedupe.py
@@ -30,6 +30,16 @@ class DedupeTest(DuperemoveTest):
         # Both copies become shared: net change counts the shared bytes on each.
         self.assertEqual(2 * MiB, self.net_change(), "net shared change for a 1 MiB pair")
 
+    def test_reports_honest_reclaimed(self):
+        # The human summary reports the disk actually freed: deduping a 1 MiB
+        # pair keeps one copy and frees the other, so 1.0 MiB across 1 group —
+        # not the 2 MiB fiemap "net change in shared extents".
+        self.mkdup("tree/a", "tree/b", MiB)
+        self.sync()
+        self.dm("-rd", self.path("tree"), quiet=False)  # -q hides the summary
+        self.assertDmOk()
+        self.assertReclaimed("1.0 MiB", 1)
+
     def test_is_idempotent(self):
         a, b = self.mkdup("tree/a", "tree/b", MiB)
         self.sync()


### PR DESCRIPTION
Two follow-ups from the v1.2.0 release session.

## `scripts/release.sh`

Encodes the `CLAUDE.md` "Releasing" convention as a two-phase script (merging the bump PR stays a human decision):

- **`prepare X.Y.Z`** — branches `release/vX.Y.Z` off `origin/master`, bumps the version string in the two man pages (`docs/man/oans.8`, `docs/man/oans.md`), runs the full `scripts/verify.sh` gate, pushes, and opens the `Bump version to X.Y.Z` PR. Refuses on a dirty tree or existing tag.
- **`publish X.Y.Z [NOTES]`** — refuses until the bump is on `origin/master` (PR merged), then creates the annotated tag and the GitHub release. Auto-seeds notes from the commit log since the previous tag if no file is given.

Honors `PKG_CONFIG_PATH` / `DUPEREMOVE_TEST_DIR` like `verify.sh`; never merges the PR itself. Arg-validation and man-page sed patterns verified against the current tree; `bash -n` clean.

## `assertReclaimed` test helper

The suite runs everything with `-q`, which suppresses the human summary — so the honest `Reclaimed` line was only ever pinned via `--json`. Added:
- `dm(..., quiet=False)` to opt into the full summary block,
- `reclaimed_summary()` → `(size_str, groups)` and `assertReclaimed(size, groups)`,
- `test_reports_honest_reclaimed`: a 1 MiB pair reports `1.0 MiB across 1 group`.

Full suite: 88 pass (was 87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)