### PR TITLE
docs(CLAUDE): trim ~24% + add scripts/devenv.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,299 +4,225 @@
 the kernel `FIDEDUPERANGE` ioctl (atomic, byte-verified). Hashes live in a
 SQLite **hashfile** (WAL mode, `synchronous=OFF`, `cache_size=-65536` = 64 MB).
 
-All C sources live under `src/` (main program `src/oans.c`); man page sources
-under `docs/man/`. The binary is `oans`; `make install` adds a `duperemove`
-compat symlink. Some identifiers keep the old name on purpose: the
-`DUPEREMOVE*` env vars and the `DuperemoveTest` python test base class.
+C sources are under `src/` (main `src/oans.c`); man-page sources under
+`docs/man/`. The binary is `oans`; `make install` adds a `duperemove` compat
+symlink. Some identifiers keep the old name on purpose: the `DUPEREMOVE*` env
+vars and the `DuperemoveTest` python base class.
+
+**Local dev box:** `source scripts/devenv.sh` once per shell — it points
+pkg-config at the local header shim, sets the reflink test dir, and adds pandoc
+to `PATH` (each a no-op if absent), so `make`, `scripts/verify.sh`, etc. need no
+env prefixes. This box can't `dnf install` the `-devel` packages, hence the shim
+under `/tmp/devroot`; a normal machine with the README's deps needs none of it.
 
 ## Repo layout & workflow (read first)
 
-- **This checkout is a git *worktree*.** The default branch `master` is checked
-  out in a *sibling* worktree (`../duperemove-master`), so `git checkout master`
-  here fails ("already used by worktree"). To sync/branch from latest master:
-  `git fetch origin && git checkout --detach origin/master`, then
-  `git checkout -b <branch> origin/master`. After a branch is merged+deleted,
-  park this worktree with `git checkout --detach origin/master`.
-- **GitHub is a fork.** All `gh` commands need `--repo martinus/oans`
-  (`gh pr create --repo martinus/oans …`); a bare `gh pr create` fails.
-- **Never merge a PR without the user explicitly saying so** ("merge it"). The
-  established rhythm is: build on a branch → open a PR → wait. The user often
-  asks for a `/simplify` pass on the branch before merging.
-- **`scripts/verify.sh`** is the one-shot pre-PR gate: build (warnings = failure),
-  `make check`, and a valgrind scan+dedupe+replay smoke. Run it as
-  `PKG_CONFIG_PATH=/tmp/devroot/pc DUPEREMOVE_TEST_DIR=/home/martinus/.itest-scratch bash scripts/verify.sh`.
-- **`make doc`** (regenerate the man page from `docs/man/oans.md`) needs
-  `pandoc`, which isn't always installed; a static build was fetched to
-  `/tmp/pandoc-3.6.4/bin` (ephemeral — re-fetch if `/tmp` was cleared) and run as
-  `PATH=/tmp/pandoc-3.6.4/bin:$PATH make doc`. roff escapes `-` as `\-`, so grep
-  the generated `.8` accordingly.
-- Confirm you are testing *this* build (`./oans`), not a system-installed
-  `duperemove`, before diagnosing any runtime behaviour.
+- **This checkout is a git *worktree*.** `master` is checked out in a sibling
+  worktree (`../duperemove-master`), so `git checkout master` here fails. Branch
+  with `git fetch origin && git checkout -b <branch> origin/master`; park the
+  worktree afterwards with `git checkout --detach origin/master`.
+- **GitHub is a fork:** every `gh` command needs `--repo martinus/oans`.
+- **Never merge a PR without the user explicitly saying "merge it".** Rhythm:
+  branch → PR → wait. The user often asks for a `/simplify` pass first.
+- **`scripts/verify.sh`** is the pre-PR gate: build (warnings = failure),
+  `make check`, and a valgrind scan+dedupe+replay smoke.
+- **`make doc`** regenerates the man page from `docs/man/oans.md` and needs
+  `pandoc` (on `PATH` via `devenv.sh`). roff escapes `-` as `\-`, so grep the
+  generated `.8` accordingly.
+- Confirm you're testing *this* `./oans`, not a system `duperemove`, before
+  diagnosing runtime behaviour.
 
 ## Releasing
 
-The version string comes from `git describe --tags` (Makefile), so **a release
-is just a git tag** — there is no committed `VERSION` file to bump. Use
-**`scripts/release.sh`**, which encodes the whole convention (latest: `v1.2.0`,
-2026-07-18). It's two phases because merging the bump PR is a human decision:
+The version is `git describe --tags` (Makefile) — **a release is just a tag**,
+no `VERSION` file. **`scripts/release.sh`** encodes the convention in two phases
+(merging the bump PR is a human step):
 
 ```sh
-scripts/release.sh prepare X.Y.Z          # bump both man pages, run verify.sh, open the PR
-#   → review & merge the "Bump version to X.Y.Z" PR (with the user's OK, as always)
+scripts/release.sh prepare X.Y.Z          # bump man pages, run verify.sh, open the PR
+#   → review & merge the "Bump version to X.Y.Z" PR
 scripts/release.sh publish X.Y.Z [NOTES]  # tag the merged master + create the GH release
 ```
 
-- `prepare` branches `release/vX.Y.Z` off `origin/master`, bumps the committed
-  man-page version strings (the script owns the exact files and sed patterns),
-  runs the full `verify.sh` gate, then pushes and opens the PR. It refuses on a
-  dirty tree or an existing tag.
-- `publish` refuses until that bump is on `origin/master` (i.e. the PR merged),
-  then makes the annotated tag and the GitHub release. With no `NOTES` file it
-  seeds the body from the commit log since the previous tag (edit on GitHub
-  after); pass a file for grouped notes (Features / Performance / Correctness /
-  Housekeeping). Releases attach **no** build artifacts — source only.
-- It honors `PKG_CONFIG_PATH` / `DUPEREMOVE_TEST_DIR` like `verify.sh`, so on
-  this box run it with `PKG_CONFIG_PATH=/tmp/devroot/pc scripts/release.sh …`.
+`prepare` refuses on a dirty tree or existing tag; `publish` refuses until the
+bump is on `origin/master`, then tags and releases (auto-seeds notes from the
+commit log if no `NOTES` file). Releases attach no build artifacts.
 
-- **Versioning is incremental semver.** The CLI is a superset of duperemove's and
-  hashfiles auto-rebuild, so feature batches are backward-compatible → **minor**
-  bumps (`1.1.1` → `1.2.0`). Reserve major for an actual break. (`v1.0.0`/`1.1.x`
-  were all cut 2026-07-17 *before* the fork's headline features; `1.2.0` was the
-  first release carrying `--stats`, `--history`/`--json`, `--autotune`, systemd
-  timers, self-describing hashfiles and honest reclaimed reporting.)
-- **`gh pr merge --merge` is blocked by the local permission classifier**; use
-  `--squash` (allowed). Prior release commits are merge commits, but squash is fine.
+- **Incremental semver.** The CLI is a superset of duperemove's and hashfiles
+  auto-rebuild, so feature batches are backward-compatible → **minor** bumps
+  (`1.1.1`→`1.2.0`); reserve major for a real break. (`1.2.0` was the first
+  release carrying the fork's headline features.)
+- **`gh pr merge --merge` is blocked by the local permission classifier** — use
+  `--squash`.
 
 ## Build & test
 
 ```sh
-make -j$(nproc)                         # builds oans
-make check                              # C unit tests (src/tests.c) + Python integration suite
-DUPEREMOVE=./oans python3 tests/run.py           # integration suite only
+make -j$(nproc)                        # build oans
+make check                             # C unit tests + Python integration suite
+DUPEREMOVE=./oans python3 tests/run.py # integration suite only
 ```
 
-Integration tests are Python stdlib `unittest` (no extra deps); they drive the
-built binary against a scratch tree and assert on the hashfile and on-disk
-sharing. Dedupe cases need a reflink-capable fs — override with
-`DUPEREMOVE_TEST_DIR=/mnt/btrfs` (this box: `/home/martinus/.itest-scratch`, on
-btrfs). Keep tests in `tests/`; don't add shell tests.
+Integration tests are stdlib `unittest` (no deps); they drive the built binary
+against a scratch tree and assert on the hashfile and on-disk sharing. Dedupe
+cases need a reflink fs (`DUPEREMOVE_TEST_DIR`, set by `devenv.sh`). Keep tests
+in `tests/`; no shell tests.
 
-- **Don't run scans/benchmarks out of `/tmp` — it's tmpfs**, which is not
-  reflink-capable and which `is_fs_supported()` rejects, so a scan there stores
-  **0 files silently** and dedupe is a no-op. Always point test data and
-  `DUPEREMOVE_TEST_DIR` at real btrfs/xfs, and verify a non-zero file count
-  before trusting any before/after comparison. (The `~/git` tree, ~174k files on
-  btrfs, is the usual real-data benchmark target.)
+- **Never scan/benchmark out of `/tmp` — it's tmpfs**, not reflink-capable and
+  rejected by `is_fs_supported()`, so a scan there stores **0 files silently**
+  and dedupe is a no-op. Use real btrfs/xfs and verify a non-zero file count
+  before trusting any before/after. (The `~/git` tree, ~174k files on btrfs, is
+  the usual benchmark target.)
 
-### Building on Fedora
+## Profiling & measurement — read before optimizing
 
-Missing headers (`uuid/uuid.h`, libbsd `queue.h`, xxhash) come from a dev shim:
-put `.pc` files under `/tmp/devroot/pc` and build with
-`PKG_CONFIG_PATH=/tmp/devroot/pc make`. This is a local workaround, not part of
-the repo — don't commit it.
-
-## Profiling & measurement — read this before optimizing
-
-Startup/scan cost has burned us before. The rules:
-
-- **`scripts/perf-profile.sh`** wraps all of this: it runs an oans command
-  under `perf` and prints the self/leaf view, the caller/stack view, `perf stat`,
-  and a syscall summary. E.g.
+- **`scripts/perf-profile.sh`** runs an oans command under `perf` and prints the
+  self/leaf + caller/stack views, `perf stat`, and a syscall summary, e.g.
   `scripts/perf-profile.sh --cold -- -dr --hashfile=/tmp/prof.db ~/git`.
-- **Never draw conclusions from `strace -c`.** Its per-syscall interception
-  overhead inflates whatever is called most often. It once reported `statx` at
-  66% (it's really ~7%) and completely hid the actual hotspot, which was
-  per-file SQLite WAL locking. Use **`perf record -g --call-graph dwarf`** +
-  `perf report` for where time goes, and **`perf stat -e task-clock`** for A/B
-  wall-clock.
-- **When A/B-testing two builds, build two distinctly-named binaries** (e.g.
-  `/tmp/dm-base`, `/tmp/dm-batch`) and confirm they actually differ before
-  trusting the numbers. A `git stash` + `make` that silently reused a stale
-  object file once made a binary look identical to itself → a real ~24% win got
-  wrongly dismissed as "no effect." Interleave runs to cancel drift.
-- **A single surprising result that contradicts prior profiling is probably a
+- **Never trust `strace -c`** — its interception overhead inflates the
+  most-called syscall. It once reported `statx` at 66% (really ~7%) and hid the
+  real hotspot (per-file SQLite WAL locking). Use `perf record -g --call-graph
+  dwarf` for where time goes, `perf stat -e task-clock` for A/B wall-clock.
+- **A/B-test two distinctly-named binaries** and confirm they differ before
+  trusting numbers — a stale object file once made a build look identical to
+  itself and a real ~24% win got dismissed. Interleave runs to cancel drift.
+- **A lone surprising result that contradicts prior profiling is probably a
   measurement bug**, not a discovery. Reconcile before acting.
 
 ## Hashfile / SQLite gotchas
 
-- **`cache_size = -65536` (64 MB per connection), not 256 MB.** The pragma is
-  applied to *every* connection (listing handle, batched writer, and one per
-  walker thread), so on a large hashfile the peak RSS was dominated by these
-  caches (a NAS user hit ~870 MB on a 1.7M-file tree). Measured on the 174k-file
-  `~/git`: dropping 256 MB → 64 MB is **perf-neutral** on both the warm rescan
-  (change-detection is btrfs-metadata-bound, and the OS page cache backs the DB)
-  and the full `-rd` (dedupe-phase group-loading). 16 MB was ~3% slower on the
-  dedupe joins, so 64 MB is the floor that keeps them cached. Don't raise it back
-  to 256 MB without a measured reason. Further memory work (giving the per-walker
-  read handles a tiny cache; `seen_inodes` scales ~50 B/file) is unexplored.
-
-- In WAL mode a connection holds its read snapshot across queries. Wrapping the
-  per-file change-detection reads in **one batched read transaction** (refreshed
-  ~10s), instead of an implicit transaction per file, cut `F_SETLK` from ~2/file
-  (283k on a 141k-file rescan) to ~800 total, ~24% faster. The writer batches on
-  the same ~10s cadence so the reader snapshot doesn't pin the WAL against
-  checkpointing. Reader and writer must stay **separate SQLite connections**.
-- The listing thread reads through the listing handle (`db`) and writes through
-  the batched writer handle (`wdb`/`scan_writer`) — keep that split.
-- `.hashfile-wal` and `.hashfile-shm` are SQLite WAL sidecars. Normal, don't
-  hand-delete them.
-- **Hardlink hazard:** `INSERT OR REPLACE` on `UNIQUE(ino, subvol)` can cascade-
-  delete rows for other links to the same inode. An in-memory `seen_inodes` set
-  guards this; a batch that aborts here can silently empty the hashfile while
-  exiting 0. There's a regression test — keep it.
-- **Deleted-file pruning is automatic and stat-based.** After each scan,
-  `dbfile_prune_missing_files()` drops rows whose path `stat()`s to ENOENT
-  (extent/block hashes cascade via the FK), then `dbfile_maybe_vacuum` compacts
-  when ≥25% is free. It must stay stat-based, not "delete rows not walked this
-  run" — otherwise scanning a subdir (or a shared hashfile) would nuke
-  out-of-scope files. Pinned by `test_prune_is_stat_based_not_scope_based`.
+- **`cache_size = -65536` (64 MB per connection).** Applied to every connection
+  (listing handle, batched writer, one per walker), so it dominates peak RSS on
+  a large hashfile (a NAS user hit ~870 MB on 1.7M files). Measured on 174k-file
+  `~/git`: 256 MB→64 MB is **perf-neutral** (warm rescan is btrfs-metadata-bound
+  and the OS page cache backs the DB; `-rd` group-loading unaffected); 16 MB was
+  ~3% slower on the dedupe joins, so 64 MB is the floor. Don't raise it back
+  without a measured reason. (Further per-handle-cache / `seen_inodes` ~50 B/file
+  memory work is unexplored.)
+- **One batched read transaction, not one per file.** In WAL mode a connection
+  holds its read snapshot across queries; wrapping the per-file change-detection
+  reads in a single transaction (refreshed ~10s) cut `F_SETLK` from ~2/file
+  (283k on a 141k rescan) to ~800, ~24% faster. The writer batches on the same
+  cadence so the reader snapshot doesn't pin the WAL against checkpointing.
+  Reader and writer must be **separate connections** (`db` listing handle vs
+  `wdb`/`scan_writer`).
+- `.hashfile-wal` / `.hashfile-shm` are SQLite WAL sidecars — don't hand-delete.
+- **Hardlink hazard:** `INSERT OR REPLACE` on `UNIQUE(ino, subvol)` can
+  cascade-delete rows for other links to the inode; an in-memory `seen_inodes`
+  set guards it (a batch aborting here could silently empty the hashfile while
+  exiting 0). Keep the regression test.
+- **Deleted-file pruning is stat-based.** After each scan
+  `dbfile_prune_missing_files()` drops rows whose path `stat()`s ENOENT (hashes
+  cascade via FK), then `dbfile_maybe_vacuum` compacts at ≥25% free. It must
+  stay stat-based, not "delete rows not walked this run" — else scanning a subdir
+  or a shared hashfile would nuke out-of-scope files. Pinned by
+  `test_prune_is_stat_based_not_scope_based`.
 
 ## Scan parallelism (the walk)
 
-The directory walk (`opendir`/`readdir`/`statx`) runs on N walker threads
-(`--io-threads`); every regular file is handed to a **single consumer** (the
-main thread) that runs `__scan_file()`. That split is deliberate: all the
-delicate per-file state — the batched writer, `dedupe_seq`, `seen_inodes`, the
-batched read transaction, `subvol_cache` — stays on the one consumer and needs
-no locking. Walkers only read `locked_fs` (set on the main thread before they
-spawn) and the mutex-guarded `verified_devs`. **Don't move per-file DB state
-onto the walker threads.**
+The walk (`opendir`/`readdir`/`statx`) runs on N walker threads
+(`--io-threads`); every regular file goes to a **single consumer** (the main
+thread) running `__scan_file()`. Deliberate: all delicate per-file state (batched
+writer, `dedupe_seq`, `seen_inodes`, batched read txn, `subvol_cache`) stays on
+the one consumer, lock-free. Walkers only read `locked_fs` (set before they
+spawn) and mutex-guarded `verified_devs`. **Don't move per-file DB state onto the
+walkers.**
 
-- **Walker count plateaus at ~8 on btrfs — do not raise the default cap.**
-  Measured on a cold 149k-file `~/git` scan: 1→2→4 threads scaled well
-  (15s→9.9s→7.8s), 8 was the knee (7.3s), and 16/32 gave no wall-clock gain
-  while `sys` time exploded (16s→23s→46s). It's btrfs metadata b-tree lock
-  contention (`btrfs_search_slot` / `_raw_spin_lock`), not I/O latency, so more
-  threads just burn cores. The default cap (8) is right.
-- On a cold walk the cost is fundamental btrfs metadata I/O
-  (`statx → btrfs_iget → btree reads`); SQLite is <2%, so parallelizing the
-  consumer would not help that workload.
+- **Walker count plateaus at ~8 on btrfs — don't raise the cap.** Cold 149k-file
+  `~/git`: 1→2→4 scaled (15→9.9→7.8s), 8 was the knee (7.3s), 16/32 gave no wall
+  gain while `sys` exploded (16→23→46s). It's btrfs metadata b-tree lock
+  contention (`btrfs_search_slot`/`_raw_spin_lock`), not I/O.
+- Cold-walk cost is fundamental btrfs metadata I/O (`statx→btrfs_iget→btree`);
+  SQLite is <2%, so parallelizing the consumer wouldn't help.
 
-## io-threads auto-tuning (storage detection + --autotune)
+## io-threads auto-tuning (--autotune)
 
-`--io-threads` sizes three pools (walkers, the csum/read pool, the dedupe
-pool). Its default is no longer a flat `min(nproc, 8)`; two mechanisms refine
-it, both **only when the user didn't pass `--io-threads`** (tracked by
-`options.io_threads_set`), and both resolved on the main thread *after* the
-roots are known (`auto_tune_io_threads()` in `oans.c`, called before
-`print_header`/`scan_files`) — the fs isn't known at the old pre-parse default
-site.
+`--io-threads` sizes three pools (walkers, csum/read, dedupe). Two mechanisms
+refine its default, both **only when the user didn't pass `--io-threads`**
+(`options.io_threads_set`) and both resolved on the main thread after the roots
+are known (`auto_tune_io_threads()` in `oans.c`).
 
 - **`src/storage.{c,h}` — heuristic from device type.** `storage_detect()`
-  reports rotational-ness + device count. btrfs pools have an anonymous
-  `st_dev` with no `/sys/block` entry, so members are enumerated via
-  `BTRFS_IOC_FS_INFO` (`num_devices`, `max_id`) + `BTRFS_IOC_DEV_INFO` (device
-  path → `st_rdev` → `/sys/dev/block/MAJ:MIN/queue/rotational`, with a
-  `../queue` parent fallback for partitions). Single-device fs reads the file's
-  `st_dev` directly. `storage_recommend_io_threads()` is **pure and
-  unit-tested** (`test_storage_recommend_io_threads`): SSD/unknown keep
-  `min(nproc,8)` (the previously-validated path, unchanged); a single HDD gets
-  ≤4; an HDD pool gets ~2 per device, capped at 8. These HDD constants are
-  *educated guesses* — they were never measured on real spinning-disk/RAID
-  hardware. Treat `--autotune` as authoritative.
-- **`src/autotune.{c,h}` — empirical measurement (`--autotune`).** Re-execs
-  `oans` on a bounded sample (fed as a `-` file list, **no hashfile** → pure
-  in-memory read+hash) at each candidate thread count, interleaved across
-  rounds, keeping each candidate's *fastest* run (per the profiling rules:
-  interleave to cancel drift, min-of-N for noise). It drops the page cache
-  between trials (`/proc/sys/vm/drop_caches`, needs root) and the scan's own
-  `POSIX_FADV_DONTNEED` keeps the sample cold for free. Sample/round bounds:
-  `DUPEREMOVE_AUTOTUNE_{MAX_FILES,MAX_BYTES,ROUNDS}`. With `--hashfile` it
-  stores the winner under config key `autotune_io_threads`
-  (`dbfile_{set,get}_config_int`); a later plain run reads it back and it wins
-  over the storage heuristic (but an explicit `--io-threads` still overrides
-  everything). Pinned by `test_autotune.py`.
-- **Measuring on the dev box is misleading:** the sandbox/CI fs is often ext,
-  which `is_fs_supported()` rejects, so autotune trials read 0 bytes and the
-  throughput numbers are pure process-startup noise. The *mechanism* still
-  runs; real numbers need a btrfs/xfs target.
+  reports rotational-ness + device count (btrfs pools enumerated via
+  `BTRFS_IOC_FS_INFO`/`DEV_INFO` → `/sys/.../queue/rotational`).
+  `storage_recommend_io_threads()` is pure and unit-tested: SSD/unknown keep
+  `min(nproc,8)` (the validated path, unchanged); single HDD ≤4; HDD pool
+  ~2/device capped at 8. **The HDD constants are unmeasured guesses** — treat
+  `--autotune` as authoritative.
+- **`src/autotune.{c,h}` — empirical (`--autotune`).** Re-execs oans on a bounded
+  sample (`-` file list, no hashfile → pure in-memory read+hash) at each thread
+  count, interleaved, keeping each candidate's fastest run. Drops the page cache
+  between trials (`drop_caches`, needs root). Bounds:
+  `DUPEREMOVE_AUTOTUNE_{MAX_FILES,MAX_BYTES,ROUNDS}`. With `--hashfile` it stores
+  the winner (config key `autotune_io_threads`); a later plain run reads it back
+  (an explicit `--io-threads` still overrides). Pinned by `test_autotune.py`.
+- **Measuring autotune on the dev box is misleading:** on an unsupported fs
+  (ext) trials read 0 bytes and the numbers are startup noise; needs a btrfs/xfs
+  target.
 
 ## Self-describing hashfile, history & scheduling (fork features)
 
-These are the fork's user-facing additions on top of upstream; a fresh session
-should know they exist before touching option parsing or `dbfile`.
-
-- **Self-describing hashfile.** Every run stores its scan-shaping options
-  (`-d`, `-r`, `--skip-zeroes`, `--min-filesize`, `--dedupe-options`), its roots
-  (canonicalised via `realpath`), and its `--exclude` patterns — options as
-  `opt_*` keys in `config`, roots/excludes in the `scan_roots`/`scan_excludes`
-  tables (`dbfile_store_scan_config`/`dbfile_load_scan_config`). A bare
-  `oans --hashfile=FILE` (no file args) **replays** the last run
-  (`apply_scan_config` + `drop_missing_roots` in `oans.c`). Semantics:
-  last-run-wins; other options on a bare-replay line are ignored; if a stored
-  root is missing it's skipped with a warning, and if *all* are gone oans
-  refuses (so the stat-based prune can't wipe the hashfile — e.g. an unmounted
-  drive); a replay does not re-persist (a transiently-missing root is retried
-  next time). Pinned by `test_self_describing.py`.
-- **Run history & metrics.** Each run appends a row to `run_history`
-  (`dbfile_record_run`, called from `main()` after `process_duplicates`).
-  `--history` prints a human timeline + lifetime totals; `--json` prints a flat
-  metrics object (current stats + history totals) for jq/Telegraf/node_exporter.
-  Totals go through `dbfile_get_run_summary`. Gotcha: capture the per-run
-  file count via `pscan_files_scanned()` **inside `scan_files`** (an out-param) —
-  the dedupe phase reuses the progress counters, and `pscan.files_examined` is
-  cleared ~10×/s by the renderer so it is *not* a usable total. Pinned by
-  `test_history_metrics.py`.
-- **`--stats`** prints the hashfile report (identity, stored scan config, file
-  and duplicate counts). `-L` lists files; `-R` removes paths. `-L`/`-R`/
-  `--stats`/`--history`/`--json`/`--autotune` are mutually-exclusive report
-  modes (collapsed into one `report_count` check in `parse_options`).
-- **Scheduling.** `systemd/oans@.service` + `oans@.timer` (installed by
-  `make install-systemd`, kept out of `make install`) run
-  `oans --hashfile=/var/cache/oans/%i.hash` on a timer, replaying the stored
-  config. User guide: `docs/nas-quickstart.md`.
-- The `fdupes` mode was **removed** (redundant with the core scan+dedupe); don't
-  reintroduce it.
+- **Self-describing hashfile.** Each run stores its scan-shaping options (`opt_*`
+  keys in `config`), roots (realpath'd) and `--exclude` patterns
+  (`scan_roots`/`scan_excludes` tables) via
+  `dbfile_store_scan_config`/`load_scan_config`. A bare `oans --hashfile=FILE`
+  **replays** the last run (`apply_scan_config`+`drop_missing_roots`):
+  last-run-wins, other options ignored, a missing root skipped with a warning —
+  but if *all* roots are gone oans refuses (so the stat prune can't wipe the
+  hashfile, e.g. an unmounted drive); a replay doesn't re-persist. Pinned by
+  `test_self_describing.py`.
+- **Run history & metrics.** Each run appends to `run_history`
+  (`dbfile_record_run`, from `main()` after `process_duplicates`). `--history` =
+  human timeline + lifetime totals (`dbfile_get_run_summary`); `--json` = a flat
+  metrics object for jq/Telegraf. Gotcha: take the per-run file count from
+  `pscan_files_scanned()` (out-param) **inside `scan_files`** — the dedupe phase
+  reuses the progress counters and `pscan.files_examined` is cleared ~10×/s by
+  the renderer. Pinned by `test_history_metrics.py`.
+- **Report modes** `-L`/`-R`/`--stats`/`--history`/`--json`/`--autotune` are
+  mutually exclusive (one `report_count` check in `parse_options`): `--stats` =
+  hashfile report, `-L` lists files, `-R` removes paths.
+- **Scheduling.** `systemd/oans@.{service,timer}` (via `make install-systemd`,
+  kept out of `make install`) run `oans --hashfile=/var/cache/oans/%i.hash` on a
+  timer, replaying the stored config. Guide: `docs/nas-quickstart.md`.
+- The `fdupes` mode was **removed** — don't reintroduce it.
 
 ## Measured dead-ends — don't re-attempt without new evidence
 
-Each of these was investigated/measured and rejected; re-deriving them wastes a
-session (see the profiling rules above — measure, don't guess):
-
-- **Warm rescan is single-consumer pipeline-latency-bound**, not
-  CPU/query-bound. A no-op rescan of ~174k files is ~2s wall / ~0.9s CPU,
-  invariant to `--io-threads` (1..16) and CPU count — the serial consumer
-  (`__scan_file`: queue handoff + per-file `dbfile_describe_file`) sets the
-  floor. `dbfile_describe_file` is only ~0.12s of CPU.
-- **Bulk in-memory change-detection cache** (preload the `files` table into a
-  hash to skip the per-file `describe_file` query) was prototyped and
-  **measured a regression** (2.0s→3.1s): the query isn't the bottleneck, and the
-  upfront load adds ~1s. Rejected.
-- **statx-relative-to-dir-fd** (avoid re-resolving the absolute path per file)
-  gave ~5-8% less scan *CPU* but **zero wall-clock** change (walk isn't the
-  wall bottleneck); PR was closed as not worth it.
-- **A savings "preview"/dry-run is not worth building.** You can't predict real
-  reclaimed disk without doing the dedupe (compression, extent alignment, the
-  kernel declining a dedupe, and especially snapshot/external refcounts), and
-  dedupe is already safe + self-reporting, so "just run it" wins. `--stats`
-  already reports the logical upper bound.
-- **"Biggest-savings-first" dedupe order already exists**: `push_extents`
-  (`run_dedupe.c`) qsorts groups by `cmp_dext_work` = `de_len*(de_num_dupes-1)`
-  (reclaimable bytes, descending) before dispatching to the pool. Only caveat is
-  it's per generation-pass, not global — not worth changing.
+- **Warm rescan is single-consumer pipeline-latency-bound**, not CPU/query. A
+  no-op rescan of ~174k files is ~2s wall / ~0.9s CPU, invariant to
+  `--io-threads` (1..16); the serial consumer (`__scan_file` queue handoff +
+  per-file `dbfile_describe_file`, only ~0.12s CPU) sets the floor.
+- **Bulk in-memory change-detection cache** (preload `files` to skip the per-file
+  `describe_file`) was prototyped and **measured a regression** (2.0→3.1s): the
+  query isn't the bottleneck and the preload adds ~1s.
+- **statx-relative-to-dir-fd** gave ~5-8% less scan *CPU* but **zero wall**
+  change; PR closed.
+- **A savings preview / dry-run isn't worth building.** Real reclaimed disk can't
+  be predicted without doing the dedupe (compression, extent alignment, the
+  kernel declining, snapshot/external refcounts), and dedupe is already safe and
+  self-reporting. `--stats` gives the logical upper bound. (A compsize-style
+  *physical* estimate needs root — `BTRFS_IOC_LOGICAL_INO` — so it can't back an
+  unprivileged preview either.)
+- **"Biggest-savings-first" order already exists:** `push_extents` qsorts by
+  `cmp_dext_work = de_len*(de_num_dupes-1)` (reclaimable bytes, desc). Only per
+  generation-pass, not global — not worth changing.
 
 ## dedupe_seq (incremental dedup)
 
 Scan assigns `seq = config+1`, bumped every `--batchsize`/`-B` files (default
 1024). `process_duplicates` loops `for i=dedupe_seq; i<max` over generations;
-each group is deduped exactly once regardless of batch size (verified — a
-no-change rerun nets 0).
-
-The group is never *re-deduped*, but until the cross-pass fix the loaders did
-re-load and re-fiemap-check every already-deduped member of a group each pass
-it appeared in — wasted work, not a correctness bug — and
-`pick_least_fragmented_target` picked a fresh target per pass, so a group
-spanning many passes converged to one cluster *per pass* instead of a single
-extent. The `GET_DUPLICATE_*` loaders now load only the members new in a pass
-plus one stable representative (min id/rowid) as the target, and mark that
-dext `de_anchored` to pin the target. Force many small passes with
-`DUPEREMOVE_FILES_PER_PASS` to exercise it (see `test_cross_pass.py`). Don't
-reintroduce loading all `dedupe_seq <= ?2` members.
+each group is deduped exactly once (a no-change rerun nets 0). The
+`GET_DUPLICATE_*` loaders load only the members new in a pass plus one stable
+representative (min id) as the target, marked `de_anchored` to pin it — this
+fixed both wasted per-pass re-load/re-fiemap of already-deduped members and
+per-pass target drift (a group spanning passes used to converge to one cluster
+*per pass* instead of a single extent). Exercise with `DUPEREMOVE_FILES_PER_PASS`
+(`test_cross_pass.py`); don't reintroduce loading all `dedupe_seq <= ?2` members.
 
 ## Valgrind
 
-Run with the suppressions file, which filters the one class of library
-false-positive:
+`verify.sh` runs the smoke. Manual, with the suppressions file (filters the one
+library false-positive):
 
 ```sh
 valgrind --leak-check=full --track-origins=yes \
@@ -304,53 +230,43 @@ valgrind --leak-check=full --track-origins=yes \
 ```
 
 The suppressed noise is GLib/glibc **thread TLS** ("possibly lost" under
-`pthread_create` -> `_dl_allocate_tls`): GLib caches idle pool threads instead
-of joining them all at exit. Not an oans leak. Everything else must be clean —
-`definitely lost` and any uninitialised-value / invalid-access errors are real.
-(One such was fixed: `__dbfile_get_config` read an unterminated UUID buffer;
-config string buffers from `get_config_text` are raw `memcpy`, so anything
+`pthread_create`→`_dl_allocate_tls`: GLib caches idle pool threads). Everything
+else must be clean — `definitely lost` and any uninitialised-value /
+invalid-access errors are real. (One fixed: `__dbfile_get_config` read an
+unterminated UUID buffer; `get_config_text` buffers are raw `memcpy`, so anything
 `strlen`'d must be zero-initialised.)
 
-## Hashfile identity (oans vs duperemove)
+## Hashfile identity & schema version
 
-The hashfile schema version is `DB_FILE_MAJOR.MINOR` in `dbfile.h` (5.0; oans
-forked at upstream duperemove's 4.1 and jumped to 5.0 as a deliberate clean
-break). Every oans hashfile is also stamped with SQLite `PRAGMA application_id =
-OANS_APP_ID` ("oans" in ASCII) and `dbfile_check()` **strictly** refuses any file
-that doesn't carry the brand — foreign, or a pre-brand/duperemove file. A
-brand-new empty file (`dbfile_config_empty()`) is stamped *before* the check, so
-a fresh scan doesn't recreate-loop; existing files must already carry the brand.
-A failed check unlinks and recreates the hashfile (it's only a cache).
+Schema version is `DB_FILE_MAJOR.MINOR` in `dbfile.h` (5.0; forked at upstream
+4.1, jumped to 5.0 as a clean break). Every hashfile is stamped `PRAGMA
+application_id = OANS_APP_ID` ("oans"); `dbfile_check()` strictly refuses any file
+without the brand (foreign, or pre-brand/duperemove). A brand-new empty file is
+stamped *before* the check (so a fresh scan doesn't recreate-loop); a failed
+check unlinks and recreates (it's only a cache).
 
-**On schema changes and `DB_FILE_MINOR`:** `dbfile_check()` rejects a file whose
-`minor` differs, which *discards and rebuilds* it — so a bump forces every
-existing hashfile to be re-scanned from scratch. Therefore bump `DB_FILE_MINOR`
-**only** for a change an old binary could misread; do **not** bump for a purely
-*additive* change (a new `CREATE TABLE IF NOT EXISTS`, or a new optional key in
-the `config` table). `create_tables()` runs on every open, so additive tables
-appear on old files automatically and old binaries just ignore the extra
-rows/keys. The self-describing (`scan_roots`/`scan_excludes`), run-history
-(`run_history`), and autotune (`autotune_io_threads` config key) features were
-all added this way and left `DB_FILE_MINOR` at `5.0` on purpose.
-
-A from-scratch build (new hashfile or a recreated one) sets `hashfile_rebuilt`,
-which makes `dbfile_maybe_vacuum()` force a one-off `VACUUM` at the end: a fresh
-build is at insert density (random-key `path_hash`/digest indexes fill ~2/3), so
-it lands ~15-20% smaller than the un-vacuumed size. Normal incremental runs
-still only VACUUM once ≥25% of the file is free.
+- **Bump `DB_FILE_MINOR` only for a change an old binary could misread.**
+  `dbfile_check()` rejects a differing `minor`, discarding and rebuilding the
+  file (a full re-scan). Do **not** bump for purely *additive* changes (a new
+  `CREATE TABLE IF NOT EXISTS`, or an optional `config` key): `create_tables()`
+  runs every open, so additive tables appear on old files and old binaries ignore
+  the extras. Self-describing, run-history and autotune were all added this way,
+  left at `5.0`.
+- A from-scratch build sets `hashfile_rebuilt` → `dbfile_maybe_vacuum()` forces a
+  one-off `VACUUM` (a fresh build is at insert density, ~15-20% larger
+  un-vacuumed). Incremental runs only VACUUM at ≥25% free.
 
 ## Correctness invariants
 
-- Ctrl+C is safe: `FIDEDUPERANGE` is atomic and the hashfile stays WAL-consistent
-  on process kill. Only power loss risks the hashfile (due to `synchronous=OFF`).
-- A no-op rescan must net **0** changes and leave row counts identical. Use this
-  as a smoke test after any scan-path change.
-- **The "Reclaimed" figure is logical, not disk.** It counts the honest bytes
-  freed (kernel-deduped = one physical copy kept per group), but on a compressed
-  btrfs (e.g. `zstd`) dedupe frees *compressed* blocks while the number is the
-  *logical* (uncompressed) amount, so real disk reclaimed is ~ratio smaller. The
-  piped/`-q` "net change in shared extents" line is a separate fiemap diagnostic
-  that counts the surviving copy as shared too (~2x for pairs). To
-  verify actual space freed, compare `compsize` **Disk Usage** before/after (not
-  `df`); `Referenced` staying constant proves nothing was lost. `--json`'s
-  `reclaimable_logical_bytes` is likewise a logical upper bound.
+- **Ctrl+C is safe:** `FIDEDUPERANGE` is atomic and the hashfile stays
+  WAL-consistent on kill. Only power loss risks it (`synchronous=OFF`).
+- **A no-op rescan must net 0 changes** and leave row counts identical — a smoke
+  test after any scan-path change.
+- **"Reclaimed" is a logical figure, not disk.** It's the honest bytes freed
+  (kernel-deduped = one physical copy kept per group), but on compressed btrfs
+  dedupe frees *compressed* blocks while the number is *logical*, so real disk
+  freed is ~ratio smaller. Verify with `compsize` **Disk Usage** before/after
+  (not `df`); `Referenced` staying constant proves nothing was lost. The piped /
+  `-q` "net change in shared extents" line is a separate fiemap diagnostic
+  (counts the surviving copy too, ~2× for pairs); `--json`
+  `reclaimable_logical_bytes` is a logical upper bound.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,10 @@ C sources are under `src/` (main `src/oans.c`); man-page sources under
 symlink. Some identifiers keep the old name on purpose: the `DUPEREMOVE*` env
 vars and the `DuperemoveTest` python base class.
 
-**Local dev box:** `source scripts/devenv.sh` once per shell — it points
-pkg-config at the local header shim, sets the reflink test dir, and adds pandoc
-to `PATH` (each a no-op if absent), so `make`, `scripts/verify.sh`, etc. need no
-env prefixes. This box can't `dnf install` the `-devel` packages, hence the shim
-under `/tmp/devroot`; a normal machine with the README's deps needs none of it.
+**Local dev box:** `source scripts/devenv.sh` once per shell (see its header) so
+`make`, `scripts/verify.sh`, etc. need no env prefixes. This box can't `dnf
+install` the `-devel` packages, hence the `/tmp/devroot` pkg-config shim; a
+normal machine with the README's deps needs none of it.
 
 ## Repo layout & workflow (read first)
 

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -9,23 +9,24 @@
 #
 # Every knob is set only if its target exists, so sourcing this is a harmless
 # no-op on a normal machine (where the README's dnf/apt deps cover everything).
+# Override any location if your setup differs, e.g.
+#   OANS_DEVROOT=/opt/oans-shim source scripts/devenv.sh
 #
 # The pkg-config shim itself - headers/libs for uuid, libbsd and xxhash under
-# /tmp/devroot, referenced by the two .pc files in /tmp/devroot/pc - is a local,
-# uncommitted artifact; recreate it there if /tmp was cleared.
+# $OANS_DEVROOT, referenced by the two .pc files in $OANS_DEVROOT/pc - is a
+# local, uncommitted artifact; recreate it there if /tmp was cleared.
 
-# Header/lib shim so pkg-config finds uuid, libbsd, xxhash.
-[ -d /tmp/devroot/pc ] &&
-	export PKG_CONFIG_PATH="/tmp/devroot/pc${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+: "${OANS_DEVROOT:=/tmp/devroot}"             # pkg-config header/lib shim
+: "${OANS_TEST_DIR:=$HOME/.itest-scratch}"    # reflink-capable test scratch dir
+: "${OANS_PANDOC_BIN:=/tmp/pandoc-3.6.4/bin}" # static pandoc for `make doc`
 
-# Integration-test scratch dir; must be reflink-capable (btrfs/xfs).
-[ -d "$HOME/.itest-scratch" ] &&
-	export DUPEREMOVE_TEST_DIR="$HOME/.itest-scratch"
+[ -d "$OANS_DEVROOT/pc" ] &&
+	export PKG_CONFIG_PATH="$OANS_DEVROOT/pc${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+[ -d "$OANS_TEST_DIR" ] &&
+	export DUPEREMOVE_TEST_DIR="$OANS_TEST_DIR"
+[ -d "$OANS_PANDOC_BIN" ] &&
+	export PATH="$OANS_PANDOC_BIN:$PATH"
 
-# Static pandoc for `make doc` (man-page regeneration).
-[ -d /tmp/pandoc-3.6.4/bin ] &&
-	export PATH="/tmp/pandoc-3.6.4/bin:$PATH"
-
-# Sourced, not executed: end on a success so a failed [ -d ] test above does not
+# Sourced, not executed: end on success so a failed [ -d ] test above does not
 # leave $? non-zero in the caller's shell.
 :

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# devenv.sh - SOURCE this once per shell to set up the local dev-box environment
+# for building and testing oans on a sandbox that can't install the -devel
+# packages system-wide:
+#
+#   source scripts/devenv.sh
+#   make -j"$(nproc)" && scripts/verify.sh
+#
+# Every knob is set only if its target exists, so sourcing this is a harmless
+# no-op on a normal machine (where the README's dnf/apt deps cover everything).
+#
+# The pkg-config shim itself - headers/libs for uuid, libbsd and xxhash under
+# /tmp/devroot, referenced by the two .pc files in /tmp/devroot/pc - is a local,
+# uncommitted artifact; recreate it there if /tmp was cleared.
+
+# Header/lib shim so pkg-config finds uuid, libbsd, xxhash.
+[ -d /tmp/devroot/pc ] &&
+	export PKG_CONFIG_PATH="/tmp/devroot/pc${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+# Integration-test scratch dir; must be reflink-capable (btrfs/xfs).
+[ -d "$HOME/.itest-scratch" ] &&
+	export DUPEREMOVE_TEST_DIR="$HOME/.itest-scratch"
+
+# Static pandoc for `make doc` (man-page regeneration).
+[ -d /tmp/pandoc-3.6.4/bin ] &&
+	export PATH="/tmp/pandoc-3.6.4/bin:$PATH"
+
+# Sourced, not executed: end on a success so a failed [ -d ] test above does not
+# leave $? non-zero in the caller's shell.
+:


### PR DESCRIPTION
`CLAUDE.md` had grown to 356 lines. Two changes:

## Trim (356 → 272 lines, ~24%)
A tightening pass over every section. **Kept** all the load-bearing content — the measured dead-ends, the SQLite/hashfile gotchas, the walker/parallelism findings, the `DB_FILE_MINOR` bump rule, and the correctness invariants (that's the whole point of the file). **Cut** restated implementation detail that already lives in the code (e.g. the blow-by-blow of `storage_detect()`'s ioctl walk, exact option lists).

## Automate local env → `scripts/devenv.sh`
`source scripts/devenv.sh` once per shell exports the three machine-specific knobs — `PKG_CONFIG_PATH` (the `/tmp/devroot` header shim), `DUPEREMOVE_TEST_DIR`, and pandoc on `PATH`. Each is **guarded on the target existing**, so sourcing it is a harmless no-op on a normal machine (README deps cover everything there).

That let the doc drop the repeated `PKG_CONFIG_PATH=/tmp/devroot/pc …` command prefixes and fold the "Building on Fedora" + pandoc paragraphs into one reference.

Verified: `source scripts/devenv.sh` then `make` builds shim-free; full suite 88 pass via the devenv-provided `DUPEREMOVE_TEST_DIR`.

Docs + one sourced helper; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)