### PR TITLE
docs: launch-prep — comparison FAQ, benchmarks, AUR packaging, contributor onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report a problem with oans (crash, wrong result, missed or wasted dedupe)
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Dedupe goes through the kernel's byte-verifying
+        `FIDEDUPERANGE` ioctl, so oans cannot corrupt your data — but it can
+        waste work or miss a dedupe, and those are worth fixing.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did oans do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command line
+      description: The exact `oans` invocation (redact paths if you like).
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: oans version
+      description: Output of `oans --version`.
+    validations:
+      required: true
+  - type: dropdown
+    id: filesystem
+    attributes:
+      label: Filesystem
+      options:
+        - btrfs
+        - xfs
+        - other / not sure
+    validations:
+      required: true
+  - type: input
+    id: kernel
+    attributes:
+      label: Kernel version
+      description: Output of `uname -r`.
+    validations:
+      required: true
+  - type: dropdown
+    id: fresh-hashfile
+    attributes:
+      label: Does it reproduce with a fresh (empty) hashfile?
+      options:
+        - "Yes"
+        - "No"
+        - "Not tested"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Logs, `--stats` output, or steps to reproduce.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/martinus/oans/discussions
+    about: For setup/usage questions, prefer Discussions over an issue.
+  - name: NAS / server quick-start
+    url: https://github.com/martinus/oans/blob/master/docs/nas-quickstart.md
+    about: Step-by-step guide for scheduled, monitored dedupe on a NAS.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case, not just the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing options/tools you've tried, and why they fall short.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.o
-oans
-duperemove
+/oans
+/duperemove
 btrfs-extent-same
 csum-test
 hashstats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to oans
+
+Thanks for your interest! oans is a performance-focused fork of
+[duperemove](https://github.com/markfasheh/duperemove) — the core engine is the
+work of Mark Fasheh and the upstream contributors, and contributions here are
+expected to keep that lineage and its GPL-2.0 license intact.
+
+## Reporting bugs and requesting features
+
+Open an [issue](https://github.com/martinus/oans/issues) using the templates. For
+a suspected dedupe/correctness problem, please include your kernel version,
+filesystem (`btrfs` / `xfs`), the exact command line, and whether it reproduces
+on a fresh hashfile.
+
+> Deduplication goes through the kernel's `FIDEDUPERANGE` ioctl, which
+> byte-compares every range before sharing it. A bug can waste work or miss a
+> dedupe — it cannot corrupt your data.
+
+## Building and testing
+
+Install the build dependencies listed in the [README](README.md), then:
+
+```sh
+make -j$(nproc)     # build (warnings are treated as failures)
+make check          # C unit tests + Python integration suite
+```
+
+The integration suite is stdlib-only Python `unittest`. Dedupe test cases need a
+**reflink-capable filesystem** (btrfs or xfs) as the scratch dir — see
+[`tests/README.md`](tests/README.md). Never run tests or benchmarks out of
+`/tmp` (tmpfs is not reflink-capable; a scan there silently stores zero files).
+
+Before opening a PR, run the full pre-flight gate:
+
+```sh
+scripts/verify.sh   # build + make check + a valgrind scan/dedupe/replay smoke
+```
+
+## Pull requests
+
+- Branch from `master`, keep the change focused, and describe what you measured.
+- **Performance claims must be backed by a measurement.** A/B two distinctly
+  named binaries, interleave the runs, and confirm they actually differ before
+  trusting numbers. See [`docs/benchmarks.md`](docs/benchmarks.md).
+- Add or update tests for behavior changes; keep the suite green.
+- If you touch the man page, edit `docs/man/oans.md` and run `make doc` to
+  regenerate `oans.8` (needs `pandoc`).
+- New code should read like the code around it — match the existing style.
+
+## License
+
+By contributing you agree your changes are licensed under
+[GPL-2.0](LICENSE), the same as upstream.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Requires Linux 3.13+ with a btrfs or XFS filesystem.
 make && sudo make install
 ```
 
+> **Arch Linux:** `PKGBUILD`s live in [`packaging/aur/`](packaging/aur) (`oans`
+> for releases, `oans-git` for `master`).
+
 ```sh
 # 1. First run: hash the tree and deduplicate it (-r recurse, -d dedupe)
 sudo oans -dr --hashfile=/var/cache/oans/data.hash /srv/data
@@ -103,7 +106,8 @@ resumes where it left off.
 ## What the fork changes, measured
 
 Benchmarked on real btrfs data (2.07M files, ~230 GiB); your mileage depends
-on your data and filesystem.
+on your data and filesystem. The exact tree, commands and comparison binary are
+documented in the **[benchmark methodology](docs/benchmarks.md)**.
 
 | Change | Effect |
 |---|---|
@@ -116,6 +120,24 @@ on your data and filesystem.
 
 Full reference — every option, FAQ, examples: **[oans man page](docs/man/oans.md)** (`man 8 oans` once installed).
 
+## How it compares
+
+**vs. [bees](https://github.com/Zygo/bees):** bees is an always-on daemon doing
+continuous, block-level dedupe across the *whole* filesystem. oans is the other
+trade-off — an *offline, batch* tool you point at specific trees and run on a
+schedule (or a systemd timer): no resident daemon, no constant background I/O,
+plus per-run stats, history and honest accounting. Pick bees for always-on
+whole-fs dedupe; pick oans for scheduled, observable, targeted runs.
+
+**vs. ZFS deduplication:** ZFS dedupes inline and keeps a large dedupe table
+permanently in RAM (on the order of 1–5 GiB per TiB of data), and it's hard to
+undo. oans needs no dedupe table and no permanent RAM cost — you run it when you
+want, on the btrfs/XFS you already have.
+
+**vs. upstream duperemove:** the same engine, tuned for *re-running regularly*
+— see [What the fork changes](#what-the-fork-changes-measured) above, and the
+attribution below.
+
 ## Relationship to duperemove
 
 oans (Austrian dialect for *"one"* — as in one copy) builds on
@@ -123,7 +145,10 @@ oans (Austrian dialect for *"one"* — as in one copy) builds on
 design and code is the work of **Mark Fasheh** and the upstream contributors,
 and none of this exists without them. The fork's improvements were developed
 with the help of AI tooling; every change was reviewed, tested, and benchmarked
-on real btrfs data before landing.
+on real btrfs data before landing. By design the tool cannot put your data at
+risk regardless: dedupe is performed by the kernel's `FIDEDUPERANGE` ioctl,
+which byte-compares every range before sharing it (see the note near the top),
+so the worst a bug can do is waste work or miss a dedupe.
 
 Differences to know about:
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,62 @@
+# Benchmark methodology
+
+The headline numbers in the [README](../README.md) come from the measurements
+below. They are one person's results on one real dataset; **your mileage depends
+heavily on your data, filesystem and hardware.** Everything here is reproducible
+— the point is that you can re-run it on your own tree rather than trust a
+number.
+
+## Dataset
+
+- A real btrfs tree: **~2.07M files, ~230 GiB**, mostly stable between runs
+  (the shape oans is built for: a NAS / backup / build tree re-scanned
+  regularly).
+- Filesystem: **btrfs** on the test machine. (Never benchmark on `/tmp` — it is
+  tmpfs, not reflink-capable, and a scan there stores zero files silently.)
+
+## What "cold" vs "warm" means
+
+- **Cold first run** — empty hashfile: every file is read and hashed, then
+  deduped. This is dominated by btrfs metadata I/O and raw hashing; oans gains
+  the least here.
+- **Warm re-run** — an existing hashfile from a previous run: only changed files
+  are re-hashed, and files whose extents are already shared are skipped up
+  front. This is the workflow oans optimizes, and where the large speedups show.
+
+## Commands
+
+```sh
+# Cold: fresh hashfile
+sudo oans -dr --hashfile=/var/cache/oans/bench.hash /srv/data
+
+# Warm: re-run against the populated hashfile (no other args needed —
+# oans replays the stored paths/options)
+sudo oans --hashfile=/var/cache/oans/bench.hash
+```
+
+Compared against **duperemove 0.15.2** on the same tree and hardware, runs
+interleaved to cancel drift (A/B/A/B), keeping each candidate's fastest run.
+
+## Headline results
+
+| Scenario | duperemove 0.15.2 | oans | Speedup |
+|---|---|---|---|
+| Warm re-run of an already-deduped tree | ~11 min | ~92 s | ~7× |
+| Dedupe phase (no cross-generation reprocessing) | ~294 s | ~188 s | ~1.6× |
+| Batched SQLite transactions (rescan) | baseline | ~24 % faster | — |
+
+Cold first runs gain much less: the win is in *not repeating work* on re-runs,
+not in the initial hash-everything pass.
+
+## Caveats worth stating up front
+
+- **`Reclaimed` is a logical figure.** On compressed btrfs (e.g. zstd) the real
+  disk freed is smaller by roughly your compression ratio, because dedupe shares
+  logical extents while disk holds compressed blocks. For ground truth compare
+  `compsize` **Disk Usage** before/after; `Referenced` staying constant proves
+  nothing was lost.
+- **Walker parallelism plateaus.** On btrfs, scaling `--io-threads` past ~8 gives
+  no wall-clock gain — it is metadata b-tree lock contention, not I/O. Use
+  `--autotune` to pick the fastest count for your disks.
+- **Numbers are not portable across machines.** Reproduce on your own tree
+  before quoting them.

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -475,6 +475,15 @@ Two logically identical files are not always deduped: \f[CR]oans\f[R]
 works on extent boundaries, so files with the same content but a
 different on\-disk extent layout may not match unless block\-level
 matching is enabled with \f[B]\-\-dedupe\-options=partial\f[R].
+.PP
+\f[CR]oans\f[R] is offline, batch deduplication: you point it at
+specific trees and run it on demand or on a timer.
+This differs from \f[CR]bees\f[R], an always\-on daemon that
+deduplicates the whole filesystem continuously, and from inline
+filesystem dedupe such as ZFS, which maintains a permanent in\-RAM
+dedupe table.
+\f[CR]oans\f[R] keeps no such table and imposes no background cost
+between runs.
 .SH SEE ALSO
 \f[CR]btrfs\f[R](8), \f[CR]xfs\f[R](8), \f[CR]filesystems\f[R](5),
 \f[CR]ioctl_fideduprange\f[R](2), \f[CR]compsize\f[R](8)

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -410,6 +410,12 @@ boundaries, so files with the same content but a different on-disk extent layout
 may not match unless block-level matching is enabled with
 **\--dedupe-options=partial**.
 
+`oans` is offline, batch deduplication: you point it at specific trees and run it
+on demand or on a timer. This differs from `bees`, an always-on daemon that
+deduplicates the whole filesystem continuously, and from inline filesystem
+dedupe such as ZFS, which maintains a permanent in-RAM dedupe table. `oans` keeps
+no such table and imposes no background cost between runs.
+
 # SEE ALSO
 
 `btrfs`(8), `xfs`(8), `filesystems`(5), `ioctl_fideduprange`(2), `compsize`(8)

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,33 @@
+# AUR packaging
+
+Source `PKGBUILD`s for the Arch User Repository, kept in-tree so they version
+alongside the code:
+
+- [`oans/PKGBUILD`](oans/PKGBUILD) — stable, builds from the latest release tag.
+- [`oans-git/PKGBUILD`](oans-git/PKGBUILD) — VCS package, builds from `master`.
+
+Both install a `duperemove` compatibility symlink, so they `provides`/`conflicts`
+with the `duperemove` package.
+
+## Publishing to the AUR
+
+The AUR expects each package in its own git repo containing `PKGBUILD` and a
+generated `.SRCINFO`. To publish or update `oans`:
+
+```sh
+cd packaging/aur/oans
+makepkg --printsrcinfo > .SRCINFO   # regenerate whenever PKGBUILD changes
+# then push PKGBUILD + .SRCINFO to ssh://aur@aur.archlinux.org/oans.git
+```
+
+## On a new release
+
+Bump `pkgver`, reset `pkgrel=1`, and refresh the checksum in
+[`oans/PKGBUILD`](oans/PKGBUILD):
+
+```sh
+updpkgsums          # rewrites sha256sums from the release tarball
+```
+
+`oans-git` needs no checksum or manual `pkgver` bump — its `pkgver()` derives the
+version from `git describe`.

--- a/packaging/aur/oans-git/PKGBUILD
+++ b/packaging/aur/oans-git/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: martinus <martin.ankerl@gmail.com>
+pkgname=oans-git
+pkgver=1.2.0.r0.g0000000
+pkgrel=1
+pkgdesc="Fast, safe filesystem deduplication for btrfs & xfs — a duperemove fork (VCS)"
+arch=('x86_64')
+url="https://github.com/martinus/oans"
+license=('GPL-2.0-only')
+depends=('glib2' 'sqlite' 'xxhash' 'util-linux-libs' 'libbsd')
+makedepends=('git' 'pkgconf')
+provides=('oans' 'duperemove')
+conflicts=('oans' 'duperemove')
+source=("git+$url.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd oans
+  git describe --long --tags --abbrev=7 | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd oans
+  make
+}
+
+package() {
+  cd oans
+  make install DESTDIR="$pkgdir" PREFIX=/usr
+  make install-systemd DESTDIR="$pkgdir" PREFIX=/usr
+}

--- a/packaging/aur/oans/PKGBUILD
+++ b/packaging/aur/oans/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: martinus <martin.ankerl@gmail.com>
+pkgname=oans
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="Fast, safe filesystem deduplication for btrfs & xfs — a duperemove fork"
+arch=('x86_64')
+url="https://github.com/martinus/oans"
+license=('GPL-2.0-only')
+depends=('glib2' 'sqlite' 'xxhash' 'util-linux-libs' 'libbsd')
+makedepends=('pkgconf')
+provides=('duperemove')
+conflicts=('duperemove')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('257580e6dd3c1099750e7780fbbcd7b9d59b99b6097cd3346c5862caa9483413')
+
+build() {
+  cd "$pkgname-$pkgver"
+  make
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  make install DESTDIR="$pkgdir" PREFIX=/usr
+  make install-systemd DESTDIR="$pkgdir" PREFIX=/usr
+}


### PR DESCRIPTION
Groundwork so the repo is ready for a marketing push. **Docs, packaging and metadata only — no code changes.**

## What's here
- **README + man page — "How it compares"**: bees vs ZFS dedup vs upstream duperemove, the question that leads every btrfs-dedup thread. The attribution paragraph now sits the byte-verifying `FIDEDUPERANGE` safety guarantee right next to the "developed with AI tooling" line.
- **`docs/benchmarks.md`**: the exact tree, cold-vs-warm commands and duperemove 0.15.2 comparison behind the ~7× / 294→188 s numbers, linked from the README so the claims are reproducible.
- **`packaging/aur/`**: in-tree `PKGBUILD`s for `oans` (release, checksummed against v1.2.0) and `oans-git` (VCS), each `provides`/`conflicts` the `duperemove` package. README covers publishing to the AUR.
- **`CONTRIBUTING.md` + issue templates**: bug/feature YAML forms + Discussions/NAS-guide contact links, for when traffic arrives.
- **`.gitignore`**: anchored the built-binary rules to root (`/oans`, `/duperemove`) — the unanchored `oans` rule was silently ignoring the new `packaging/aur/oans/` directory.

## Also done outside this PR
- Added repo discovery topics: `nas`, `homelab`, `selfhosted`, `storage`, `linux`.

## Still needs a human (can't do from here)
- Publish the AUR package (needs your AUR account/SSH key — see `packaging/aur/README.md`).
- Record an asciinema/GIF of a real run for the README.
- Set a custom social preview image.
- **XFS**: CI only exercises btrfs; the tests are fs-adaptive with explicit XFS handling, so support is real but not CI-proven — worth a manual `oans -dr` smoke on a real XFS reflink fs before launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)