### PR TITLE
Finish the "Compacting the rebuilt hashfile" line with "done"

### DIFF
--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1267,17 +1267,33 @@ void dbfile_maybe_vacuum(struct dbhandle *db)
 	    (total == 0 || freelist * 100 < total * VACUUM_FREE_PCT))
 		return;
 
+	/* Announce without a trailing newline and finish the line with "done"
+	 * afterwards, so the compaction never looks like it is still running once
+	 * it has completed. The progress printer is not running here, so the
+	 * partial line is buffered - flush it before the (possibly slow) VACUUM. */
 	if (hashfile_rebuilt) {
-		qprintf("Compacting the rebuilt hashfile ...\n");
+		qprintf("Compacting the rebuilt hashfile ... ");
 	} else {
-		vprintf("Vacuuming hashfile: %"PRIu64" of %"PRIu64" pages free\n",
+		vprintf("Vacuuming hashfile: %"PRIu64" of %"PRIu64" pages free ... ",
 			freelist, total);
 	}
+	fflush(stdout);
 
 	/* Maintenance only: a failure here must not fail the run. */
 	ret = sqlite3_exec(db->db, "VACUUM", NULL, NULL, NULL);
-	if (ret)
+
+	if (ret) {
+		if (hashfile_rebuilt) {
+			qprintf("\n");
+		} else {
+			vprintf("\n");
+		}
 		perror_sqlite(ret, "vacuuming hashfile");
+	} else if (hashfile_rebuilt) {
+		qprintf("done\n");
+	} else {
+		vprintf("done\n");
+	}
 }
 
 static int get_config_int(sqlite3_stmt *stmt, const char *name, int *val)


### PR DESCRIPTION
On a from-scratch build, the one-off `VACUUM` printed `Compacting the rebuilt hashfile ...` and then ran a potentially slow compaction with nothing after it — so the finished run's **last line was the in-progress message**, making it look like oans was still working.

Now it announces without a trailing newline (flushed — the progress printer isn't running at that point, so the partial line would otherwise stay buffered) and completes the line after the VACUUM:

```
Compacting the rebuilt hashfile ... done
```

The verbose `Vacuuming hashfile: …` path gets the same `… done` treatment; on VACUUM error the line is terminated before `perror_sqlite`.

Output-only change. Verified: `scripts/verify.sh` green (88 tests + valgrind smoke), and a fresh-hashfile `-dr` run now prints the completed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)