### PR TITLE
Reduce peak RSS: smaller read buffers + per-role SQLite cache budgets

### DIFF
--- a/scripts/bench-ram.sh
+++ b/scripts/bench-ram.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# A/B peak-RSS + wall-time benchmark for the scan / find_dupes path.
+#
+# Runs `oans -r` (scan + duplicate search, NO -d, so it is non-destructive and
+# repeatable) against a synthetic tree, reporting peak RSS and wall time. Point
+# it at two binaries (e.g. a baseline built from master and your working build)
+# and interleave to compare — that is how the read-buffer and per-connection
+# cache budgets were tuned.
+#
+#   scripts/bench-ram.sh <work-dir on btrfs/xfs> <oans-binary> [many|big] [io-threads]
+#
+# Profiles (dataset is generated once and reused):
+#   many  ~250k small files, dup-heavy  -> exercises the find_dupes search pool
+#   big   ~48 large files (~40 MiB each) -> exercises the per-thread read buffers
+#
+# Example A/B:
+#   git worktree add /tmp/oans-base origin/master && make -C /tmp/oans-base
+#   scripts/bench-ram.sh ~/bench /tmp/oans-base/oans many
+#   scripts/bench-ram.sh ~/bench ./oans            many
+set -euo pipefail
+
+WORK="${1:?usage: bench-ram.sh <work-dir> <oans-binary> [many|big] [io-threads]}"
+BIN="${2:?need path to an oans binary}"
+PROFILE="${3:-many}"
+IO="${4:-8}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$PROFILE" in
+  many) gen=(DEMO_UNIQUE=50000 DEMO_DUP_GROUPS=50000 DEMO_COPIES=4 DEMO_MEAN_KB=8  DEMO_MAX_KB=64) ;;
+  big)  gen=(DEMO_UNIQUE=48    DEMO_DUP_GROUPS=1     DEMO_COPIES=2 DEMO_MEAN_KB=40000 DEMO_MIN_KB=40000 DEMO_MAX_KB=40000) ;;
+  *) echo "unknown profile '$PROFILE' (use many|big)" >&2; exit 1 ;;
+esac
+
+# Generate the tree once; reuse it across binaries/runs for a fair comparison.
+if [ ! -d "$WORK/tree" ]; then
+  env "${gen[@]}" DROP_CACHES=0 bash "$here/demo/setup.sh" "$WORK" >&2
+fi
+
+rm -f "$WORK"/h.db*
+/usr/bin/time -v "$BIN" -r --io-threads="$IO" --cpu-threads="$IO" \
+  --hashfile="$WORK/h.db" "$WORK/tree" 2>"$WORK/.time" >/dev/null
+wall=$(awk -F'wall clock).*: ' '/Elapsed \(wall/{print $2}' "$WORK/.time")
+rss=$(awk '/Maximum resident/{print $6}' "$WORK/.time")
+printf '%-22s io=%s  wall=%-9s  peakRSS=%d MiB\n' "$(basename "$BIN") [$PROFILE]" "$IO" "$wall" "$((rss/1024))"

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -385,7 +385,10 @@ static int dbfile_set_modes(sqlite3 *db)
 		return ret;
 	}
 
-	ret = sqlite3_exec(db, "PRAGMA cache_size = -65536", NULL, NULL, NULL);
+	char cache_pragma[48];
+	snprintf(cache_pragma, sizeof(cache_pragma),
+		 "PRAGMA cache_size = -%d", DB_CACHE_KB_DEFAULT);
+	ret = sqlite3_exec(db, cache_pragma, NULL, NULL, NULL);
 	if (ret) {
 		perror_sqlite(ret, "configuring database (cache size)");
 		return ret;
@@ -766,6 +769,24 @@ err:
 struct dbhandle *dbfile_open_handle(char *filename)
 {
 	return open_handle(filename, false);
+}
+
+/*
+ * Shrink (or grow) a handle's SQLite page-cache budget from the default. Used to
+ * cap peak RSS: the walker and search-pool connections don't run the heavy
+ * dedupe joins, so they don't need the full DB_CACHE_KB_DEFAULT each.
+ */
+void dbfile_set_cache_kb(struct dbhandle *db, unsigned int kb)
+{
+	char pragma[48];
+	int ret;
+
+	if (!db)
+		return;
+	snprintf(pragma, sizeof(pragma), "PRAGMA cache_size = -%u", kb);
+	ret = sqlite3_exec(db->db, pragma, NULL, NULL, NULL);
+	if (ret)
+		perror_sqlite(ret, "adjusting cache size");
 }
 
 /*

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -83,6 +83,19 @@ struct dbhandle *dbfile_open_handle_ro(char *filename);
 void dbfile_close_handle(struct dbhandle *db);
 
 /*
+ * Per-connection SQLite page-cache budgets, in KiB. Every connection defaults
+ * to DB_CACHE_KB_DEFAULT; on a large hashfile that cache fills toward the cap,
+ * so connections that don't run the heavy dedupe joins are given a smaller
+ * budget to bound peak RSS (the search pool alone opens up to cpu_threads of
+ * them). Override a handle's budget with dbfile_set_cache_kb() after opening.
+ */
+#define DB_CACHE_KB_DEFAULT	65536	/* loader / reader / writer: the heavy joins */
+#define DB_CACHE_KB_SEARCH	32768	/* find_dupes search pool (x cpu_threads) */
+#define DB_CACHE_KB_WALKER	 2048	/* walkers only read the fs-uuid config, if that */
+
+void dbfile_set_cache_kb(struct dbhandle *db, unsigned int kb);
+
+/*
  * Open the database (options.hashfile)
  * On success, the handle is registered to be freed when the thread pool is freed
  */

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -200,7 +200,15 @@ static void scan_writer_close(void)
 	scan_writer = NULL;
 }
 
-#define READ_BUF_LEN (8*1024*1024) // 8MB
+/*
+ * Per-read-thread streaming buffer (one static __thread buffer per csum thread,
+ * reused across files). Files larger than this are read in successive passes, so
+ * the size only trades read() syscall count against memory: at --io-threads=8
+ * the old 8 MiB cost 64 MiB of resident buffers on large-file trees. 1 MiB
+ * saturates sequential read throughput (the scan is I/O/metadata-bound) while
+ * cutting that to 8 MiB. Measured perf-neutral; see scripts/bench-ram.sh.
+ */
+#define READ_BUF_LEN (1*1024*1024) // 1MB
 
 struct buffer {
 	char *buf;
@@ -889,6 +897,9 @@ int filescan_walk_run(struct dbhandle *db)
 		struct dbhandle *wdb = dbfile_open_handle(options.hashfile);
 
 		abort_on(!wdb);
+		/* Walkers only ever read the fs-uuid config (once, if at all), so
+		 * a full 64 MiB page cache each is pure overhead - shrink it. */
+		dbfile_set_cache_kb(wdb, DB_CACHE_KB_WALKER);
 		threads[i] = g_thread_new("walker", walk_thread, wdb);
 	}
 

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -294,6 +294,11 @@ static void search_file_extents(struct filerec *file, struct results_tree *dupe_
 				options.hashfile == NULL ? "(null)" : options.hashfile);
 			return;
 		}
+		/* Up to cpu_threads of these run at once; a smaller per-connection
+		 * cache bounds peak RSS on large hashfiles. The hot index/DB pages
+		 * stay warm in the shared OS page cache, so the joins keep their
+		 * speed. */
+		dbfile_set_cache_kb(db, DB_CACHE_KB_SEARCH);
 	}
 
 	/*


### PR DESCRIPTION
Two memory optimizations for large trees, both **measured perf-neutral**. Investigation started from massif: peak heap was 88% the per-thread read buffer, and the 64 MiB SQLite cache (a lazily-filled *ceiling*) multiplies across the walker and search-pool connections at scale.

## Changes
1. **Read/hash buffer 8 MiB → 1 MiB** (`file_scan.c`). One `static __thread` buffer per csum thread, so at `--io-threads=8` the old size cost **64 MiB** of resident buffers on large-file trees. Files larger than the buffer are already read in successive passes, and 1 MiB saturates sequential read throughput (scan is I/O/metadata-bound).
2. **Per-connection SQLite cache budgets** (`dbfile`). Every connection defaulted to 64 MiB. Connections that don't run the heavy dedupe joins now get less: the **find_dupes search pool** (up to `cpu_threads` connections) → 32 MiB, and the **walkers** (which only read the fs-uuid config, if that) → 2 MiB. The loader/reader/writer keep 64 MiB. Hot pages stay warm in the shared OS page cache, so the joins keep their speed. (`sqlite3_soft_heap_limit64` was ruled out — the distro SQLite isn't built with `SQLITE_ENABLE_MEMORY_MANAGEMENT`.)

## Benchmarks (btrfs, io/cpu-threads=8, interleaved A/B via `scripts/bench-ram.sh`)
| Workload | wall base → new | peak RSS base → new |
|---|---|---|
| Large files (2 GB, read-buffer path) | 2.00 s → **2.00 s** | 70 → **15 MiB** (−54) |
| 250k files, dup-heavy (66 MiB hashfile) | 10.92 s → **10.91 s** | ~200 → **167 MiB** (−~35) |

The #2 saving grows with hashfile size (this was only a 66 MiB hashfile; the 870 MiB/1.7M-file reports are where the ≤8 search connections × 64 MiB really bite).

## Also
- New reproducible harness `scripts/bench-ram.sh` (non-destructive `oans -r`, peak RSS + wall).
- Correctness: `scripts/verify.sh` green (88 tests + valgrind).

Follow-ups not in this PR (measured separately): shrinking `seen_inodes` (~50 B/file) and trying `PRAGMA mmap_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)