### PR TITLE
README: Add libtomic dependency for Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Summary
 
 ```sh
 # Fedora / RHEL
-sudo dnf install gcc make pkgconf-pkg-config \
+sudo dnf install gcc make libatomic pkgconf-pkg-config \
     glib2-devel sqlite-devel xxhash-devel \
     libuuid-devel libmount-devel libblkid-devel libbsd-devel
 


### PR DESCRIPTION
This may be needed for other Fedora version, but has not been tested. Also, this was not a normal Fedora install, so installing from iso may already include libatomic. Regardless, libatomic is a depedency.