### PR TITLE
stats: relabel "reclaimable" as "duplicated" (logical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Summary
 | ⚡ **Fast where it counts** | Re-runs skip everything already hashed *and* everything already shared. Rescanning a deduped 2M-file / 230 GiB tree: **~92 s with oans vs ~11 min with duperemove 0.15.2** (~7×). |
 | 🪄 **Zero-config re-runs** | The hashfile remembers your options, paths and excludes. After the first run, `oans --hashfile=FILE` — nothing else — replays it incrementally. |
 | ⏰ **Scheduling built in** | `sudo make install-systemd`, then `systemctl enable --now oans@data.timer`. Weekly dedupe at idle I/O priority, no cron scripts. |
-| 📊 **Statistics & history** | `--stats` shows what a hashfile holds and how much is reclaimable; `--history` shows space reclaimed over time; `--json` exports metrics for dashboards. |
+| 📊 **Statistics & history** | `--stats` shows what a hashfile holds and how much is duplicated; `--history` shows space actually reclaimed over time; `--json` exports metrics for dashboards. |
 | 🎯 **Honest reporting** | A clean, colorful live progress display (rate + ETA) and a summary that reports the disk space *actually freed* — not an inflated shared-extents figure. |
 | 🔒 **Hardened** | Fixes a data-loss-adjacent upstream bug (hardlinks could silently empty the hashfile), read-only report modes that are safe while a dedupe runs, and an integration suite CI runs against a real btrfs. |
 | 🤝 **Drop-in compatible** | The CLI is a close superset of duperemove's, and `make install` provides a `duperemove` compatibility symlink. |
@@ -105,7 +105,7 @@ the fastest I/O settings for your disks).
 ## Watching it work
 
 ```sh
-oans --stats   --hashfile=data.hash   # files, hashes, duplication, reclaimable space
+oans --stats   --hashfile=data.hash   # files, hashes, logical duplication (freed if deduped)
 oans --history --hashfile=data.hash   # reclaimed space per run + lifetime total
 oans --json    --hashfile=data.hash   # machine-readable metrics for a dashboard
 ```

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -228,9 +228,12 @@ Default is the host CPU count capped at \f[B]8\f[R]; an explicit
 \f[B]\-\-stats\f[R]
 Print a summary of the hashfile and exit: its format and identity, the
 stored scan configuration a bare replay would use, how many files and
-hashes it holds, the total logical data tracked, the whole\-file
-duplication it records (duplicate groups and reclaimable bytes), and how
-much a compaction would reclaim.
+hashes it holds, the total logical data tracked, and the whole\-file
+duplication it records (duplicate groups and their logical duplicate
+volume).
+That volume is a logical figure \- it is already shared on disk if you
+have run a dedupe, so check \f[B]\-\-history\f[R] for bytes actually
+freed and \f[CR]compsize\f[R](8) for on\-disk usage.
 Requires \f[B]\-\-hashfile\f[R].
 .TP
 \f[B]\-\-history\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -184,9 +184,11 @@ directory scans the regular files directly inside it; add **-r** to recurse.
 **\--stats**
   ~ Print a summary of the hashfile and exit: its format and identity, the
     stored scan configuration a bare replay would use, how many files and hashes
-    it holds, the total logical data tracked, the whole-file duplication it
-    records (duplicate groups and reclaimable bytes), and how much a compaction
-    would reclaim. Requires **\--hashfile**.
+    it holds, the total logical data tracked, and the whole-file duplication it
+    records (duplicate groups and their logical duplicate volume). That volume is
+    a logical figure — it is already shared on disk if you have run a dedupe, so
+    check **\--history** for bytes actually freed and `compsize`(8) for on-disk
+    usage. Requires **\--hashfile**.
 
 **\--history**
   ~ Print the run history recorded in the hashfile and exit: the number of runs,

--- a/src/oans.c
+++ b/src/oans.c
@@ -340,11 +340,12 @@ static int print_hashfile_stats(char *filename)
 	printf("\n%s%swhole-file duplicates%s\n", col_bold, col_blue, col_reset);
 	printf("  %sgroups%s          %"PRIu64"\n", col_dim, col_reset, groups);
 	printf("  %sfiles in groups%s %"PRIu64"\n", col_dim, col_reset, dupfiles);
-	printf("  %sreclaimable%s     %s%s%s   %s(%.1f%% of tracked data)%s\n",
+	printf("  %sduplicated%s      %s%s%s   %s(%.1f%% of tracked data; logical - already"
+	       " freed if deduped, see --history)%s\n",
 	       col_dim, col_reset, col_green, human_size(reclaim), col_reset,
 	       col_dim, logical ? 100.0 * reclaim / logical : 0.0, col_reset);
 	if (ntop)
-		printf("  %stop groups%s      %ssize x copies · reclaimable · example%s\n",
+		printf("  %stop groups%s      %ssize x copies · duplicated · example%s\n",
 		       col_dim, col_reset, col_dim, col_reset);
 	for (i = 0; i < ntop; i++) {
 		char szb[48], wb[32];

--- a/tests/integration/test_stats.py
+++ b/tests/integration/test_stats.py
@@ -20,7 +20,7 @@ class StatsTest(DuperemoveTest):
         self.assertIn("whole-file duplicates", out)
         self.assertRegex(out, r"tracked\s+4")
         self.assertRegex(out, r"groups\s+1")
-        self.assertIn("reclaimable", out)
+        self.assertIn("duplicated", out)
         # top-groups list: the a/b/c group of 3 shows as "... x 3 ..."
         self.assertIn("top groups", out)
         self.assertRegex(out, r"x 3\b")


### PR DESCRIPTION
Fixes a genuinely confusing `--stats` line (it confused me *and* the author while debugging a real NAS run).

## Problem
The `--stats` "reclaimable" figure is computed purely from **content hashes** (whole-file duplicate groups) — it has no idea about on-disk sharing. So on an already-deduped tree it still reports the full duplicate volume, which reads as *"410 GiB waiting to be freed"* when in reality it's **already shared** (confirmed on a real 1.7M-file NAS: `--stats` said "reclaimable 410 GiB" while `compsize` showed ~400 GiB already deduped).

I first tried to *split* it into reclaimed vs reclaimable, but the hashfile can't support that: `poff` is `0` after a plain scan, and dedupe rewrites the extent rows — there's no reliable "already shared" signal to query without touching the filesystem (which `--stats` deliberately doesn't).

## Fix
Relabel it to what it actually is, and point at the real numbers:
```
whole-file duplicates
  groups          209201
  files in groups 587072
  duplicated      410.7 GiB   (8.1% of tracked data; logical - already freed if deduped, see --history)
```
- `--history` = bytes **actually** freed over time.
- `compsize` = on-disk truth.

Man page, README, and the top-groups column header updated to match; `test_stats` now asserts the new label. `--json`'s `reclaimable_logical_bytes` keeps its name (already honest — it has "logical").

Output-only; no behavior change. `oans.8` was hand-patched (not `make doc`-regenerated) to avoid a pandoc-version reflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)