### PR TITLE
Hash largest files first (LPT scheduling)

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -76,8 +76,78 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st);
 static bool seen_inode(uint64_t ino, uint64_t subvol);
 static void mark_inode_seen(uint64_t ino, uint64_t subvol);
 static void mark_file_seen(int64_t id);
+struct buffer;
+static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer);
 
-static struct threads_pool scan_pool;
+/*
+ * Scan work queue — approximate longest-processing-time-first (LPT) dispatch.
+ *
+ * Files are queued as the walk discovers them and hashing starts immediately,
+ * exactly as before, but a free csum thread always takes work from the largest
+ * non-empty size class first. That keeps every thread busy and avoids the
+ * failure mode where a huge file happens to be the last thing left and hashes
+ * single-threaded while the other threads sit idle.
+ *
+ * Rather than order files exactly, they are bucketed by size on a log scale:
+ * bucket 0 is everything <1 MiB, then one bucket per power of two above that
+ * (1 MiB, 2 MiB, 4 MiB, …). Each bucket is an intrusive FIFO (walk order
+ * preserved within a class) and a 64-bit occupancy bitmask names the non-empty
+ * buckets, so both push and pop are O(1): pop finds the top bucket with a single
+ * count-leading-zeros on the mask, never a scan over buckets. A huge file sits
+ * alone in a high bucket and is therefore dispatched first; the only slack vs
+ * exact LPT is the <2× size spread within one bucket, which does not matter for
+ * the idle-tail we are avoiding. On a tree of only small files everything lands
+ * in bucket 0 and this degrades to plain FIFO at zero cost.
+ */
+/*
+ * Files smaller than the floor all share bucket 0. Below this size, ordering by
+ * size can't help makespan (a sub-floor file hashes in well under a millisecond,
+ * so it is never the straggler LPT avoids) and keeping them in one FIFO
+ * preserves walk-order read locality. Above the floor: one bucket per power of
+ * two. Raise the floor to reorder fewer files; lower it only for a measured
+ * reason.
+ */
+#define SCAN_BUCKET_FLOOR_LOG2 20	/* 1 MiB */
+#define SCAN_NBUCKETS 64		/* bucket 0 plus one per power of two; fits a u64 mask */
+
+/* Index of the highest set bit; x must be non-zero. */
+static inline unsigned highest_set_bit(uint64_t x)
+{
+	return 63 - __builtin_clzll(x);
+}
+
+static inline unsigned scan_bucket(uint64_t size)
+{
+	if (size < (1ULL << SCAN_BUCKET_FLOOR_LOG2))	/* below the floor -> bucket 0 */
+		return 0;
+	/* size >= floor here, so highest_set_bit's precondition holds */
+	return highest_set_bit(size) - (SCAN_BUCKET_FLOOR_LOG2 - 1); /* floor->1, 2*floor->2, ... */
+}
+
+/*
+ * A uint64_t size has its top bit at position <= 63, so the largest possible
+ * bucket is 63 - (SCAN_BUCKET_FLOOR_LOG2 - 1). It must index the head/tail
+ * arrays and fit the u64 occupancy mask; this guards the invariant if the floor
+ * or bucket count change.
+ */
+_Static_assert(63 - (SCAN_BUCKET_FLOOR_LOG2 - 1) < SCAN_NBUCKETS,
+	       "largest scan bucket must fit SCAN_NBUCKETS");
+
+struct scan_workq {
+	GMutex lock;
+	GCond cond;			/* signalled on push and on drain */
+	struct file_to_scan *head[SCAN_NBUCKETS];	/* per-bucket FIFO */
+	struct file_to_scan *tail[SCAN_NBUCKETS];
+	uint64_t occupied;		/* bit b set iff bucket b is non-empty */
+	GThread **workers;
+	unsigned int nworkers;
+	bool draining;			/* no more pushes; drain, then workers exit */
+};
+static struct scan_workq scan_workq;
+
+static void scan_workq_push(struct file_to_scan *file);
+static void scan_workq_start(unsigned int nworkers);
+static void scan_workq_drain(void);
 
 /*
  * Scan-phase batched writer.
@@ -202,7 +272,7 @@ static void scan_writer_close(void)
 }
 
 /*
- * Per-read-thread streaming buffer (one static __thread buffer per csum thread,
+ * Per-worker streaming read buffer (each scan worker owns one struct buffer,
  * reused across files). Files larger than this are read in successive passes, so
  * the size only trades read() syscall count against memory: at --io-threads=8
  * the old 8 MiB cost 64 MiB of resident buffers on large-file trees. 1 MiB
@@ -340,8 +410,6 @@ static int prepare_buffer(struct buffer *buffer)
 		goto err;
 
 	buffer->size = READ_BUF_LEN;
-
-	register_cleanup(&scan_pool, (void*)&free, buffer->buf);
 	return 0;
 
 err:
@@ -1018,7 +1086,6 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	int ret;
 	struct file dbfile = {0,};
 	static unsigned int seq = 0, counter = 0;
-	GError *err = NULL;
 	struct file_to_scan *file;
 	int64_t fileid = 0;
 	bool file_renamed;
@@ -1157,13 +1224,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	position++;
 	file->file_position = position;
 
-	if(!g_thread_pool_push(scan_pool.pool, file, &err)) {
-		eprintf("g_thread_pool_push: %s\n", err->message);
-		g_error_free(err);
-		err = NULL;
-		free(file);
-		return 1;
-	}
+	scan_workq_push(file);
 
 	return 0;
 }
@@ -1571,7 +1632,102 @@ static inline bool is_inlined(struct scan_ctxt *ctxt)
 	return extent && extent->fe_flags & FIEMAP_EXTENT_DATA_INLINE;
 }
 
-static void csum_whole_file(struct file_to_scan *file)
+/*
+ * Queue a file for hashing. Called only from the single __scan_file() consumer.
+ * O(1): append to the tail of its size bucket and mark the bucket occupied.
+ */
+static void scan_workq_push(struct file_to_scan *file)
+{
+	struct scan_workq *q = &scan_workq;
+	unsigned b = scan_bucket(file->filesize);
+
+	file->next = NULL;
+	g_mutex_lock(&q->lock);
+	if (q->occupied & (1ULL << b))
+		q->tail[b]->next = file;
+	else
+		q->head[b] = file;
+	q->tail[b] = file;
+	q->occupied |= (1ULL << b);
+	g_cond_signal(&q->cond);
+	g_mutex_unlock(&q->lock);
+}
+
+/* Pop from the largest non-empty bucket, or NULL once drained. Blocks. O(1). */
+static struct file_to_scan *scan_workq_pop(struct scan_workq *q)
+{
+	struct file_to_scan *file;
+	unsigned b;
+
+	g_mutex_lock(&q->lock);
+	while (q->occupied == 0 && !q->draining)
+		g_cond_wait(&q->cond, &q->lock);
+	if (q->occupied == 0) {
+		g_mutex_unlock(&q->lock);
+		return NULL;		/* draining and empty: worker exits */
+	}
+	b = highest_set_bit(q->occupied);	/* biggest non-empty bucket */
+	file = q->head[b];
+	q->head[b] = file->next;
+	if (!q->head[b]) {
+		q->tail[b] = NULL;
+		q->occupied &= ~(1ULL << b);
+	}
+	g_mutex_unlock(&q->lock);
+	return file;
+}
+
+static gpointer scan_worker(gpointer arg)
+{
+	struct scan_workq *q = arg;
+	struct file_to_scan *file;
+	/* One read buffer per worker, allocated on first use and reused across
+	 * files; owned here so it is freed when the worker exits. */
+	struct buffer buffer = {0,};
+
+	while ((file = scan_workq_pop(q)))
+		csum_whole_file(file, &buffer);
+
+	free(buffer.buf);
+	return NULL;
+}
+
+static void scan_workq_start(unsigned int nworkers)
+{
+	struct scan_workq *q = &scan_workq;
+
+	abort_on(q->workers);		/* not re-entrant */
+	if (nworkers < 1)
+		nworkers = 1;
+	q->draining = false;
+	q->occupied = 0;
+	q->workers = calloc(nworkers, sizeof(*q->workers));
+	abort_on(!q->workers);
+	for (unsigned int i = 0; i < nworkers; i++)
+		q->workers[i] = g_thread_new("csum", scan_worker, q);
+	q->nworkers = nworkers;
+}
+
+/* Signal end-of-input and wait for every queued file to finish hashing. */
+static void scan_workq_drain(void)
+{
+	struct scan_workq *q = &scan_workq;
+
+	g_mutex_lock(&q->lock);
+	q->draining = true;
+	g_cond_broadcast(&q->cond);
+	g_mutex_unlock(&q->lock);
+
+	for (unsigned int i = 0; i < q->nworkers; i++)
+		g_thread_join(q->workers[i]);
+
+	free(q->workers);
+	q->workers = NULL;
+	q->nworkers = 0;
+	/* All buckets are empty now (workers drained them); nothing to free. */
+}
+
+static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer)
 {
 	int ret = 0;
 
@@ -1584,7 +1740,6 @@ static void csum_whole_file(struct file_to_scan *file)
 	 * serialized (and batched) behind the write lock.
 	 */
 	struct dbhandle *db = scan_writer;
-	static __thread struct buffer buffer = {0,};
 
 	/* Dummy variables used to trigger the cleanup code */
 	_cleanup_(pscan_reset_thread) struct pscan_thread *tprogress = NULL;
@@ -1599,16 +1754,16 @@ static void csum_whole_file(struct file_to_scan *file)
 	/* Prevent close on fd 0 if, somehow, an error occurs before we open */
 	ctxt.fd = -1;
 
-	if (!(buffer.buf)) {
-		ret = prepare_buffer(&buffer);
+	if (!(buffer->buf)) {
+		ret = prepare_buffer(buffer);
 		if (ret) {
 			eprintf("unable to prepare our read buffer\n");
 			return;
 		}
 	} else {
 		/* Clean leftovers from another call */
-		buffer.dl_offset = 0;
-		buffer.dl_len = 0;
+		buffer->dl_offset = 0;
+		buffer->dl_len = 0;
 	}
 
 	if (!db) {
@@ -1685,7 +1840,7 @@ static void csum_whole_file(struct file_to_scan *file)
 			continue;
 		}
 
-		ret = fill_buffer(&ctxt, &buffer);
+		ret = fill_buffer(&ctxt, buffer);
 		if (ret < 0) {
 			ret = errno;
 			eprintf("Unable to read file %s: %s\n",
@@ -1696,7 +1851,7 @@ static void csum_whole_file(struct file_to_scan *file)
 		if (ret == 0)
 			eof_reached = true;
 
-		bytes_processed = process_blocks(&ctxt, &buffer, &hashes);
+		bytes_processed = process_blocks(&ctxt, buffer, &hashes);
 		if (bytes_processed < 0) {
 			eprintf("process_blocks failed somehow\n");
 			return;
@@ -1706,9 +1861,9 @@ static void csum_whole_file(struct file_to_scan *file)
 		tprogress->total_scanned_bytes += bytes_processed;
 
 		/* Process the last partial block */
-		if (eof_reached && (size_t)bytes_processed < buffer.dl_len) {
-			ret = process_block(buffer.buf + bytes_processed,
-					    buffer.dl_len - bytes_processed,
+		if (eof_reached && (size_t)bytes_processed < buffer->dl_len) {
+			ret = process_block(buffer->buf + bytes_processed,
+					    buffer->dl_len - bytes_processed,
 					    ctxt.off + bytes_processed,
 					    &hashes);
 			if (ret) {
@@ -1716,19 +1871,19 @@ static void csum_whole_file(struct file_to_scan *file)
 				return;
 			}
 
-			bytes_processed += buffer.dl_len - bytes_processed;
+			bytes_processed += buffer->dl_len - bytes_processed;
 		}
 
-		add_to_running_checksum(ctxt.file_csum, (unsigned char*)(buffer.buf), bytes_processed);
+		add_to_running_checksum(ctxt.file_csum, (unsigned char*)(buffer->buf), bytes_processed);
 
 		if (!options.only_whole_files) {
-			ret = process_extents(&ctxt, &buffer, &hashes, bytes_processed);
+			ret = process_extents(&ctxt, buffer, &hashes, bytes_processed);
 			if (ret)
 				break;
 		}
 
-		buffer.dl_offset = bytes_processed;
-		buffer.dl_len -= bytes_processed;
+		buffer->dl_offset = bytes_processed;
+		buffer->dl_len -= bytes_processed;
 
 		/* Ack the processed data and move the current offset accordingly */
 		ctxt.off += bytes_processed;
@@ -2054,16 +2209,15 @@ static void seen_inodes_free(void)
 
 void filescan_init(void)
 {
-	abort_on(scan_pool.pool);
+	abort_on(scan_workq.workers);
 	abort_on(scan_writer_open());
 	seen_inodes_init();
-	setup_pool(&scan_pool, csum_whole_file, NULL, options.io_threads);
-	abort_on(!scan_pool.pool);
+	scan_workq_start(options.io_threads);
 }
 
 void filescan_free(void)
 {
-	free_pool(&scan_pool);
+	scan_workq_drain();		/* wait for all queued files to finish */
 	/* All workers have joined: flush the batched reads and drop the writer. */
 	scan_read_flush();
 	scan_writer_close();

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -69,6 +69,9 @@ struct file_to_scan {
 	 * to print the progress bar
 	 */
 	unsigned long long file_position;
+
+	/* Intrusive FIFO link, owned by the scan work queue (file_scan.c). */
+	struct file_to_scan *next;
 };
 
 int add_exclude_pattern(const char *pattern);

--- a/src/tests.c
+++ b/src/tests.c
@@ -233,6 +233,56 @@ MU_TEST(test_storage_recommend_io_threads) {
 	mu_check(storage_recommend_io_threads(&p, 0) == 1);
 }
 
+MU_TEST(test_scan_bucket) {
+	/* Boundaries: <1 MiB => 0, then one bucket per power of two above 1 MiB. */
+	mu_check(scan_bucket(0) == 0);
+	mu_check(scan_bucket(1) == 0);
+	mu_check(scan_bucket((1u << 20) - 1) == 0);		/* just under 1 MiB */
+	mu_check(scan_bucket(1u << 20) == 1);			/* 1 MiB (2^20) */
+	mu_check(scan_bucket((1u << 21) - 1) == 1);		/* just under 2 MiB */
+	mu_check(scan_bucket(1u << 21) == 2);			/* 2 MiB */
+	mu_check(scan_bucket(1u << 22) == 3);			/* 4 MiB */
+	mu_check(scan_bucket(1u << 24) == 5);			/* 16 MiB */
+	mu_check(scan_bucket(100ull << 20) == 7);		/* 100 MiB (2^26 top bit) */
+	mu_check(scan_bucket(8ull << 30) == 14);		/* 8 GiB (2^33) */
+	/* Even the largest possible size stays a valid bucket index. */
+	mu_check(scan_bucket(~0ull) == 44);			/* 2^63 top bit */
+	mu_check(scan_bucket(~0ull) < SCAN_NBUCKETS);
+}
+
+MU_TEST(test_scan_workq_priority) {
+	/*
+	 * A free thread must take the largest-bucket work first, FIFO (walk order)
+	 * within a bucket. Drive scan_workq_push/pop directly (no workers): with
+	 * items queued, pop() returns immediately in dispatch order.
+	 */
+	memset(&scan_workq, 0, sizeof(scan_workq));
+
+	struct file_to_scan files[] = {
+		{ .filesize = 512u << 10, .file_position = 1 },	/* 512 KiB -> b0 */
+		{ .filesize = 8u << 20,   .file_position = 2 },	/* 8 MiB   -> b4 */
+		{ .filesize = 2u << 20,   .file_position = 3 },	/* 2 MiB   -> b2 */
+		{ .filesize = 8u << 20,   .file_position = 4 },	/* 8 MiB   -> b4 */
+		{ .filesize = 100u << 20, .file_position = 5 },	/* 100 MiB -> b7 */
+	};
+	for (unsigned int i = 0; i < G_N_ELEMENTS(files); i++)
+		scan_workq_push(&files[i]);
+
+	/* Biggest bucket first; within b4, FIFO keeps pos2 before pos4. */
+	struct file_to_scan *f;
+	f = scan_workq_pop(&scan_workq); mu_check(f->file_position == 5);	/* b7 */
+	f = scan_workq_pop(&scan_workq); mu_check(f->file_position == 2);	/* b4 */
+	f = scan_workq_pop(&scan_workq); mu_check(f->file_position == 4);	/* b4 */
+	f = scan_workq_pop(&scan_workq); mu_check(f->file_position == 3);	/* b2 */
+	f = scan_workq_pop(&scan_workq); mu_check(f->file_position == 1);	/* b0 */
+
+	/* Empty + draining => pop returns NULL (worker would exit). */
+	scan_workq.draining = true;
+	mu_check(scan_workq_pop(&scan_workq) == NULL);
+
+	memset(&scan_workq, 0, sizeof(scan_workq));
+}
+
 MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_block_zeroed);
 	MU_RUN_TEST(test_block_len);
@@ -241,6 +291,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_get_extent);
 	MU_RUN_TEST(test_sanitize_ctrl);
 	MU_RUN_TEST(test_storage_recommend_io_threads);
+	MU_RUN_TEST(test_scan_bucket);
+	MU_RUN_TEST(test_scan_workq_priority);
 }
 
 int main(int argc [[maybe_unused]], char *argv[]) {


### PR DESCRIPTION
Closes #88 — the cheap alternative to the chunked-hashing approach in #90.

## Problem
When a scan's files vary a lot in size, one very large file can end up as the last thing in the hash queue. A single csum thread then hashes it alone while every other thread has already gone idle — the makespan is dominated by that one straggler.

## Approach — longest-processing-time-first, via size buckets
Hashing still starts immediately as files stream in from the walk. The only change is the order work is handed out: a free csum thread always takes work from the **largest non-empty size class first**.

Files are bucketed by size on a log scale — bucket 0 is everything <1 MiB, then one bucket per power of two (1, 2, 4, 8 MiB, …) — into per-bucket intrusive FIFOs, with a `u64` occupancy bitmask. **Push and pop are both O(1)**: pop finds the top non-empty bucket with a single `clz` on the mask (never a scan over buckets). A huge file sits alone in a high bucket and is dispatched first; the only slack vs exact ordering is the <2× spread within a bucket, which doesn't affect the idle tail. Walk order is preserved within a bucket, and a tree of only small files all lands in bucket 0, degrading to plain FIFO at zero cost.

## Why buckets and not a sort function or a heap
- `g_thread_pool_set_sort_function` was the first cut and it's a trap: GLib's sorted push is **O(queue depth)**, and the walk front-loads tens of thousands of files, so it turned a **13s `~/git` scan into 35s**.
- An exact O(log n) max-heap works and is makespan-equivalent, but costs ~0.45s more user CPU on the 174k-file `~/git` tree (all files <1 MiB, ordering buys nothing). Buckets get that back and match plain FIFO's CPU.

## Results
**Adversarial tree** — one 8 GiB file + 80×100 MiB, `--io-threads=2`, warm:

| build | makespan (warm) |
|-------|-----------------|
| buckets | steady **2.16s** — the `max(largest_file, total/2)` optimum |
| exact heap | steady 2.16s (identical) |
| FIFO (master) | 2.16s best, **up to 4.46s (~2×)** when the big file lands late |

**Uniform `~/git`** (~174k files, all <1 MiB), mean user CPU / wall:

| build | user CPU | wall |
|-------|----------|------|
| buckets | **5.89s** | 13.1s |
| exact heap | 6.34s | 13.2s |
| FIFO (master) | 5.85s | 12.9s |

Buckets match FIFO's CPU (the reorder is free when everything is bucket 0); wall is neutral across all three.

## What this does *not* do
It can't parallelize a *single* file larger than the sum of everything else — only intra-file chunking (#90) can, at the cost of a digest redefinition + hashfile rebuild. This covers the common multi-file case for free: no schema bump, no new digest, no per-file concurrency path.

## Verification
- New unit tests: `scan_bucket` boundaries, and the work queue itself (`push`/`pop` hand back largest-bucket-first, FIFO within a bucket).
- `scripts/verify.sh` green: build (warnings=errors), 90 integration + 9 unit tests, valgrind scan/dedupe/replay smoke clean on the new threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
