### PR TITLE
scan diagnostics: contention/starvation counters, honest small-file ETA, and no more idle-flicker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,13 @@ the one consumer, lock-free. Walkers only read `locked_fs` (set before they
 spawn) and mutex-guarded `verified_devs`. **Don't move per-file DB state onto the
 walkers.**
 
+- **`DUPEREMOVE_SCAN_STATS=1`** prints one scan diagnostic to stderr at end of
+  scan: csum-queue `pops`/`empty-waits` (worker starvation) and write-lock
+  `acquisitions`/`contended`/`lock-wait` (total thread-seconds + avg µs per
+  contended wait). Use it to tell producer-starvation from write-lock
+  contention. In-memory (no `--hashfile`) shows ~3 `dbfile_lock()`/file — the
+  per-file change-detection *read* serializes too (shared-cache in-memory has no
+  WAL); `--hashfile` shows ~2 with lock-free WAL-snapshot reads.
 - **Walker count plateaus at ~8 on btrfs — don't raise the cap.** Cold 149k-file
   `~/git`: 1→2→4 scaled (15→9.9→7.8s), 8 was the knee (7.3s), 16/32 gave no wall
   gain while `sys` exploded (16→23→46s). It's btrfs metadata b-tree lock
@@ -200,6 +207,21 @@ are known (`auto_tune_io_threads()` in `oans.c`).
   query isn't the bottleneck and the preload adds ~1s.
 - **statx-relative-to-dir-fd** gave ~5-8% less scan *CPU* but **zero wall**
   change; PR closed.
+- **Scan write-lock (`io_mutex`) contention is a red herring — don't do the
+  single-writer refactor.** `DUPEREMOVE_SCAN_STATS` on warm 173k-file `~/git`:
+  contended% rises with `--io-threads` (2.3→4.8→9.9→16.4% at 4/8/16/32) but wall
+  is flat past ~16 (12.21→12.22s) and total lock-wait stays ≤3.7 *thread*-seconds
+  (<1% of runtime) — the lock is off the critical path (piling threads onto it
+  just makes them wait, unchanged completion). The ~16% (and users' ~20%+ on
+  bigger trees) is scary as a *ratio* but negligible as *time*; each wait is tens
+  of µs, spread across the pool. On-disk `--hashfile` waits are ~2× longer per
+  collision than in-memory (WAL disk I/O in the critical section), still absorbed.
+- **"Idle" csum threads in the live UI are not starvation.** `empty-waits` is ~0
+  (8 = the 8-worker startup ramp) across whole scans: the single `__scan_file`
+  producer keeps the queue full. So batching worker dispatch/commits buys
+  nothing. (The *display* idle-flicker is a separate, cosmetic thing — csum
+  workers are persistent, so they hold one progress slot for life rather than
+  re-claiming per file.)
 - **A savings preview / dry-run isn't worth building.** Real reclaimed disk can't
   be predicted without doing the dedupe (compression, extent alignment, the
   kernel declining, snapshot/external refcounts), and dedupe is already safe and

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <stddef.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
@@ -35,11 +36,23 @@ static GMutex io_mutex; /* Locks db writes */
 /*
  * Diagnostic counters for the write lock (DUPEREMOVE_SCAN_STATS). total counts
  * every dbfile_lock(); contended counts the acquisitions that could not be
- * taken uncontended (a worker/producer had to block behind another writer). A
- * high contended:total ratio means the single WAL writer lock is the scan's
- * limiter; a low one means the workers are starved elsewhere, not lock-bound.
+ * taken uncontended (a worker/producer had to block behind another writer);
+ * wait_ns sums the nanoseconds those contended acquisitions spent blocked. The
+ * contended:total ratio says how *often* threads collide, but only wait_ns says
+ * whether it *costs* anything: divided by contended it gives the average stall
+ * (nanoseconds are harmless, tens of microseconds are not), and as a sum it is
+ * the total thread-time lost to the lock across the scan.
  */
-static _Atomic uint64_t iolock_total, iolock_contended;
+static _Atomic uint64_t iolock_total, iolock_contended, iolock_wait_ns;
+
+/* Monotonic nanoseconds, for timing contended lock waits. */
+static uint64_t mono_ns(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
 
 #if (SQLITE_VERSION_NUMBER < 3007015)
 #define	perror_sqlite(_err, _why)					\
@@ -115,18 +128,26 @@ void dbfile_lock(void)
 	/*
 	 * trylock first so we can tell contended acquisitions apart from
 	 * uncontended ones: if it fails the lock was held, so this caller
-	 * blocks (and we count it) before taking it for real.
+	 * blocks (and we count it, timing the wait) before taking it for real.
+	 * The clock reads are only on the already-slow contended path, so they
+	 * do not weigh on the uncontended hot path.
 	 */
 	if (!g_mutex_trylock(&io_mutex)) {
-		atomic_fetch_add_explicit(&iolock_contended, 1, memory_order_relaxed);
+		uint64_t t0 = mono_ns();
+
 		g_mutex_lock(&io_mutex);
+		atomic_fetch_add_explicit(&iolock_contended, 1, memory_order_relaxed);
+		atomic_fetch_add_explicit(&iolock_wait_ns, mono_ns() - t0,
+					  memory_order_relaxed);
 	}
 }
 
-void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended)
+void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended,
+			   uint64_t *wait_ns)
 {
 	*total = atomic_load_explicit(&iolock_total, memory_order_relaxed);
 	*contended = atomic_load_explicit(&iolock_contended, memory_order_relaxed);
+	*wait_ns = atomic_load_explicit(&iolock_wait_ns, memory_order_relaxed);
 }
 
 void dbfile_unlock(void)

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <stddef.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -30,6 +31,15 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create,
 				     bool readonly);
 
 static GMutex io_mutex; /* Locks db writes */
+
+/*
+ * Diagnostic counters for the write lock (DUPEREMOVE_SCAN_STATS). total counts
+ * every dbfile_lock(); contended counts the acquisitions that could not be
+ * taken uncontended (a worker/producer had to block behind another writer). A
+ * high contended:total ratio means the single WAL writer lock is the scan's
+ * limiter; a low one means the workers are starved elsewhere, not lock-bound.
+ */
+static _Atomic uint64_t iolock_total, iolock_contended;
 
 #if (SQLITE_VERSION_NUMBER < 3007015)
 #define	perror_sqlite(_err, _why)					\
@@ -101,7 +111,22 @@ struct dbhandle *dbfile_get_handle(void)
 
 void dbfile_lock(void)
 {
-	g_mutex_lock(&io_mutex);
+	atomic_fetch_add_explicit(&iolock_total, 1, memory_order_relaxed);
+	/*
+	 * trylock first so we can tell contended acquisitions apart from
+	 * uncontended ones: if it fails the lock was held, so this caller
+	 * blocks (and we count it) before taking it for real.
+	 */
+	if (!g_mutex_trylock(&io_mutex)) {
+		atomic_fetch_add_explicit(&iolock_contended, 1, memory_order_relaxed);
+		g_mutex_lock(&io_mutex);
+	}
+}
+
+void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended)
+{
+	*total = atomic_load_explicit(&iolock_total, memory_order_relaxed);
+	*contended = atomic_load_explicit(&iolock_contended, memory_order_relaxed);
 }
 
 void dbfile_unlock(void)

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -105,10 +105,12 @@ void dbfile_lock(void);
 void dbfile_unlock(void);
 
 /*
- * Diagnostic write-lock counters (DUPEREMOVE_SCAN_STATS): total acquisitions
- * and how many of those had to block behind another writer.
+ * Diagnostic write-lock counters (DUPEREMOVE_SCAN_STATS): total acquisitions,
+ * how many of those had to block behind another writer, and the total
+ * nanoseconds spent blocked in those contended waits.
  */
-void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended);
+void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended,
+			   uint64_t *wait_ns);
 
 /* Config-table key holding a persisted --autotune result (io-threads). */
 #define AUTOTUNE_CONFIG_KEY	"autotune_io_threads"

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -104,6 +104,12 @@ struct dbhandle *dbfile_open_handle_thread(struct threads_pool *pool);
 void dbfile_lock(void);
 void dbfile_unlock(void);
 
+/*
+ * Diagnostic write-lock counters (DUPEREMOVE_SCAN_STATS): total acquisitions
+ * and how many of those had to block behind another writer.
+ */
+void dbfile_get_lock_stats(uint64_t *total, uint64_t *contended);
+
 /* Config-table key holding a persisted --autotune result (io-threads). */
 #define AUTOTUNE_CONFIG_KEY	"autotune_io_threads"
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -78,7 +78,8 @@ static bool seen_inode(uint64_t ino, uint64_t subvol);
 static void mark_inode_seen(uint64_t ino, uint64_t subvol);
 static void mark_file_seen(int64_t id);
 struct buffer;
-static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer);
+static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
+			    struct pscan_thread *tprogress);
 
 /*
  * Scan work queue — approximate longest-processing-time-first (LPT) dispatch.
@@ -1703,10 +1704,26 @@ static gpointer scan_worker(gpointer arg)
 	/* One read buffer per worker, allocated on first use and reused across
 	 * files; owned here so it is freed when the worker exits. */
 	struct buffer buffer = {0,};
+	/*
+	 * These csum workers are persistent (one per --io-threads, alive for the
+	 * whole scan - not a churning glib pool), so each holds a single progress
+	 * slot for its lifetime and rolls it from file to file. That avoids the
+	 * per-file claim/release that made the display flash "idle" in the
+	 * microsecond gap between small files even though the queue was never
+	 * actually empty (see pscan_finish_file). Claimed lazily on the first file
+	 * with a non-idle status so a still-unclaimed slot is never reused by a
+	 * sibling worker; a worker that gets no files never shows a phantom line.
+	 */
+	struct pscan_thread *slot = NULL;
 
-	while ((file = scan_workq_pop(q)))
-		csum_whole_file(file, &buffer);
+	while ((file = scan_workq_pop(q))) {
+		if (!slot)
+			slot = pscan_claim_slot(gettid(), thread_scanning);
+		csum_whole_file(file, &buffer, slot);
+	}
 
+	if (slot)
+		pscan_slot_idle(slot);	/* out of work: park it idle */
 	free(buffer.buf);
 	return NULL;
 }
@@ -1746,7 +1763,8 @@ static void scan_workq_drain(void)
 	/* All buckets are empty now (workers drained them); nothing to free. */
 }
 
-static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer)
+static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
+			    struct pscan_thread *tprogress)
 {
 	int ret = 0;
 
@@ -1760,8 +1778,20 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer)
 	 */
 	struct dbhandle *db = scan_writer;
 
+	/*
+	 * The worker owns tprogress across files; roll its per-file accounting
+	 * (bytes/count) on every exit path but leave it claimed and non-idle.
+	 * Point the new file's fields in before any early return, so the cleanup
+	 * always reconciles this file and never re-counts the previous one.
+	 */
+	abort_on(!tprogress);
+	tprogress->status = thread_scanning;
+	tprogress->file_scanned_bytes = 0;
+	tprogress->file_total_bytes = file->filesize;
+	strncpy(tprogress->file_path, file->path, PATH_MAX);
+	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
+
 	/* Dummy variables used to trigger the cleanup code */
-	_cleanup_(pscan_reset_thread) struct pscan_thread *tprogress = NULL;
 	_cleanup_(freep) char *path = file->path;
 	_cleanup_(freep) struct file_to_scan *clean_file = file;
 
@@ -1789,14 +1819,6 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer)
 		eprintf("csum_whole_file: unable to connect to the database\n");
 		return;
 	}
-
-	/* Claimed per file, not per thread: see pscan_claim_slot(). */
-	tprogress = pscan_claim_slot(gettid(), thread_scanning);
-	abort_on(!tprogress);
-
-	tprogress->file_scanned_bytes = 0;
-	tprogress->file_total_bytes = file->filesize;
-	strncpy(tprogress->file_path, file->path, PATH_MAX);
 
 	ctxt.filesize = file->filesize;
 	ctxt.file_csum = start_running_checksum();

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -41,6 +41,7 @@
 #include <libmount/libmount.h>
 #include <sys/sysmacros.h>
 #include <uuid/uuid.h>
+#include <stdatomic.h>
 #include <bsd/sys/queue.h>
 
 #include <glib.h>
@@ -144,6 +145,16 @@ struct scan_workq {
 	bool draining;			/* no more pushes; drain, then workers exit */
 };
 static struct scan_workq scan_workq;
+
+/*
+ * Diagnostic counters for the csum work queue (DUPEREMOVE_SCAN_STATS). pops
+ * counts every file a worker dequeued; empty_waits counts the pops that found
+ * the queue empty and had to block for the single __scan_file() consumer to
+ * feed them. A high empty_waits:pops ratio means the workers are starved by the
+ * serial producer (batching their commits would not help); a low one means
+ * they are kept busy and any stalls are elsewhere (e.g. the write lock).
+ */
+static _Atomic uint64_t scan_pop_total, scan_pop_empty_waits;
 
 static void scan_workq_push(struct file_to_scan *file);
 static void scan_workq_start(unsigned int nworkers);
@@ -1658,10 +1669,13 @@ static struct file_to_scan *scan_workq_pop(struct scan_workq *q)
 {
 	struct file_to_scan *file;
 	unsigned b;
+	bool waited = false;
 
 	g_mutex_lock(&q->lock);
-	while (q->occupied == 0 && !q->draining)
+	while (q->occupied == 0 && !q->draining) {
+		waited = true;		/* starved: no work, blocking on the producer */
 		g_cond_wait(&q->cond, &q->lock);
+	}
 	if (q->occupied == 0) {
 		g_mutex_unlock(&q->lock);
 		return NULL;		/* draining and empty: worker exits */
@@ -1674,6 +1688,11 @@ static struct file_to_scan *scan_workq_pop(struct scan_workq *q)
 		q->occupied &= ~(1ULL << b);
 	}
 	g_mutex_unlock(&q->lock);
+
+	atomic_fetch_add_explicit(&scan_pop_total, 1, memory_order_relaxed);
+	if (waited)
+		atomic_fetch_add_explicit(&scan_pop_empty_waits, 1,
+					  memory_order_relaxed);
 	return file;
 }
 
@@ -2205,6 +2224,13 @@ static void seen_inodes_free(void)
 	seen_used = NULL;
 	seen_cap = 0;
 	seen_count = 0;
+}
+
+void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits)
+{
+	*pops = atomic_load_explicit(&scan_pop_total, memory_order_relaxed);
+	*empty_waits = atomic_load_explicit(&scan_pop_empty_waits,
+					    memory_order_relaxed);
 }
 
 void filescan_init(void)

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -79,4 +79,11 @@ int add_exclude_pattern(const char *pattern);
 void filescan_init(void);
 void filescan_free(void);
 
+/*
+ * Diagnostic csum-queue counters (DUPEREMOVE_SCAN_STATS): files dequeued by
+ * workers and how many of those dequeues had to block on an empty queue
+ * (workers starved by the single-threaded producer).
+ */
+void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits);
+
 #endif	/* __FILE_SCAN_H__ */

--- a/src/oans.c
+++ b/src/oans.c
@@ -1050,22 +1050,25 @@ static void process_duplicates(struct dbhandle *db)
  */
 static void report_scan_stats(void)
 {
-	uint64_t pops, empty_waits, lock_total, lock_contended;
+	uint64_t pops, empty_waits, lock_total, lock_contended, lock_wait_ns;
 
 	if (!getenv("DUPEREMOVE_SCAN_STATS"))
 		return;
 
 	filescan_get_workq_stats(&pops, &empty_waits);
-	dbfile_get_lock_stats(&lock_total, &lock_contended);
+	dbfile_get_lock_stats(&lock_total, &lock_contended, &lock_wait_ns);
 
 	fprintf(stderr,
 		"scan-stats: csum-queue pops=%" PRIu64 " empty-waits=%" PRIu64
 		" (%.1f%% starved); write-lock acquisitions=%" PRIu64
-		" contended=%" PRIu64 " (%.1f%%)\n",
+		" contended=%" PRIu64 " (%.1f%%); lock-wait total=%.2fs"
+		" avg=%.1fus\n",
 		pops, empty_waits,
 		pops ? 100.0 * empty_waits / pops : 0.0,
 		lock_total, lock_contended,
-		lock_total ? 100.0 * lock_contended / lock_total : 0.0);
+		lock_total ? 100.0 * lock_contended / lock_total : 0.0,
+		lock_wait_ns / 1e9,
+		lock_contended ? lock_wait_ns / 1e3 / lock_contended : 0.0);
 }
 
 static int scan_files(char **roots, int nroots, struct dbhandle *db,

--- a/src/oans.c
+++ b/src/oans.c
@@ -1040,6 +1040,34 @@ static void process_duplicates(struct dbhandle *db)
 		extents_search_free();
 }
 
+/*
+ * Print the scan contention diagnostics gathered this run, gated on
+ * DUPEREMOVE_SCAN_STATS so a benchmark run can ask for the hard numbers without
+ * the timing distortion of full -v output. empty_waits/pops says how often the
+ * csum workers starved for the single producer; contended/total says how often
+ * a writer had to block on the WAL write lock. Starvation-dominated means the
+ * serial producer is the limiter; lock-dominated means the write lock is.
+ */
+static void report_scan_stats(void)
+{
+	uint64_t pops, empty_waits, lock_total, lock_contended;
+
+	if (!getenv("DUPEREMOVE_SCAN_STATS"))
+		return;
+
+	filescan_get_workq_stats(&pops, &empty_waits);
+	dbfile_get_lock_stats(&lock_total, &lock_contended);
+
+	fprintf(stderr,
+		"scan-stats: csum-queue pops=%" PRIu64 " empty-waits=%" PRIu64
+		" (%.1f%% starved); write-lock acquisitions=%" PRIu64
+		" contended=%" PRIu64 " (%.1f%%)\n",
+		pops, empty_waits,
+		pops ? 100.0 * empty_waits / pops : 0.0,
+		lock_total, lock_contended,
+		lock_total ? 100.0 * lock_contended / lock_total : 0.0);
+}
+
 static int scan_files(char **roots, int nroots, struct dbhandle *db,
 		      uint64_t *files_scanned)
 {
@@ -1084,6 +1112,8 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 	 */
 	if (files_scanned)
 		*files_scanned = pscan_files_scanned();
+
+	report_scan_stats();
 
 	if (ret)
 		return ret;

--- a/src/progress.c
+++ b/src/progress.c
@@ -478,6 +478,43 @@ void pscan_reset_thread(struct pscan_thread **progress)
 	(*progress)->file_path[0] = '\0';
 }
 
+/*
+ * Roll a persistently-held slot from one file to the next: do the per-file
+ * accounting pscan_reset_thread() does (reconcile scanned-vs-total bytes, bump
+ * the file count) but leave the slot claimed and non-idle, so a worker that
+ * hands off directly to its next file never flashes "idle" in the microsecond
+ * gap between them. The status/path stay showing the just-finished file until
+ * the next one overwrites them. _cleanup_ compatible.
+ */
+void pscan_finish_file(struct pscan_thread **progress)
+{
+	uint64_t scanned, total;
+
+	if (!progress || !*progress)
+		return;
+	scanned = (*progress)->file_scanned_bytes;
+	total = (*progress)->file_total_bytes;
+
+	if (scanned < total)
+		(*progress)->total_scanned_bytes += total - scanned;
+	if (scanned > total)
+		(*progress)->total_scanned_bytes -= scanned - total;
+
+	(*progress)->total_scanned_files++;
+}
+
+/*
+ * Park a persistently-held slot as idle once its worker has no more work (drain).
+ * No per-file accounting - pscan_finish_file() already ran for the last file.
+ */
+void pscan_slot_idle(struct pscan_thread *slot)
+{
+	if (!slot)
+		return;
+	slot->status = thread_idle;
+	slot->file_path[0] = '\0';
+}
+
 bool is_progress_printer_running(void)
 {
 	return printer ? true : false;

--- a/src/progress.c
+++ b/src/progress.c
@@ -246,18 +246,40 @@ static unsigned int print_scan_progress(void)
 		return 3;
 	}
 
-	s_printf("\tFiles scanned: %" PRIu64 "/%" PRIu64 " (%05.2f%%)\n",
+	s_printf("\tFiles scanned: %" PRIu64 "/%" PRIu64 " (%05.2f%%)",
 	      files_scanned, tf, tf ? (double)files_scanned / tf * 100 : 100.0);
+	if (files_scanned && elapsed > 1.0)
+		printf(" · %.0f files/s", files_scanned / elapsed);
+	printf("\n");
+
 	s_printf("\tBytes scanned: %s/%s (%05.2f%%)",
 	      human_size(bytes_scanned), human_size(tb),
 	      tb ? (double)bytes_scanned / tb * 100 : 100.0);
 	if (bytes_scanned && elapsed > 1.0) {
-		double rate = bytes_scanned / elapsed;
+		double brate = bytes_scanned / elapsed;
+		double eta = 0.0;
 
-		printf(" · %s/s", human_size((uint64_t)rate));
+		printf(" · %s/s", human_size((uint64_t)brate));
+
+		/*
+		 * Both bytes and files must reach 100%, and which one dominates
+		 * the time left flips during a scan: big files first
+		 * (byte-bound), then a long tail of tiny files (file-count
+		 * bound). A pure byte ETA collapses to a few seconds during that
+		 * tail while hundreds of thousands of small files still remain,
+		 * so take the larger of the byte- and file-rate estimates.
+		 */
 		if (bytes_scanned < tb)
-			printf(" · ETA ~%s",
-			       human_duration((tb - bytes_scanned) / rate));
+			eta = (tb - bytes_scanned) / brate;
+		if (files_scanned && files_scanned < tf) {
+			double feta = (tf - files_scanned) /
+				       (files_scanned / elapsed);
+
+			if (feta > eta)
+				eta = feta;
+		}
+		if (eta > 0.0)
+			printf(" · ETA ~%s", human_duration(eta));
 	}
 	printf("\n");
 	s_printf("\tFile listing: completed\n");

--- a/src/progress.c
+++ b/src/progress.c
@@ -246,10 +246,13 @@ static unsigned int print_scan_progress(void)
 		return 3;
 	}
 
+	/* Files/s, reused by the file-rate ETA below; 0 until we have a second. */
+	double frate = (files_scanned && elapsed > 1.0) ? files_scanned / elapsed : 0.0;
+
 	s_printf("\tFiles scanned: %" PRIu64 "/%" PRIu64 " (%05.2f%%)",
 	      files_scanned, tf, tf ? (double)files_scanned / tf * 100 : 100.0);
-	if (files_scanned && elapsed > 1.0)
-		printf(" · %.0f files/s", files_scanned / elapsed);
+	if (frate > 0.0)
+		printf(" · %.0f files/s", frate);
 	printf("\n");
 
 	s_printf("\tBytes scanned: %s/%s (%05.2f%%)",
@@ -271,9 +274,8 @@ static unsigned int print_scan_progress(void)
 		 */
 		if (bytes_scanned < tb)
 			eta = (tb - bytes_scanned) / brate;
-		if (files_scanned && files_scanned < tf) {
-			double feta = (tf - files_scanned) /
-				       (files_scanned / elapsed);
+		if (frate > 0.0 && files_scanned < tf) {
+			double feta = (tf - files_scanned) / frate;
 
 			if (feta > eta)
 				eta = feta;
@@ -453,29 +455,15 @@ void pscan_join(void)
 
 void pscan_reset_thread(struct pscan_thread **progress)
 {
-	if (!progress || !*progress)
-		return;
-	uint64_t scanned = (*progress)->file_scanned_bytes;
-	uint64_t total = (*progress)->file_total_bytes;
-
-	(*progress)->status = thread_idle;
 	/*
-	 * The file may have shrinked between the statx and
-	 * the end of the scan.
-	 * Does not matter much, we fake-fill the missing bytes
-	 * so the global progress don't diverge much
+	 * The churning dedupe pool re-claims a slot per work item, so its reset
+	 * is just "finish this file's accounting, then park the slot idle" - the
+	 * two persistent-slot primitives composed, so the byte reconciliation has
+	 * a single source of truth.
 	 */
-	if (scanned < total)
-		(*progress)->total_scanned_bytes += total - scanned;
-
-	/*
-	 * Also, the file may have grow.
-	 */
-	if (scanned > total)
-		(*progress)->total_scanned_bytes -= scanned - total;
-
-	(*progress)->total_scanned_files++;
-	(*progress)->file_path[0] = '\0';
+	pscan_finish_file(progress);
+	if (progress && *progress)
+		pscan_slot_idle(*progress);
 }
 
 /*
@@ -495,6 +483,11 @@ void pscan_finish_file(struct pscan_thread **progress)
 	scanned = (*progress)->file_scanned_bytes;
 	total = (*progress)->file_total_bytes;
 
+	/*
+	 * The file may have shrunk between the statx and the end of the scan;
+	 * fake-fill the missing bytes so the global progress doesn't diverge.
+	 * It may also have grown, so trim the overshoot.
+	 */
 	if (scanned < total)
 		(*progress)->total_scanned_bytes += total - scanned;
 	if (scanned > total)

--- a/src/progress.h
+++ b/src/progress.h
@@ -68,10 +68,11 @@ void pscan_run(void);
 void pscan_join(void);
 
 /*
- * Reset file tracking data
- * This is used by the csum_whole_file(): regardless of its outcome,
- * the thread is set as idle, total_scanned_files is incremented and
- * total_scanned_bytes is fed up to the file size (in case it shrank)
+ * Per-work-item reset for the churning dedupe pool: finish the current file's
+ * accounting (total_scanned_files++, total_scanned_bytes fed up to the file
+ * size in case it shrank) and park the slot idle. Equivalent to
+ * pscan_finish_file() followed by pscan_slot_idle(); persistent csum workers
+ * use those two directly instead so they don't flash idle between files.
  */
 void pscan_reset_thread(struct pscan_thread **progress);
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -75,6 +75,15 @@ void pscan_join(void);
  */
 void pscan_reset_thread(struct pscan_thread **progress);
 
+/*
+ * For a persistently-held slot (one kept by a long-lived worker across many
+ * files, rather than re-claimed per file): pscan_finish_file() does the per-file
+ * byte/count accounting without going idle, so no "idle" flashes between files;
+ * pscan_slot_idle() parks the slot when the worker finally runs out of work.
+ */
+void pscan_finish_file(struct pscan_thread **progress);
+void pscan_slot_idle(struct pscan_thread *slot);
+
 bool is_progress_printer_running(void);
 
 /*


### PR DESCRIPTION
## What & why

Started from a question — *"when hashing many small files the UI shows many threads as idle, is that a UI problem or is the mutex a limiting factor?"* — and instrumented the scan to answer it. The answer turned out to be **neither**: the workers are essentially never starved, and the write-lock contention, while real, is off the critical path. Along the way this fixes the misleading idle display and the wrong small-file-tail ETA.

## Changes

- **`DUPEREMOVE_SCAN_STATS=1` scan diagnostics** (env-gated, stderr, one line at end of scan):
  - csum work-queue `pops` / `empty-waits` — tells producer-starvation apart from lock-contention (workers were never starved: `empty-waits` ≈ the startup ramp).
  - write-lock `acquisitions` / `contended` / `lock-wait total+avg` — the wait **time**, not just the collision count, so the number can actually justify (or rule out) a fix.
- **Honest small-file-tail ETA + files/s.** The ETA was byte-based, so during a tail of hundreds of thousands of tiny files (bytes ≈ done, files not) it collapsed to a few seconds. Now shows a files/s rate and takes `ETA = max(byte-eta, file-eta)`.
- **No more idle-flicker.** The persistent csum workers re-claimed a progress slot per file and released it to idle at the end of each one — a leftover from the old churning-pool model — so the live view flashed "idle" in the microsecond gap between small files. Each worker now holds one slot for its lifetime and only parks idle at genuine drain. Idle-fraction on a 300k-tiny-file tree: **27.8% → 4.5%** (the residual is the real end-of-scan drain); `~/git`: 5.4% → 0.9%. The churning dedupe pool keeps its per-work-item model.

## Measured conclusion (now recorded in CLAUDE.md dead-ends)

Sweeping `--io-threads` on warm 173k-file `~/git`: contention rises with thread count (2.3→4.8→9.9→16.4% at 4/8/16/32) but **wall-clock is flat past ~16 threads** (12.21→12.22s) and total lock-wait stays ≤3.7 *thread*-seconds (<1% of runtime). The lock is off the critical path — **the single-writer refactor isn't worth it.** On-disk `--hashfile` waits are ~2× longer per collision than in-memory (WAL disk I/O in the critical section), still absorbed. Also documents that in-memory (no `--hashfile`) does ~3 `dbfile_lock()`/file vs ~2 on-disk, because the per-file change-detection read serializes too.

## Verification

- Clean build (warnings = failure), **all 90 tests pass**.
- Ran a `/simplify` pass (4 review agents): composed `pscan_reset_thread` from the two new slot primitives (single source of truth for the byte accounting) and hoisted the files/s rate.
- No-op rescan still nets 0 files; the timing/counter work is confined to the already-slow contended lock path and relaxed atomics, so the hot path is unaffected (the persistent slot is actually a small per-file win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)