### PR TITLE
file_scan: block-aligned block-count estimate, clearer hole names (#89 review)

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -385,14 +385,28 @@ static bool allocate_hashes(struct hashes *hashes, struct scan_ctxt *ctxt)
 	 * of MB of block records we will never fill. Holes are skipped in the
 	 * scan loop, so they contribute no block hashes. add_block_hash()
 	 * grows the array if this estimate is ever short.
+	 *
+	 * Count the oans blocks each extent *touches*, not fe_length/blocksize:
+	 * FIEMAP extents are aligned to the filesystem block size (~4K), not to
+	 * oans blocksize (128K by default), so an extent can start and end mid
+	 * block and a partially-overlapped block is still read and hashed. Sum
+	 * (last block touched - first block touched) so the estimate never
+	 * under-counts (which would trip the one-at-a-time realloc growth in
+	 * add_block_hash). Adjacent extents sharing a block can over-count, but
+	 * erring high just wastes a little memory once, the safe bias here.
 	 */
-	size_t mapped = 0;
-	for (unsigned int i = 0; i < ctxt->fiemap->fm_mapped_extents; i++)
-		mapped += ctxt->fiemap->fm_extents[i].fe_length;
-	if (mapped > ctxt->filesize)
-		mapped = ctxt->filesize;
+	size_t mapped_blocks = 0;
+	for (unsigned int i = 0; i < ctxt->fiemap->fm_mapped_extents; i++) {
+		struct fiemap_extent *e = &ctxt->fiemap->fm_extents[i];
+		uint64_t first = e->fe_logical / blocksize;
+		uint64_t last = (e->fe_logical + e->fe_length + blocksize - 1) / blocksize;
+		mapped_blocks += last - first;
+	}
+	size_t max_blocks = ctxt->filesize / blocksize + 1;
+	if (mapped_blocks > max_blocks)
+		mapped_blocks = max_blocks;
 
-	hashes->blocks_count = mapped / blocksize + 1;
+	hashes->blocks_count = mapped_blocks + 1;
 	hashes->blocks = calloc(hashes->blocks_count, sizeof(struct block_csum));
 
 	return hashes->extents && hashes->blocks;
@@ -1373,7 +1387,7 @@ static inline bool block_is_hole(const struct fiemap_extent *e, size_t off)
  * If the block at ctxt->off is entirely a hole, return the length of the
  * block-aligned run of all-hole blocks starting there; otherwise 0.
  */
-static size_t hole_run_at(struct scan_ctxt *ctxt)
+static size_t hole_run_length(struct scan_ctxt *ctxt)
 {
 	struct fiemap_extent *e = get_extent(ctxt->fiemap, ctxt->off,
 					     &ctxt->extent_cursor);
@@ -1870,14 +1884,14 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		 * older faked-zeroes path in fill_buffer instead; unifying the
 		 * two would change preallocated files' digests for no gain here.)
 		 */
-		size_t hole = hole_run_at(&ctxt);
-		if (hole) {
-			uint64_t desc[2] = { ctxt.off, hole };
+		size_t hole_length = hole_run_length(&ctxt);
+		if (hole_length) {
+			uint64_t desc[2] = { ctxt.off, hole_length };
 			add_to_running_checksum(ctxt.file_csum,
 						(unsigned char *)desc, sizeof(desc));
-			ctxt.off += hole;
-			tprogress->file_scanned_bytes += hole;
-			tprogress->total_scanned_bytes += hole;
+			ctxt.off += hole_length;
+			tprogress->file_scanned_bytes += hole_length;
+			tprogress->total_scanned_bytes += hole_length;
 			continue;
 		}
 


### PR DESCRIPTION
Follow-up addressing @crass's review comments on #89 (sparse-hole-skip), now merged.

## What

1. **Block-count estimate no longer under-counts** (`allocate_hashes`). The old
   code sized the block array from `sum(fe_length) / blocksize + 1`. FIEMAP
   extents are aligned to the *filesystem* block size (~4K), not to oans
   `blocksize` (128K default), so an extent can start and end mid-block and a
   partially-overlapped block is still read and hashed. The estimate could
   under-count by up to ~2 blocks per mapped extent, tripping the
   one-at-a-time `realloc` growth in `add_block_hash()` on fragmented files.
   Each extent is now rounded out to oans-block boundaries before summing, so
   the estimate never under-counts. Adjacent extents sharing a block can
   over-count, but erring high only wastes a little memory once — the safe bias
   for a preallocation. (crass's suggestion.)

2. **Naming:** `hole_run_at()` → `hole_run_length()` and the local `hole` →
   `hole_length`. Both name a byte length, not a position.

## Not a bug fix

Correctness was never affected — `add_block_hash()` already grows the array
when the estimate is short, so no hash or dedupe result changes. This just
avoids the realloc churn and reads more clearly.

## Testing

`scripts/verify.sh` green: build clean, 90 tests pass (incl. the sparse-file
suite), valgrind scan+dedupe+replay smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)