### PR TITLE
README: note CI covers XFS too, not just btrfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Summary
 | ⏰ **Scheduling built in** | `sudo make install-systemd`, then `systemctl enable --now oans@data.timer`. Weekly dedupe at idle I/O priority, no cron scripts. |
 | 📊 **Statistics & history** | `--stats` shows what a hashfile holds and how much is duplicated; `--history` shows space actually reclaimed over time; `--json` exports metrics for dashboards. |
 | 🎯 **Honest reporting** | A clean, colorful live progress display (rate + ETA) and a summary that reports the disk space *actually freed* — not an inflated shared-extents figure. |
-| 🔒 **Hardened** | Fixes a data-loss-adjacent upstream bug (hardlinks could silently empty the hashfile), read-only report modes that are safe while a dedupe runs, and an integration suite CI runs against a real btrfs. |
+| 🔒 **Hardened** | Fixes a data-loss-adjacent upstream bug (hardlinks could silently empty the hashfile), read-only report modes that are safe while a dedupe runs, and an integration suite CI runs against a real btrfs and XFS. |
 | 🤝 **Drop-in compatible** | The CLI is a close superset of duperemove's, and `make install` provides a `duperemove` compatibility symlink. |
 
 ## Quick start


### PR DESCRIPTION
CI now runs a `scratch_fs: [btrfs, xfs]` matrix (integration suite against an
`mkfs.xfs -m reflink=1` loopback image as well as btrfs), so the "Hardened" row
claiming CI "runs against a real btrfs" was understated. Updated to say btrfs
**and XFS**.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)