### PR TITLE
Add scan ETA (weighted-progress)

### DIFF
--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -45,15 +45,6 @@ static GMutex io_mutex; /* Locks db writes */
  */
 static _Atomic uint64_t iolock_total, iolock_contended, iolock_wait_ns;
 
-/* Monotonic nanoseconds, for timing contended lock waits. */
-static uint64_t mono_ns(void)
-{
-	struct timespec ts;
-
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
-}
-
 #if (SQLITE_VERSION_NUMBER < 3007015)
 #define	perror_sqlite(_err, _why)					\
 	eprintf("%s(): Database error %d while %s: %s\n",	\

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -157,6 +157,23 @@ static struct scan_workq scan_workq;
  */
 static _Atomic uint64_t scan_pop_total, scan_pop_empty_waits;
 
+/*
+ * Per-file overhead vs byte-proportional hash time (DUPEREMOVE_SCAN_STATS).
+ * Their ratio is the ideal ETA file weight B = (overhead/file)/(hash/byte),
+ * for checking the fixed weight against real storage (see report_scan_stats).
+ */
+static _Atomic uint64_t scan_overhead_ns, scan_hash_ns, scan_hashed_files,
+			scan_hashed_bytes;
+
+void filescan_get_eta_calibration(uint64_t *overhead_ns, uint64_t *hash_ns,
+				  uint64_t *files, uint64_t *bytes)
+{
+	*overhead_ns = atomic_load(&scan_overhead_ns);
+	*hash_ns = atomic_load(&scan_hash_ns);
+	*files = atomic_load(&scan_hashed_files);
+	*bytes = atomic_load(&scan_hashed_bytes);
+}
+
 static void scan_workq_push(struct file_to_scan *file);
 static void scan_workq_start(unsigned int nworkers);
 static void scan_workq_drain(void);
@@ -1848,6 +1865,8 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	/* Prevent close on fd 0 if, somehow, an error occurs before we open */
 	ctxt.fd = -1;
 
+	uint64_t t_start = mono_ns(), t_hash = 0, t_done = 0;	/* calibration */
+
 	if (!(buffer->buf)) {
 		ret = prepare_buffer(buffer);
 		if (ret) {
@@ -1898,6 +1917,8 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * loop again until pread returns 0 or
 	 * until we reach the expected EOF, based on the expected filesize
 	 */
+	t_hash = mono_ns();	/* calibration: setup done, read+hash begins */
+
 	while (ctxt.off < ctxt.filesize) {
 		/* In the buffer, how much bytes are processed as blocks
 		 * Extents processing and file processing will not consumme
@@ -1984,6 +2005,8 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		return;
 	}
 
+	t_done = mono_ns();	/* calibration: read+hash done, finalize/DB follow */
+
 	finish_running_checksum(ctxt.file_csum, file_digest);
 	ctxt.file_csum = NULL;
 
@@ -2049,6 +2072,14 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	}
 
 	dbfile_unlock();
+
+	/* Calibration: overhead is everything but the byte-proportional read+hash
+	 * loop (setup + finalize + DB write). */
+	atomic_fetch_add(&scan_overhead_ns,
+			 (t_hash - t_start) + (mono_ns() - t_done));
+	atomic_fetch_add(&scan_hash_ns, t_done - t_hash);
+	atomic_fetch_add(&scan_hashed_files, 1);
+	atomic_fetch_add(&scan_hashed_bytes, ctxt.off);
 }
 
 int add_exclude_pattern(const char *pattern)

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -86,4 +86,12 @@ void filescan_free(void);
  */
 void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits);
 
+/*
+ * Diagnostic ETA-calibration counters (DUPEREMOVE_SCAN_STATS): summed per-file
+ * overhead (setup + finalize + DB write) and read+hash time, with their file
+ * and byte counts. overhead/file over hash/byte is the ideal ETA file weight.
+ */
+void filescan_get_eta_calibration(uint64_t *overhead_ns, uint64_t *hash_ns,
+				  uint64_t *files, uint64_t *bytes);
+
 #endif	/* __FILE_SCAN_H__ */

--- a/src/oans.c
+++ b/src/oans.c
@@ -1051,6 +1051,7 @@ static void process_duplicates(struct dbhandle *db)
 static void report_scan_stats(void)
 {
 	uint64_t pops, empty_waits, lock_total, lock_contended, lock_wait_ns;
+	uint64_t over_ns, hash_ns, cal_files, cal_bytes;
 
 	if (!getenv("DUPEREMOVE_SCAN_STATS"))
 		return;
@@ -1069,6 +1070,26 @@ static void report_scan_stats(void)
 		lock_total ? 100.0 * lock_contended / lock_total : 0.0,
 		lock_wait_ns / 1e9,
 		lock_contended ? lock_wait_ns / 1e3 / lock_contended : 0.0);
+
+	/*
+	 * ETA calibration: the ratio of measured per-file overhead to per-byte
+	 * hash time is the ideal ETA file weight for this storage; compare it to
+	 * the fixed weight actually used (see progress.c). Handy for tuning the
+	 * weight on real hardware - e.g. a NAS/HDD.
+	 */
+	filescan_get_eta_calibration(&over_ns, &hash_ns, &cal_files, &cal_bytes);
+	if (cal_files && hash_ns) {
+		double over_per_file = (double)over_ns / cal_files;
+		double hash_per_byte = (double)hash_ns / cal_bytes;
+
+		fprintf(stderr,
+			"eta-calibration: overhead=%.1fus/file hash=%.2fs/GiB"
+			" -> ideal weight %.0f KiB/file (using %" PRIu64 " KiB)\n",
+			over_per_file / 1e3,
+			hash_per_byte * (double)(1ULL << 30) / 1e9,
+			over_per_file / hash_per_byte / 1024.0,
+			pscan_eta_file_weight() / 1024);
+	}
 }
 
 static int scan_files(char **roots, int nroots, struct dbhandle *db,
@@ -1235,6 +1256,16 @@ static void auto_tune_io_threads(const char *root)
 {
 	struct storage_profile p = {0};
 
+	/*
+	 * Detect the backing storage once: it sizes both the io-threads default
+	 * and the scan-ETA per-file weight. The weight must be set even when
+	 * io-threads is fixed below (an explicit flag, or a stored --autotune
+	 * result), so a NAS/HDD still gets the rotational weight.
+	 */
+	if (root)
+		storage_detect(root, &p);
+	pscan_set_storage_rotational(p.rotational && p.rotational_known);
+
 	if (options.io_threads)		/* explicit --io-threads (0 == auto) */
 		return;
 
@@ -1248,12 +1279,10 @@ static void auto_tune_io_threads(const char *root)
 	}
 
 	/*
-	 * Heuristic from the backing storage. storage_recommend_io_threads()
-	 * returns the plain CPU-count default for unknown media, so a failed
-	 * detect (leaving the zeroed profile) still yields a sane value.
+	 * storage_recommend_io_threads() returns the plain CPU-count default for
+	 * unknown media, so a failed detect (zeroed profile) still yields a sane
+	 * value.
 	 */
-	if (root)
-		storage_detect(root, &p);
 	options.io_threads = storage_recommend_io_threads(&p, get_num_cpus());
 
 	if (verbose) {

--- a/src/progress.c
+++ b/src/progress.c
@@ -74,6 +74,55 @@ static unsigned int drawn_lines;
 static uint64_t files_scanned, bytes_scanned;
 
 /*
+ * ETA by weighted progress. Hashing a file costs roughly k*bytes + d: a
+ * per-byte rate plus a fixed per-file overhead (open, fiemap, the DB write).
+ * Rather than fit k and d - which is ill-conditioned while only big files have
+ * been hashed, and blows the ETA up to hours on a cold scan when the per-file
+ * overhead spikes under I/O contention - we fix the *ratio* d/k as a constant
+ * file weight (in byte-equivalents) and let the elapsed time supply the scale.
+ *
+ * Each file counts as `weight` bytes of work, so total work = bytes +
+ * weight*files is known from the listing up front (no warm-up, no discovery of
+ * the small-file tail mid-scan). The remaining fraction is extrapolated by the
+ * time already spent, which measures the true speed empirically - parallelism,
+ * cache state and device all fold into elapsed/done. A wrong weight only
+ * reweights files vs bytes and is self-limiting (too large and it degrades to a
+ * plain file-rate ETA; it cannot run away), so a fixed value per storage class
+ * is robust where fitting d was not.
+ */
+#define ETA_FILE_WEIGHT_SSD	(32u << 10)	/* 32 KiB: ~ measured d/k on flash */
+#define ETA_FILE_WEIGHT_HDD	(1u << 20)	/* 1 MiB: seek-bound rotational disks */
+static uint64_t eta_file_weight = ETA_FILE_WEIGHT_SSD;
+
+void pscan_set_storage_rotational(bool rotational)
+{
+	eta_file_weight = rotational ? ETA_FILE_WEIGHT_HDD : ETA_FILE_WEIGHT_SSD;
+}
+
+uint64_t pscan_eta_file_weight(void)
+{
+	return eta_file_weight;
+}
+
+/*
+ * Seconds left, or -1 if nothing measurable yet. weight is the per-file work in
+ * byte-equivalents. Pure, unit-tested (see tests.c).
+ */
+static double scan_eta_seconds(uint64_t done_bytes, uint64_t done_files,
+			       uint64_t total_bytes, uint64_t total_files,
+			       uint64_t weight, double elapsed)
+{
+	double done = (double)done_bytes + (double)weight * done_files;
+	double total = (double)total_bytes + (double)weight * total_files;
+
+	if (done <= 0.0)
+		return -1.0;
+	if (total <= done)
+		return 0.0;
+	return elapsed * (total - done) / done;
+}
+
+/*
  * Used to track the status of our search extents from blocks
  */
 static _Atomic uint64_t search_total, search_processed;
@@ -246,7 +295,7 @@ static unsigned int print_scan_progress(void)
 		return 3;
 	}
 
-	/* Files/s, reused by the file-rate ETA below; 0 until we have a second. */
+	/* Files/s for the display line; 0 until we have a second of data. */
 	double frate = (files_scanned && elapsed > 1.0) ? files_scanned / elapsed : 0.0;
 
 	s_printf("\tFiles scanned: %" PRIu64 "/%" PRIu64 " (%05.2f%%)",
@@ -260,26 +309,10 @@ static unsigned int print_scan_progress(void)
 	      tb ? (double)bytes_scanned / tb * 100 : 100.0);
 	if (bytes_scanned && elapsed > 1.0) {
 		double brate = bytes_scanned / elapsed;
-		double eta = 0.0;
+		double eta = scan_eta_seconds(bytes_scanned, files_scanned,
+					      tb, tf, eta_file_weight, elapsed);
 
 		printf(" · %s/s", human_size((uint64_t)brate));
-
-		/*
-		 * Both bytes and files must reach 100%, and which one dominates
-		 * the time left flips during a scan: big files first
-		 * (byte-bound), then a long tail of tiny files (file-count
-		 * bound). A pure byte ETA collapses to a few seconds during that
-		 * tail while hundreds of thousands of small files still remain,
-		 * so take the larger of the byte- and file-rate estimates.
-		 */
-		if (bytes_scanned < tb)
-			eta = (tb - bytes_scanned) / brate;
-		if (frate > 0.0 && files_scanned < tf) {
-			double feta = (tf - files_scanned) / frate;
-
-			if (feta > eta)
-				eta = feta;
-		}
 		if (eta > 0.0)
 			printf(" · ETA ~%s", human_duration(eta));
 	}

--- a/src/progress.h
+++ b/src/progress.h
@@ -43,6 +43,16 @@ struct pscan_global {
 
 void pscan_finish_listing(void);
 
+/*
+ * Set the storage class for the scan ETA's per-file work weight (rotational
+ * disks carry a much larger per-file seek cost). Call before the scan; defaults
+ * to non-rotational.
+ */
+void pscan_set_storage_rotational(bool rotational);
+
+/* The per-file work weight (bytes) currently used by the scan ETA. */
+uint64_t pscan_eta_file_weight(void);
+
 /* Used to increment the global todo list */
 void pscan_set_progress(uint64_t added_files, uint64_t added_bytes);
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -283,6 +283,42 @@ MU_TEST(test_scan_workq_priority) {
 	memset(&scan_workq, 0, sizeof(scan_workq));
 }
 
+/* Within eps of expected. */
+static bool near(double got, double want, double eps)
+{
+	double e = got - want;
+	return e < eps && e > -eps;
+}
+
+MU_TEST(test_scan_eta) {
+	const uint64_t GiB = 1ull << 30, W = 1ull << 30;   /* 1 GiB per-file weight */
+
+	/* Weighted progress: work = bytes + W*files, ETA = elapsed*(total-done)/done. */
+
+	/* Nothing scanned yet -> no estimate. */
+	mu_check(scan_eta_seconds(0, 0, 4 * GiB, 0, W, 10.0) < 0.0);
+
+	/* Pure files (weight is what counts): 1 of 4 files done in 10 s -> 30 s left.
+	 * done_work = W, total_work = 4*W, eta = 10*(4-1)/1. */
+	mu_check(near(scan_eta_seconds(0, 1, 0, 4, W, 10.0), 30.0, 1e-6));
+
+	/* Pure bytes: 2 of 8 GiB in 12 s -> 36 s. */
+	mu_check(near(scan_eta_seconds(2 * GiB, 0, 8 * GiB, 0, W, 12.0), 36.0, 1e-6));
+
+	/* Mixed, weight ties them together: done_work = 1 GiB + W*1 = 2 GiB,
+	 * total_work = 1 GiB + W*5 = 6 GiB, eta = 10*(6-2)/2 = 20 s. */
+	mu_check(near(scan_eta_seconds(GiB, 1, GiB, 5, W, 10.0), 20.0, 1e-6));
+
+	/* A larger weight up-weights the remaining files, raising the estimate:
+	 * done_work = 1 GiB + 2 GiB*1 = 3 GiB, total = 1 GiB + 2 GiB*5 = 11 GiB,
+	 * eta = 10*(11-3)/3. */
+	mu_check(near(scan_eta_seconds(GiB, 1, GiB, 5, 2 * GiB, 10.0),
+		      10.0 * 8.0 / 3.0, 1e-6));
+
+	/* Done >= total -> 0, never negative or a fallback signal. */
+	mu_check(near(scan_eta_seconds(4 * GiB, 4, 4 * GiB, 4, W, 10.0), 0.0, 1e-6));
+}
+
 MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_block_zeroed);
 	MU_RUN_TEST(test_block_len);
@@ -293,6 +329,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_storage_recommend_io_threads);
 	MU_RUN_TEST(test_scan_bucket);
 	MU_RUN_TEST(test_scan_workq_priority);
+	MU_RUN_TEST(test_scan_eta);
 }
 
 int main(int argc [[maybe_unused]], char *argv[]) {

--- a/src/util.c
+++ b/src/util.c
@@ -72,6 +72,14 @@ double elapsed_seconds(void)
 	       (now.tv_nsec - timer_start.tv_nsec) / 1e9;
 }
 
+uint64_t mono_ns(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
 /* Compact human-readable duration: "45s", "2m14s", "1h03m". */
 int human_duration_snprintf(double seconds, char *str, size_t str_bytes)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -75,6 +75,9 @@ void color_init(bool disable);
 void start_timer(void);
 double elapsed_seconds(void);
 
+/* Monotonic wall-clock nanoseconds, for ad-hoc interval timing. */
+uint64_t mono_ns(void);
+
 int num_digits(unsigned long long num);
 
 /* Online logical CPU count (at least 1). */


### PR DESCRIPTION
Adds a remaining-time estimate to the scan progress display.

## Approach

Hashing a file costs about `k·bytes + d` — a per-byte rate plus a fixed per-file overhead (`open`, `fiemap`, the DB write). Instead of *fitting* `k` and `d`, fix their **ratio** as a per-file weight in byte-equivalents and let elapsed time supply the scale:

```
work        = bytes + weight·files          (total known from the listing up front)
ETA         = elapsed · (total_work − done_work) / done_work
```

`elapsed/done_work` measures the true speed empirically, so parallelism, cache state, and cold-vs-warm all fold in with no model to go unstable. `weight` is fixed per storage class (32 KiB flash, 1 MiB rotational — the rotational flag reuses the `storage_detect()` that already sizes `--io-threads`, resolved *before* the io-threads choice so an explicit `--io-threads` or a stored `--autotune` value still gets the right weight).

## Why not fit k and d

I first built an online least-squares fit of `k` and `d`. It was fragile and complex:
- while only big files have been hashed, the two coefficients are collinear and unidentifiable;
- on a **cold** scan the per-file overhead `d` spikes under I/O contention (`open`/`fiemap` stalling for milliseconds — confirmed by direct measurement), and the fitted `d` × ~1M remaining files ran the ETA up to **hours**.

Fixing the ratio sidesteps both: a wrong weight only reweights files vs bytes and is **self-limiting** (too large → degrades to a plain file-rate ETA; it cannot run away). Two other approaches were measured and rejected: a dedicated smallest-file-first worker (throughput- and ETA-neutral) and directly measuring per-file setup time live (non-stationary under cold contention).

## Result

Cold A/B on the real 112 GiB / 1.17M-file tree (`drop_caches`, 3 rounds; mean abs error of the shown ETA vs actual time-remaining):

| | fit | **weighted** |
|---|---|---|
| whole scan | 7.0s | **4.3s** |
| first 60% of scan | 17.7s | **6.6s** |

No early-underestimate window, no engagement jump, no cold blow-up.

## Calibrating the weight on real hardware

The 32K/1M weights are calibrated on flash; the rotational value is a reasoned estimate. `DUPEREMOVE_SCAN_STATS=1` now prints an `eta-calibration:` line at end of scan showing the *measured* per-file overhead vs per-byte hash time and the ideal weight it implies for that storage, next to the weight actually used — so the constant can be checked on a NAS/HDD.

## Testing

`scripts/verify.sh` green: build (warnings = failure), `make check` (91 integration + 10 C unit tests), valgrind scan+dedupe+replay smoke. `test_scan_eta` covers the weighted formula. Accuracy numbers are cold (`drop_caches`); the estimate never renders before the file listing completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)