### PR TITLE
Scan progress: show "mapping:" during pre-read setup

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1847,7 +1847,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * always reconciles this file and never re-counts the previous one.
 	 */
 	abort_on(!tprogress);
-	tprogress->status = thread_scanning;
+	tprogress->status = thread_mapping;	/* open + do_fiemap: no bytes yet */
 	tprogress->file_scanned_bytes = 0;
 	tprogress->file_total_bytes = file->filesize;
 	strncpy(tprogress->file_path, file->path, PATH_MAX);
@@ -1918,6 +1918,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * until we reach the expected EOF, based on the expected filesize
 	 */
 	t_hash = mono_ns();	/* calibration: setup done, read+hash begins */
+	tprogress->status = thread_scanning;	/* first byte imminent: show % */
 
 	while (ctxt.off < ctxt.filesize) {
 		/* In the buffer, how much bytes are processed as blocks

--- a/src/progress.c
+++ b/src/progress.c
@@ -216,6 +216,16 @@ static void ellipsize_path(const char *path, char *out, size_t out_len,
 	snprintf(out, out_len, "%.*s…%s", head, path, path + len - tail);
 }
 
+/* Short label per status (thread_idle is rendered separately below). Indexed
+ * by the enum, so the order is irrelevant and adding a state is a one-liner. */
+static const char *const status_label[] = {
+	[thread_mapping]	= "mapping:",
+	[thread_scanning]	= "hashing:",
+	[thread_waiting_lock]	= "wait lock:",
+	[thread_committing]	= "commit:",
+	[thread_deduping]	= "deduping:",
+};
+
 static void print_thread_progress(struct pscan_thread *tprogress)
 {
 	char buf[BUF_LEN];
@@ -223,30 +233,30 @@ static void print_thread_progress(struct pscan_thread *tprogress)
 	char clean[PATH_MAX + 1];
 	int avail;
 
+	/* The only thing that varies is the suffix: a byte percentage while
+	 * hashing/deduping, else a size (no bytes processed yet to show a %). */
 	switch (tprogress->status) {
 	case thread_idle:
 		s_printf("[%u] idle\n", tprogress->tid);
 		return;
 	case thread_scanning:
 	case thread_deduping:
-		snprintf(prefix, sizeof(prefix), "[%u] %-20s", tprogress->tid,
-			 tprogress->status == thread_scanning ?
-			 "checksumming:" : "deduping:");
 		snprintf(suffix, sizeof(suffix), ": %s/%s (%05.2f%%)",
 			 human_size(tprogress->file_scanned_bytes),
 			 human_size(tprogress->file_total_bytes),
 			 percent(tprogress->file_scanned_bytes,
 				 tprogress->file_total_bytes));
 		break;
+	case thread_mapping:
 	case thread_waiting_lock:
 	case thread_committing:
-		snprintf(prefix, sizeof(prefix), "[%u] %-20s", tprogress->tid,
-			 tprogress->status == thread_waiting_lock ?
-			 "waiting for lock:" : "committing:");
 		snprintf(suffix, sizeof(suffix), " (size: %s)",
 			 human_size(tprogress->file_total_bytes));
 		break;
 	}
+
+	snprintf(prefix, sizeof(prefix), "[%u] %-11s", tprogress->tid,
+		 status_label[tprogress->status]);
 
 	/*
 	 * The numbers on the right must stay visible: give the path whatever

--- a/src/progress.h
+++ b/src/progress.h
@@ -7,6 +7,7 @@
 
 enum pscan_thread_status {
 	thread_idle,
+	thread_mapping,		/* "mapping:" - setup before the first byte: open + do_fiemap */
 	thread_scanning,
 	thread_waiting_lock,
 	thread_committing,


### PR DESCRIPTION
## Problem

During a scan, a csum worker's progress line shows a frozen `hashing: 0.00%` for the entire pre-read setup phase of each file — `open()` + `do_fiemap()` — because `file_scanned_bytes` only starts moving once the read/hash loop begins. On huge fragmented or heavily-reflinked files (Steam `.ucas`, VM images) on a cold HDD, `do_fiemap` walks the btrfs extent tree twice before the first byte is hashed, which can take a long time. With biggest-file-first scheduling every worker enters this phase at once, so several lines sit at `0.00%` together and the display looks hung.

## Change

- Add a `thread_mapping` status, shown as **`mapping:`** during the open + fiemap setup, flipping to the byte-percentage **`hashing:`** exactly at the point the read loop starts (`t_hash` marker). A long fiemap now reads as `mapping: (size: 18 GiB)` — visibly working — instead of a frozen `hashing: 0.00%`.
- Purely cosmetic: no counters, ETA, or scan logic touched.
- Shorten all status labels (`checksumming:`→`hashing:`, `waiting for lock:`→`wait lock:`, `committing:`→`commit:`) and drop the column padding from `%-20s` to `%-11s`, freeing ~9 columns for the path.
- Fold the two hand-rolled label ternary chains into a single `status_label[]` table indexed by the enum, so adding a state is a one-line change and the `%-11s` width lives in one place.

## Testing

- Clean build (warnings = failure gate), `make check` — all 91 tests pass.
- Smoke scan on a real btrfs tree completes normally.
- Note: the new state won't reproduce on warm/small files (they map instantly); it's visible on large fragmented files on cold storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)