### PR TITLE
Scan ETA: retune HDD per-file weight to 256 KiB

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -90,8 +90,9 @@ static uint64_t files_scanned, bytes_scanned;
  * plain file-rate ETA; it cannot run away), so a fixed value per storage class
  * is robust where fitting d was not.
  */
-#define ETA_FILE_WEIGHT_SSD	(32u << 10)	/* 32 KiB: ~ measured d/k on flash */
-#define ETA_FILE_WEIGHT_HDD	(1u << 20)	/* 1 MiB: seek-bound rotational disks */
+#define ETA_FILE_WEIGHT_SSD	(32u << 10)	/* 32 KiB: measured d/k ~30 KiB on flash */
+#define ETA_FILE_WEIGHT_HDD	(256u << 10)	/* 256 KiB: measured d/k ~268 KiB on a
+						 * 4-HDD btrfs RAID (1.7M files, cold) */
 static uint64_t eta_file_weight = ETA_FILE_WEIGHT_SSD;
 
 void pscan_set_storage_rotational(bool rotational)


### PR DESCRIPTION
## What

The scan ETA weights each file as a fixed number of byte-equivalents of work (its per-file open+`do_fiemap`+DB overhead, the `d/k` ratio). The HDD constant was an **unmeasured 1 MiB guess**.

A cold full hash on a 4-HDD btrfs RAID (1.71M files, 4.9 TiB) calibrated it:
```
overhead=7702.9us/file  hash=30.11s/GiB  ->  ideal weight 268 KiB/file (using 1024 KiB)
```
So the shipped 1 MiB is ~3.8× too large. Set it to **256 KiB** (2¹⁸), matching the measurement.

Too-large a weight is self-limiting (it only degrades the ETA toward a plain file-rate estimate, over-weighting the small-file tail — it can't run away), so this is an accuracy improvement, not a correctness fix. SSD stays 32 KiB (measured ~30). No logic change — one constant.

## Testing

- `make check` — all 91 tests pass; clean build (warnings = failure gate).
- Anchored on the same real-hardware calibration line the change documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)