### PR TITLE
Fix use-after-free and leak when recreating a rejected hashfile

### DIFF
--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -476,8 +476,9 @@ static int dbfile_set_modes(sqlite3 *db)
  */
 static bool hashfile_rebuilt;
 
-static int dbfile_prepare(sqlite3 *db, bool readonly)
+static int dbfile_prepare(sqlite3 **db_p, bool readonly)
 {
+	sqlite3 *db = *db_p;
 	struct dbfile_config cfg;
 	int ret;
 	char dbpath[PATH_MAX + 1];
@@ -548,8 +549,18 @@ static int dbfile_prepare(sqlite3 *db, bool readonly)
 			return ret;
 		}
 
+		/*
+		 * Hand the freshly-opened handle back to the caller: dbfile_prepare
+		 * took *db_p by reference precisely so this replacement propagates.
+		 * The old handle was just closed above; returning it (as the by-value
+		 * version did) left the caller using freed memory and leaking this new
+		 * one.
+		 */
 		db = __dbfile_open_handle(dbpath, false, false);
-		return dbfile_prepare(db, false);
+		*db_p = db;
+		if (!db)
+			return -1;
+		return dbfile_prepare(db_p, false);
 	}
 
 	/* May store the default config, if fields were missing
@@ -603,7 +614,7 @@ static sqlite3 *__dbfile_open_handle(char *filename, bool force_create,
 		return NULL;
 	}
 
-	ret = dbfile_prepare(db, readonly);
+	ret = dbfile_prepare(&db, readonly);
 	if (ret) {
 		sqlite3_close(db);
 		return NULL;


### PR DESCRIPTION
## What

When an existing hashfile fails `dbfile_check()` — a foreign/unbranded file, or a schema-minor mismatch — `dbfile_prepare()` takes the *"Recreating hashfile"* path: it `sqlite3_close()`s the handle, unlinks the file, reopens a fresh one, and recurses.

The handle was passed **by value**, so the reopened handle only lived in `dbfile_prepare()`'s local variable. The caller `__dbfile_open_handle()` kept — and returned — a pointer to the **closed** handle:

- `open_handle()` then ran `sqlite3_prepare_v2()` on the freed handle → **use-after-free**, surfacing as `SQLITE_MISUSE` / `Database error 21`, and later `sqlite3_close()`d it a second time;
- the working handle opened during recreation was **leaked** (~160 KB, *"definitely lost"* under valgrind).

## Fix

Pass the handle by reference (`sqlite3 **`) so the reopened handle propagates back to the caller, and bail out cleanly if the reopen fails (the old code would otherwise recurse into `dbfile_prepare(NULL, …)`).

## Provenance

Latent defect **inherited from upstream duperemove** (same `dbfile_prepare` close/reopen/recurse shape). oans's strict `application_id` branding makes it easy to trigger, since any foreign/unbranded hashfile now takes the recreate path — upstream only hit it on a schema-version migration.

## How it was found / verified

Running the suites under valgrind:

- Plain runs **passed** (the freed-but-intact memory still read back OK) — the bug is latent without a memory checker.
- Under valgrind it failed 3 `test_appid` tests (`test_foreign_application_is_refused`, `test_unbranded_is_refused_and_rebuilt`, `test_rebuild_is_compacted`) with UAF + a definite leak.
- **After the fix:** C unit tests clean under valgrind (0 errors); full integration suite **100/100 OK** with **zero** valgrind findings across all 191 `oans` invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)