### PR TITLE
ci: run unit + integration suites under valgrind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,46 @@ jobs:
         run: make integration
         env:
           DUPEREMOVE_TEST_DIR: /mnt/oans-scratch
+
+  # Same build + suites, but under valgrind's memcheck. Kept as its own job so
+  # the fast legs above still give quick feedback; this one is ~7x slower but
+  # catches use-after-free / leaks the plain suite reads straight past (it found
+  # the dbfile recreate-path UAF fixed in #105). One filesystem is enough -
+  # memory behaviour is fs-independent - so it runs on btrfs only.
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libsqlite3-dev libglib2.0-dev libblkid-dev libmount-dev \
+            uuid-dev libbsd-dev libxxhash-dev \
+            btrfs-progs valgrind
+
+      - name: Build
+        run: make
+
+      - name: Unit tests under valgrind
+        run: |
+          make test   # builds ./test (and runs it natively - fast)
+          valgrind -q --leak-check=full --error-exitcode=42 \
+            --suppressions=tests/valgrind.supp ./test
+
+      - name: Set up a scratch btrfs
+        run: |
+          sudo modprobe btrfs || true
+          IMG="$RUNNER_TEMP/oans-scratch.img"
+          truncate -s 2G "$IMG"
+          mkfs.btrfs -q "$IMG"
+          sudo mkdir -p /mnt/oans-scratch
+          sudo mount -o loop "$IMG" /mnt/oans-scratch
+          sudo chmod 1777 /mnt/oans-scratch
+
+      - name: Integration tests under valgrind
+        run: make integration-valgrind
+        env:
+          DUPEREMOVE_TEST_DIR: /mnt/oans-scratch

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test
 *~
 *.d
 .itest-scratch/
+.vglogs/
 __pycache__/
 version
 .pandoc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,16 @@ invalid-access errors are real. (One fixed: `__dbfile_get_config` read an
 unterminated UUID buffer; `get_config_text` buffers are raw `memcpy`, so anything
 `strlen`'d must be zero-initialised.)
 
+- **`make integration-valgrind`** runs the *whole* end-to-end suite under
+  memcheck — each `oans` invocation via `tests/valgrind-wrap.sh` (set
+  `DUPEREMOVE=` to it, `OANS_VG_LOGDIR=` for per-pid logs). Findings land in
+  `.vglogs/`; a non-empty log fails the target. ~7× slower than plain
+  `integration` (so opt-in, not in `check`), but it catches use-after-free /
+  leaks the plain suite reads straight past — it found the `dbfile_prepare`
+  recreate-path UAF (a rejected hashfile reopened into a by-value local, so the
+  caller kept the closed handle; fixed by passing `sqlite3 **`). The CI
+  `valgrind` job runs it (btrfs only — memory behaviour is fs-independent).
+
 ## Hashfile identity & schema version
 
 Schema version is `DB_FILE_MAJOR.MINOR` in `dbfile.h` (5.0; forked at upstream

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,23 @@ test:
 integration: oans
 	DUPEREMOVE=./oans python3 tests/run.py
 
+# Same end-to-end suite, but every oans invocation runs under valgrind memcheck
+# (via tests/valgrind-wrap.sh). Findings go to per-pid logs; a non-empty log
+# means a real error/leak, so we fail if any survived. ~7x slower than plain
+# `integration` - opt-in, not part of `check`. Needs valgrind installed.
+VGLOGDIR = $(CURDIR)/.vglogs
+.PHONY: integration-valgrind
+integration-valgrind: oans
+	@command -v valgrind >/dev/null 2>&1 || { echo "valgrind not installed"; exit 1; }
+	rm -rf $(VGLOGDIR) && mkdir -p $(VGLOGDIR)
+	OANS_VG_LOGDIR=$(VGLOGDIR) DUPEREMOVE=tests/valgrind-wrap.sh python3 tests/run.py
+	@if find $(VGLOGDIR) -type f -size +0c | grep -q .; then \
+		echo "=== valgrind reported errors/leaks ==="; \
+		find $(VGLOGDIR) -type f -size +0c -exec cat {} +; \
+		exit 1; \
+	fi; \
+	echo "valgrind: no findings"
+
 .PHONY: check
 check: test integration
 

--- a/tests/valgrind-wrap.sh
+++ b/tests/valgrind-wrap.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# valgrind-wrap.sh - run oans under valgrind's memcheck, transparently.
+#
+# The integration harness execs a single binary named by $DUPEREMOVE, so point
+# that at this script to put every oans invocation under valgrind:
+#
+#   OANS_VG_LOGDIR=/tmp/vglogs \
+#   DUPEREMOVE=tests/valgrind-wrap.sh python3 tests/run.py
+#
+# (or just `make integration-valgrind`, which wires this up and checks the logs).
+#
+# Env knobs:
+#   OANS_BIN        the real binary to run (default: ./oans next to this script)
+#   OANS_VG_LOGDIR  if set, valgrind writes one log per pid here (vg.<pid>.log)
+#                   instead of stderr - keeps its output out of the harness's
+#                   captured stdout, so a non-empty log == a real finding.
+#
+# A definite/possible leak or any memory error also flips the exit code to 42.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+: "${OANS_BIN:=$here/../oans}"
+
+logopt=
+[ -n "${OANS_VG_LOGDIR:-}" ] && logopt="--log-file=$OANS_VG_LOGDIR/vg.%p.log"
+
+exec valgrind -q \
+	--leak-check=full \
+	--errors-for-leak-kinds=definite,possible \
+	--error-exitcode=42 \
+	--suppressions="$here/valgrind.supp" \
+	$logopt \
+	"$OANS_BIN" "$@"


### PR DESCRIPTION
Follow-up to #105. Adds a valgrind memcheck leg so use-after-free / leaks that plain runs read straight past get caught — exactly the class of bug behind #105 (the plain integration suite passed on the freed-but-intact memory; only valgrind flagged it).

## Changes

- **`tests/valgrind-wrap.sh`** — point `DUPEREMOVE` at it to run every `oans` invocation under memcheck. Findings go to per-pid logs (`OANS_VG_LOGDIR`), keeping valgrind's output out of the harness's captured stdout, so a non-empty log is a real finding. A leak/error also flips the exit code to 42.
- **`make integration-valgrind`** — wires the wrapper into the full suite and fails if any log survived. ~7× slower than plain `integration` (23 s → ~173 s here), so it's **opt-in and not part of `check`**.
- **CI** — a dedicated `valgrind` job runs the unit tests under valgrind and `make integration-valgrind`. Kept separate from `build-and-test` so the fast btrfs/xfs legs still give quick feedback; runs on **btrfs only** since memory behaviour is filesystem-independent.

## Why not the default?
The 7× slowdown plus a hard valgrind dependency would tax the inner dev loop for little day-to-day gain. A dedicated CI job pays for itself — it caught a real UAF that 100/100 green tests missed.

## Verification (locally, on btrfs)
- Unit tests under valgrind: 0 errors.
- `make integration-valgrind`: **100/100 OK, "valgrind: no findings", exit 0** across all 191 `oans` invocations.
- `ci.yml` parses; the new job mirrors the existing loopback-btrfs scratch setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)