### PR TITLE
dedupe: keep hashed data warm, and prefetch it before FIDEDUPERANGE

### DIFF
--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -22,6 +22,7 @@
 #include <sys/vfs.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 #include <errno.h>
 
@@ -376,6 +377,47 @@ static void clamp_len_to_ioctl_file(struct dedupe_ctxt *ctxt)
 	ctxt->len = ctxt->orig_len = src_size - ctxt->ioctl_file_off;
 }
 
+/*
+ * Read this round's ranges into the page cache right before the FIDEDUPERANGE
+ * ioctl. The kernel byte-compares the source against every destination in-kernel
+ * before sharing; on btrfs that read path is very slow when the pages are cold
+ * (it doesn't read ahead), so on a tree larger than the page cache - where the
+ * data we hashed has already been evicted by the time dedupe runs - dedupe
+ * crawls (~10x). A plain sequential read primes those pages fast, so the ioctl
+ * compares from RAM.
+ *
+ * It must be a real read: posix_fadvise(WILLNEED) is asynchronous and the ioctl
+ * outruns it (measured ~10x slower, i.e. no better than not prefetching). We
+ * prefetch only the current round (src_length <= DEDUPE_ROUND_LEN per range), so
+ * a duplicated file far larger than RAM is warmed a chunk at a time - the working
+ * set is (1 + dest_count) * <=32 MiB, independent of file size. When the data is
+ * already resident (the common case, since the scan just hashed it) these reads
+ * are cheap page-cache hits.
+ */
+static void prefetch_range(int fd, uint64_t off, uint64_t len)
+{
+	static __thread char buf[1 << 20];
+
+	while (len) {
+		size_t chunk = len < sizeof(buf) ? len : sizeof(buf);
+		ssize_t r = pread(fd, buf, chunk, off);
+
+		if (r <= 0)
+			return;	/* unreadable range: let the ioctl take the cold path */
+		off += r;
+		len -= r;
+	}
+}
+
+static void prefetch_dedupe_round(struct dedupe_ctxt *ctxt,
+				  struct file_dedupe_range *same)
+{
+	prefetch_range(ctxt->ioctl_file->fd, same->src_offset, same->src_length);
+	for (unsigned int i = 0; i < same->dest_count; i++)
+		prefetch_range(same->info[i].dest_fd, same->info[i].dest_offset,
+			       same->src_length);
+}
+
 int dedupe_extents(struct dedupe_ctxt *ctxt)
 {
 	int ret = 0;
@@ -387,6 +429,8 @@ int dedupe_extents(struct dedupe_ctxt *ctxt)
 
 		/* Convert the queued list into an actual request */
 		populate_dedupe_request(ctxt, ctxt->same);
+
+		prefetch_dedupe_round(ctxt, ctxt->same);
 
 retry:
 		ret = ioctl(ctxt->ioctl_file->fd, FIDEDUPERANGE, ctxt->same);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2026,11 +2026,16 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	ctxt.file_csum = NULL;
 
 	/*
-	 * We've read the whole file once and won't touch it again this scan.
-	 * Drop it from the page cache so hashing a large tree doesn't evict
-	 * everything else and push page allocation into the reclaim slowpath.
+	 * We've read the whole file once. In scan/report-only runs we won't
+	 * touch it again, so drop it from the page cache — hashing a large tree
+	 * shouldn't evict everything else and push page allocation into the
+	 * reclaim slowpath. But when dedupe follows (-d), FIDEDUPERANGE has to
+	 * byte-compare the very data we just hashed; evicting it here forces a
+	 * cold re-read from disk in the dedupe phase (btrfs' in-kernel dedupe
+	 * read path is slow cold: ~30x slower on large files). So keep it warm.
 	 */
-	posix_fadvise(ctxt.fd, 0, 0, POSIX_FADV_DONTNEED);
+	if (!options.run_dedupe)
+		posix_fadvise(ctxt.fd, 0, 0, POSIX_FADV_DONTNEED);
 
 	/*
 	 * Whether the last extent is inlined is a pure fiemap scan; compute it


### PR DESCRIPTION
Two related fixes so the dedupe phase never re-reads just-hashed data via btrfs'
slow cold in-kernel `FIDEDUPERANGE` read path. Two commits, each independently
reviewable.

## Background

`FIDEDUPERANGE` byte-compares the source against every destination *in the kernel*
before sharing, so the dedupe phase reads the very data the scan just hashed. On
btrfs that read path doesn't read ahead, so when those pages are cold it crawls
(~10× slower than a normal sequential read).

## 1. `file_scan`: don't drop page cache before a dedupe re-reads it

The scan issued `POSIX_FADV_DONTNEED` after hashing each file (cache hygiene for a
big scan). But when dedupe follows (`-d`), that evicts the data dedupe is about to
re-read, forcing a cold re-read. Gate the advice on `!options.run_dedupe`:
scan/report-only runs keep the hygiene benefit; dedupe runs keep the data warm.

Single 3.3 GiB file, two non-reflinked copies, cold, hashfile on btrfs:

| phase | before | after | upstream v0.15.2 |
|---|---|---|---|
| scan+hash (`-rq`) | 2.45 s | 2.46 s | 2.06 s |
| **full create (`-dr`)** | **146 s** | **4.5 s** | 4.5 s |
| disk read during `-dr` | 13.8 GiB | 6.9 GiB | 6.9 GiB |

This only helps when the working set fits in the page cache.

## 2. `dedupe`: prefetch each round's ranges before the ioctl

On a tree larger than RAM, the earliest-hashed files are evicted before dedupe
reaches them, so #1 can't keep them warm and the cold re-read returns. Before each
`FIDEDUPERANGE` round, `pread` the source + all destination ranges into the page
cache so the compare hits RAM. Chunked to the dedupe round (≤ `DEDUPE_ROUND_LEN`
per range), so a duplicated file far larger than RAM is warmed a piece at a time;
the working set is `(1 + dest_count) × ≤32 MiB`, independent of file size. When the
data is already resident (the common fits-in-RAM case) these are cheap page-cache
hits (~1% wall).

`posix_fadvise(WILLNEED)` was tried and does **not** work: it's asynchronous, the
ioctl outruns the readahead, and dedupe stays on the cold path (~119 s, no better
than not prefetching). The read must be synchronous.

Measured (linux tree ×2 = 11 GiB / 190k files, cold, interleaved):

| | fits in RAM | exceeds RAM (evicted) |
|---|---|---|
| no fix | 132 s | 132 s |
| #1 alone | 10.5 s | ~132 s |
| **#1 + prefetch** | **10.7 s** | **~14 s** |

## Test

`scripts/verify.sh` passes: build (warnings = error), 11 C unit tests / 5085
assertions, 100 integration tests, valgrind scan+dedupe+replay smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)