### PR TITLE
dedupe: byte-weighted smooth progress bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,33 @@ per-pass target drift (a group spanning passes used to converge to one cluster
 *per pass* instead of a single extent). Exercise with `DUPEREMOVE_FILES_PER_PASS`
 (`test_cross_pass.py`); don't reintroduce loading all `dedupe_seq <= ?2` members.
 
+## Dedupe progress is byte-weighted (not group-counted)
+
+The dedupe bar tracks the kernel **byte-verify volume**, not a fuzzy group
+count, so it moves smoothly 0→100% (like hashing) even through one giant group.
+
+- **Work of a group = `de_len * (de_num_dupes - 1)`** — the bytes the kernel
+  byte-compares, same figure `cmp_dext_work()` sorts by. The exact phase total
+  is summed up front by `dbfile_count_dupe_bytes()` (whole-file + extent, minus
+  extents owned by whole-file dup members, since the whole-file pass deletes
+  those rows first). Passed `seq_lo = first_seq`, so it matches what the
+  per-pass loaders hand the workers regardless of how generations split — the
+  sum is batch-invariant (`test_progress_bytes.py::…_stable_across_passes`).
+- **Settlement contract:** every group credits *exactly* `W0` bytes to
+  `work_done_bytes` by the time its worker returns — ticked smoothly per ≤32 MiB
+  ioctl round (via `ctxt->progress_fn`), plus a settle-up lump in
+  `dedupe_worker()` for whatever was skipped (clean_deduped, already-shared,
+  changed-since-scan, ENOENT/EINVAL, the DEDUPE_EXTENTS_CLEANED early return).
+  **Don't try to credit each skip path exactly** — capture `w0` before the work
+  (the worker can free `dext`) and settle the shortfall once. Over-ticking is
+  fine: the 99% cap + monotone display clamp + exact upfront total absorb it.
+- Block-hash-discovered groups (`--dedupe-options=partial`, off by default)
+  aren't in the upfront total; each is added via `pdedupe_add_pushed_work()` at
+  push time and the renderer clamps `total = max(upfront, pushed)`.
+- `--progress=json` emits `work_done_bytes`/`work_total_bytes` **raw** (no
+  monotone clamp — machine consumers want truth); `pdedupe_end()` emits one
+  final dedupe record so the last line shows the settled `done == total`.
+
 ## Valgrind
 
 `verify.sh` runs the smoke. Manual, with the suppressions file (filters the one

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -313,8 +313,15 @@ during hashing: \f[CR]\[dq]phase\[dq]:\[dq]hashing\[dq]\f[R] with
 \f[CR]bytes_total\f[R], and, once measurable, \f[CR]bytes_per_sec\f[R]
 and \f[CR]eta_sec\f[R]; during dedupe:
 \f[CR]\[dq]phase\[dq]:\[dq]dedupe\[dq]\f[R] with \f[CR]groups\f[R],
-\f[CR]groups_total\f[R], \f[CR]reclaimed_bytes\f[R], the current
+\f[CR]groups_total\f[R], \f[CR]work_done_bytes\f[R],
+\f[CR]work_total_bytes\f[R], \f[CR]reclaimed_bytes\f[R], the current
 \f[CR]activity\f[R], and \f[CR]eta_sec\f[R].
+\f[CR]work_total_bytes\f[R] is the total kernel byte\-verify volume the
+phase will do (computed exactly up front) and \f[CR]work_done_bytes\f[R]
+counts up to it; these drive the smooth dedupe progress bar and are
+emitted raw (never clamped backwards), so \f[CR]work_done_bytes\f[R] is
+non\-decreasing and reaches \f[CR]work_total_bytes\f[R] on the last
+dedupe line.
 The final line is
 \f[CR]{\[dq]event\[dq]:\[dq]done\[dq],\[dq]elapsed_sec\[dq]:...,\[dq]files_scanned\[dq]:...,\[dq]groups_deduped\[dq]:...,\[dq]reclaimed_bytes\[dq]:...}\f[R].
 Fields that are not yet known (an ETA, a rate) are omitted; a consumer

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -256,8 +256,13 @@ directory scans the regular files directly inside it; add **-r** to recurse.
     `{"phase":"scanning","elapsed_sec":2.1,"files_examined":48120,"files_to_hash":12340}`;
     during hashing: `"phase":"hashing"` with `files`, `files_total`, `bytes`,
     `bytes_total`, and, once measurable, `bytes_per_sec` and `eta_sec`; during
-    dedupe: `"phase":"dedupe"` with `groups`, `groups_total`, `reclaimed_bytes`,
-    the current `activity`, and `eta_sec`. The final line is
+    dedupe: `"phase":"dedupe"` with `groups`, `groups_total`, `work_done_bytes`,
+    `work_total_bytes`, `reclaimed_bytes`, the current `activity`, and `eta_sec`.
+    `work_total_bytes` is the total kernel byte-verify volume the phase will do
+    (computed exactly up front) and `work_done_bytes` counts up to it; these
+    drive the smooth dedupe progress bar and are emitted raw (never clamped
+    backwards), so `work_done_bytes` is non-decreasing and reaches
+    `work_total_bytes` on the last dedupe line. The final line is
     `{"event":"done","elapsed_sec":...,"files_scanned":...,"groups_deduped":...,"reclaimed_bytes":...}`.
     Fields that are not yet known (an ETA, a rate) are omitted; a consumer
     reading a line at a time can ignore any line that is not valid JSON.

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -2143,6 +2143,77 @@ uint64_t dbfile_count_dupe_groups(struct dbhandle *db, bool whole_file_only)
 	return files > extents ? files : extents;
 }
 
+/* Like dbfile_query_u64 but binds a single uint64 into ?1 first. */
+static uint64_t dbfile_query_u64_arg(sqlite3 *db, const char *sql, uint64_t arg)
+{
+	_cleanup_(sqlite3_stmt_cleanup) sqlite3_stmt *stmt = NULL;
+	uint64_t v = 0;
+
+	if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) == SQLITE_OK &&
+	    sqlite3_bind_int64(stmt, 1, arg) == SQLITE_OK &&
+	    sqlite3_step(stmt) == SQLITE_ROW)
+		v = sqlite3_column_int64(stmt, 0);
+	return v;
+}
+
+uint64_t dbfile_count_dupe_bytes(struct dbhandle *db, unsigned int seq_lo,
+				 bool whole_file_only)
+{
+	uint64_t files, extents;
+
+	/*
+	 * Whole-file work. Mirrors GET_DUPLICATE_FILES: a group with an
+	 * already-deduped member (old_cnt > 0) dedupes all its new members
+	 * against that anchor (new_cnt copies); a group with only new members
+	 * promotes one to target and dedupes the rest (new_cnt - 1). Summing
+	 * per-group over the whole hashfile is exact regardless of how the
+	 * generations get split into passes: across passes the first new member
+	 * becomes the anchor and every later one dedupes against it.
+	 */
+	files = dbfile_query_u64_arg(db->db,
+		"select coalesce(sum(size * (case when old_cnt > 0 then new_cnt "
+		"                                 else new_cnt - 1 end)), 0) "
+		"from ( "
+		"  select size, "
+		"         sum(dedupe_seq >  ?1) as new_cnt, "
+		"         sum(dedupe_seq <= ?1) as old_cnt "
+		"  from files "
+		"  where digest is not null and not (flags & 1) "
+		"  group by digest, size "
+		"  having count(*) > 1 and new_cnt > 0)", seq_lo);
+	if (whole_file_only)
+		return files;
+
+	/*
+	 * Extent work, excluding extents whose file is a whole-file dup-group
+	 * member: the whole-file pass deletes those extent rows
+	 * (dbfile_remove_extent_hashes) before the extent loader runs in the
+	 * same pass, so counting them would double-count. This exclusion is
+	 * what makes the total exact where the group-count estimate could only
+	 * be max()-fudged.
+	 */
+	extents = dbfile_query_u64_arg(db->db,
+		"with filedup(id) as ( "
+		"  select id from files "
+		"  where digest is not null and not (flags & 1) "
+		"    and (digest, size) in ( "
+		"      select digest, size from files "
+		"      where digest is not null and not (flags & 1) "
+		"      group by digest, size having count(*) > 1)) "
+		"select coalesce(sum(len * (case when old_cnt > 0 then new_cnt "
+		"                                else new_cnt - 1 end)), 0) "
+		"from ( "
+		"  select e.len as len, "
+		"         sum(f.dedupe_seq >  ?1) as new_cnt, "
+		"         sum(f.dedupe_seq <= ?1) as old_cnt "
+		"  from extents e join files f on e.fileid = f.id "
+		"  where not exists (select 1 from filedup fd "
+		"                    where fd.id = e.fileid) "
+		"  group by e.digest, e.len "
+		"  having count(*) > 1 and new_cnt > 0)", seq_lo);
+	return files + extents;
+}
+
 /*
  * Remove entries from the files table that were listed but never csummed, i.e.
  * whose digest is still NULL. This happens when a previous run was interrupted

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -293,6 +293,17 @@ unsigned int get_max_dedupe_seq(struct dbhandle *db);
  * duplicate-extent groups across the whole hashfile.
  */
 uint64_t dbfile_count_dupe_groups(struct dbhandle *db, bool whole_file_only);
+
+/*
+ * Exact pending dedupe work in bytes for generations > seq_lo, matching what the
+ * loaders (GET_DUPLICATE_FILES / GET_DUPLICATE_EXTENTS) will hand to the workers:
+ * de_len * (de_num_dupes - 1) summed over every group. The extent part excludes
+ * extents owned by whole-file dup-group members, since the whole-file pass
+ * deletes those rows before the extent loader runs. Unless whole_file_only, the
+ * result is the sum of both parts. Used for the byte-weighted dedupe progress bar.
+ */
+uint64_t dbfile_count_dupe_bytes(struct dbhandle *db, unsigned int seq_lo,
+				 bool whole_file_only);
 int dbfile_prune_unscanned_files(struct dbhandle *db);
 int64_t dbfile_prune_missing_files(struct dbhandle *db, bool (*seen)(int64_t));
 

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -452,8 +452,8 @@ retry:
 
 		process_dedupes(ctxt, ctxt->same);
 
-		if (ctxt->progress)
-			*ctxt->progress += round;
+		if (ctxt->progress_fn)
+			ctxt->progress_fn(ctxt->progress_arg, round);
 
 		/*
 		 * Guard against an infinite loop (upstream #396/#407): if a full

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -52,11 +52,15 @@ struct dedupe_ctxt {
 	struct list_head	completed;
 
 	/*
-	 * Optional live progress counter: when set, dedupe_extents() adds the
-	 * bytes deduped after every ioctl round, so a status display can show
-	 * movement inside large requests instead of one jump at the end.
+	 * Optional live progress callback: when set, dedupe_extents() reports
+	 * the bytes deduped after every ioctl round, so a status display can
+	 * show movement inside large requests instead of one jump at the end.
+	 * A callback (rather than a bare counter) keeps dedupe.c free of the
+	 * progress.h layering: run_dedupe.c both ticks its per-thread status
+	 * line and credits the global byte bar from the same callback.
 	 */
-	uint64_t		*progress;
+	void			(*progress_fn)(void *arg, uint64_t bytes);
+	void			*progress_arg;
 
 	struct file_dedupe_range *same;
 };

--- a/src/oans.c
+++ b/src/oans.c
@@ -1090,6 +1090,14 @@ static void process_duplicates(struct dbhandle *db)
 		pdedupe_set_activity("analyzing duplicates");
 		total = dbfile_count_dupe_groups(db, options.only_whole_files);
 		pdedupe_set_estimate(total);
+		/*
+		 * Exact byte total for the smooth progress bar. Uses first_seq
+		 * (the phase-start dedupe_seq) as the "old" watermark so it
+		 * matches exactly what the per-pass loaders hand the workers,
+		 * regardless of how the generations get split across passes.
+		 */
+		pdedupe_set_work_total(dbfile_count_dupe_bytes(db, first_seq,
+						options.only_whole_files));
 	}
 
 	for (unsigned int i = first_seq; i < max; i += stride) {

--- a/src/progress.c
+++ b/src/progress.c
@@ -183,6 +183,17 @@ static struct {
 	_Atomic uint64_t	done;		/* groups finished */
 	_Atomic uint64_t	queued;		/* groups pushed to the pool */
 	uint64_t		estimate;	/* fuzzy total, see dbfile */
+	/*
+	 * Byte-weighted progress: the kernel byte-verify volume the phase will
+	 * do. work_total_bytes is the exact upfront SQL sum (grow-only, clamped
+	 * up by pushed_bytes if block-hash search discovers extra work);
+	 * work_done_bytes is ticked by the workers; shown_pct is the printer
+	 * thread's monotone display clamp so the bar never renders backwards.
+	 */
+	_Atomic uint64_t	work_done_bytes;
+	_Atomic uint64_t	work_total_bytes;
+	_Atomic uint64_t	pushed_bytes;	/* sum of W0 pushed so far */
+	uint64_t		shown_pct;	/* printer thread only */
 	unsigned int		batch, batches;
 	const char		*activity;	/* static string */
 	/* reclaimed: honest disk freed (kernel-deduped bytes). net_shared: fiemap
@@ -190,6 +201,18 @@ static struct {
 	 * line only (it counts the surviving copy as shared too, so ~2x for pairs). */
 	_Atomic uint64_t	reclaimed, net_shared;
 } pdd;
+
+/*
+ * The byte total to render against: the exact upfront sum, clamped up to the
+ * work actually pushed (the byte analog of max(estimate, queued)). With an
+ * exact upfront total this only rises for block-hash-discovered groups.
+ */
+static uint64_t work_total_clamped(void)
+{
+	uint64_t total = pdd.work_total_bytes, pushed = pdd.pushed_bytes;
+
+	return pushed > total ? pushed : total;
+}
 
 #define s_printf(args...) do { if (tty) printf("\33[K"); printf(args); } while (0)
 
@@ -507,21 +530,30 @@ static unsigned int print_bar_line(void)
 	unsigned int pct = 0;
 
 	if (pdd.phase) {
-		uint64_t done = pdd.done, queued = pdd.queued;
-		uint64_t total = pdd.estimate > queued ? pdd.estimate : queued;
 		double elapsed = (g_get_monotonic_time() - pdd.start_us) / 1e6;
+		uint64_t wdone = pdd.work_done_bytes;
+		uint64_t wtotal = work_total_clamped();
 
-		/* Fuzzy total: cap at 99% while the phase is still running. */
-		if (total) {
-			frac = (double)done / total;
-			pct = (unsigned int)(100.0 * done / total);
+		if (wtotal) {
+			/* Byte-weighted bar: cap at 99% while still running. */
+			frac = (double)wdone / wtotal;
+			pct = (unsigned int)(100.0 * wdone / wtotal);
 			if (pct > 99)
 				pct = 99;
+			/* Monotone clamp (printer thread only): never step back. */
+			if (pct < pdd.shown_pct)
+				pct = pdd.shown_pct;
+			else
+				pdd.shown_pct = pct;
+			if (frac < (double)pct / 100.0)
+				frac = (double)pct / 100.0;
+			eta = dedupe_eta_seconds(wdone, wtotal, elapsed);
 		} else {
-			/* No group count yet (still analyzing): bounce the bar. */
+			/* No work known yet (still analyzing), or the only groups
+			 * are zero-length: bounce the bar. The fuzzy group count
+			 * still feeds the detail line and JSON, not the bar. */
 			indet = true;
 		}
-		eta = dedupe_eta_seconds(done, total, elapsed);
 	} else if (!pscan.listing_completed) {
 		/* Hashing total not known until the listing finishes. */
 		indet = true;
@@ -727,13 +759,20 @@ static void emit_json_progress(enum jphase phase)
 		uint64_t done = pdd.done, queued = pdd.queued;
 		uint64_t total = pdd.estimate > queued ? pdd.estimate : queued;
 		uint64_t st = search_total, sd = search_processed;
+		uint64_t wdone = pdd.work_done_bytes;
+		uint64_t wtotal = work_total_clamped();
 		double de = (g_get_monotonic_time() - pdd.start_us) / 1e6;
-		double eta = dedupe_eta_seconds(done, total, de);
+		/* Machine consumers get the byte-weighted ETA when available. */
+		double eta = wtotal ? dedupe_eta_seconds(wdone, wtotal, de)
+				    : dedupe_eta_seconds(done, total, de);
 
+		/* Raw values (no monotone clamp): consumers want truth. */
 		fprintf(stderr, "{\"phase\":\"dedupe\",\"elapsed_sec\":%.2f,"
 			"\"groups\":%" PRIu64 ",\"groups_total\":%" PRIu64 ","
+			"\"work_done_bytes\":%" PRIu64 ","
+			"\"work_total_bytes\":%" PRIu64 ","
 			"\"reclaimed_bytes\":%" PRIu64, elapsed, done, total,
-			(uint64_t)pdd.reclaimed);
+			wdone, wtotal, (uint64_t)pdd.reclaimed);
 		if (pdd.activity)
 			fprintf(stderr, ",\"activity\":\"%s\"", pdd.activity);
 		if (st)
@@ -1051,6 +1090,10 @@ void pdedupe_begin(unsigned int batches)
 	pdd.reclaimed = 0;
 	pdd.net_shared = 0;
 	pdd.estimate = 0;		/* set later via pdedupe_set_estimate() */
+	pdd.work_done_bytes = 0;
+	pdd.work_total_bytes = 0;	/* set later via pdedupe_set_work_total() */
+	pdd.pushed_bytes = 0;
+	pdd.shown_pct = 0;
 	pdd.batches = batches;
 	pdd.batch = batches ? 1 : 0;
 	pdd.activity = "analyzing duplicates";
@@ -1110,6 +1153,17 @@ void pdedupe_end(void)
 			fflush(stdout);
 		}
 	}
+
+	/*
+	 * Emit one last dedupe record with the settled totals. The ~1/s printer
+	 * cadence otherwise leaves the final JSONL record showing mid-phase
+	 * progress on a fast run, so machine consumers would never see
+	 * work_done_bytes reach work_total_bytes. Done after the printer joins
+	 * (single writer to stderr) but before pdd.phase clears.
+	 */
+	if (progress_json)
+		emit_json_progress(JP_DEDUPE);
+
 	pscan_free_threads();
 	pdd.phase = false;
 }
@@ -1132,6 +1186,27 @@ void pdedupe_set_estimate(uint64_t estimated_groups)
 void pdedupe_add_queued(uint64_t ngroups)
 {
 	atomic_fetch_add(&pdd.queued, ngroups);
+}
+
+void pdedupe_set_work_total(uint64_t bytes)
+{
+	pdd.work_total_bytes = bytes;
+}
+
+void pdedupe_add_work_done(uint64_t bytes)
+{
+	atomic_fetch_add(&pdd.work_done_bytes, bytes);
+}
+
+/*
+ * A group of W0 = de_len*(de_num_dupes-1) bytes was pushed to the pool. Track
+ * the running sum so the renderer can clamp the total up (total = max(upfront,
+ * pushed)) - the byte analog of the old max(estimate, queued). With an exact
+ * upfront total this only engages for block-hash-discovered work.
+ */
+void pdedupe_add_pushed_work(uint64_t bytes)
+{
+	atomic_fetch_add(&pdd.pushed_bytes, bytes);
 }
 
 void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t net_shared_bytes)

--- a/src/progress.h
+++ b/src/progress.h
@@ -154,6 +154,19 @@ void pdedupe_add_queued(uint64_t ngroups);
 void pdedupe_group_done(uint64_t reclaimed_bytes, uint64_t net_shared_bytes);
 
 /*
+ * Byte-weighted progress for the dedupe bar. The total is the kernel byte-verify
+ * volume the phase will do (de_len*(de_num_dupes-1) per group), computed exactly
+ * up front by SQL (pdedupe_set_work_total) and ticked as ioctl rounds complete
+ * (pdedupe_add_work_done), with a settle-up lump for skipped work. Groups that
+ * the block-hash search discovers mid-phase are not in the upfront total; each is
+ * added via pdedupe_add_pushed_work at push time and the renderer clamps the
+ * total up to that running sum.
+ */
+void pdedupe_set_work_total(uint64_t bytes);
+void pdedupe_add_work_done(uint64_t bytes);
+void pdedupe_add_pushed_work(uint64_t bytes);
+
+/*
  * Claim a per-thread display line for one unit of work (file scan / dedupe
  * group) and mark it with `status`; fill in file_path / file_total_bytes /
  * file_scanned_bytes afterwards. Release it with pscan_reset_thread(). Claim

--- a/src/results-tree.h
+++ b/src/results-tree.h
@@ -49,6 +49,18 @@ struct dupe_extents {
 	bool			de_anchored;
 };
 
+/*
+ * Bytes the kernel byte-verifies for a group: its length times the copies to
+ * dedupe against the target. The single definition of a group's "work" - the
+ * largest-first sort key, the per-thread status total, the byte-progress
+ * settlement target, and (restated in SQL) the upfront progress total all use
+ * it, so they must agree.
+ */
+static inline uint64_t dext_work(const struct dupe_extents *d)
+{
+	return d->de_len * (d->de_num_dupes - 1);
+}
+
 struct extent {
 	struct dupe_extents	*e_parent;
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -337,13 +337,35 @@ static void slot_show_group(struct pscan_thread *slot, struct dupe_extents *dext
 	strncpy(slot->file_path,
 		list_first_entry(&dext->de_extents, struct extent,
 				 e_list)->e_file->filename, PATH_MAX);
-	slot->file_total_bytes = dext->de_len * (dext->de_num_dupes - 1);
+	slot->file_total_bytes = dext_work(dext);
 	slot->file_scanned_bytes = 0;
+}
+
+/*
+ * Per-group byte-progress accounting. Every credit path - real ioctl rounds and
+ * the already-shared skip - goes through group_tick(), which moves the per-thread
+ * status line, records how much this group has credited so far (`ticked`), and
+ * feeds the global byte bar. dedupe_worker() then settles up any shortfall
+ * against W0 for the paths that never reach the kernel (clean_deduped, changed
+ * since scan, ENOENT, ...), so each group credits exactly W0 by the time it ends.
+ */
+struct group_progress {
+	struct pscan_thread	*slot;
+	uint64_t		ticked;	/* bytes credited globally for this group */
+};
+
+static void group_tick(void *arg, uint64_t bytes)
+{
+	struct group_progress *gp = arg;
+
+	gp->slot->file_scanned_bytes += bytes;	/* per-thread status line */
+	gp->ticked += bytes;
+	pdedupe_add_work_done(bytes);		/* the main bar */
 }
 
 #define	DEDUPE_EXTENTS_CLEANED	(-1)
 static int dedupe_extent_list(struct dupe_extents *dext,
-			      struct pscan_thread *slot,
+			      struct group_progress *gp,
 			      uint64_t *fiemap_bytes, uint64_t *kern_bytes,
 			      unsigned long long passno)
 {
@@ -353,6 +375,7 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	uint64_t shared_prev, shared_post;
 	struct extent *extent;
 	struct dedupe_ctxt *ctxt = NULL;
+	struct pscan_thread *slot = gp->slot;
 	uint64_t len = dext->de_len;
 	/* Target's extent map, fetched once and reused to skip already-shared
 	 * destinations (see the shared-check below). */
@@ -507,8 +530,10 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 				ret = ENOMEM;
 				goto out;
 			}
-			/* Tick the status line as ioctl rounds complete. */
-			ctxt->progress = &slot->file_scanned_bytes;
+			/* Tick the status line + global byte bar as ioctl
+			 * rounds complete. */
+			ctxt->progress_fn = group_tick;
+			ctxt->progress_arg = gp;
 
 			/*
 			 * If we just picked the target, it got added
@@ -537,7 +562,7 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 					     extent->e_file->fd, extent->e_loff,
 					     len)) {
 			atomic_fetch_add(&dedupe_dest_already_shared, 1);
-			slot->file_scanned_bytes += len;
+			group_tick(gp, len);	/* skipped, but credit its work */
 			vprintf("[%p] %s already shares the target's extents; "
 				"skipping.\n", g_thread_self(),
 				extent->e_file->filename);
@@ -641,16 +666,17 @@ out:
 }
 
 static int extent_dedupe_worker(struct dupe_extents *dext,
-				struct pscan_thread *slot,
+				struct group_progress *gp,
 				uint64_t *fiemap_bytes, uint64_t *kern_bytes)
 {
 	int ret;
 	unsigned long long passno = __atomic_add_fetch(&curr_dedupe_pass, 1, __ATOMIC_SEQ_CST);
 
 	struct extent *extent;
+	struct pscan_thread *slot = gp->slot;
 	struct dbhandle *db = dbfile_get_handle();
 
-	ret = dedupe_extent_list(dext, slot, fiemap_bytes, kern_bytes, passno);
+	ret = dedupe_extent_list(dext, gp, fiemap_bytes, kern_bytes, passno);
 	if (ret) {
 		if (ret == DEDUPE_EXTENTS_CLEANED)
 			return 0;
@@ -704,6 +730,13 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	struct dupe_extents *dext = priv;
 	_cleanup_(pscan_reset_thread) struct pscan_thread *slot =
 				pscan_claim_slot(gettid(), thread_deduping);
+	struct group_progress gp = { .slot = slot, .ticked = 0 };
+	/*
+	 * The group's total byte work, captured BEFORE any dedupe: the worker
+	 * can free dext (dupe_extents_free), so de_len/de_num_dupes must not be
+	 * read afterwards.
+	 */
+	uint64_t w0 = dext_work(dext);
 
 	/*
 	 * Seed the display line from the group before any work: first member
@@ -713,7 +746,18 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	 */
 	slot_show_group(slot, dext);
 
-	extent_dedupe_worker(dext, slot, &fiemap_bytes, &kern_bytes);
+	extent_dedupe_worker(dext, &gp, &fiemap_bytes, &kern_bytes);
+
+	/*
+	 * Settle up the byte bar: credit whatever work never reached the kernel
+	 * (clean_deduped removals, changed-since-scan, ENOENT/EINVAL failures,
+	 * the DEDUPE_EXTENTS_CLEANED early return) in one lump, so every group
+	 * credits exactly W0. Over-ticking (ioctl retries, clamped lengths) is
+	 * possible and harmless - the 99% cap, monotone clamp and exact upfront
+	 * total absorb it.
+	 */
+	if (gp.ticked < w0)
+		pdedupe_add_work_done(w0 - gp.ticked);
 
 	/*
 	 * Space reclaimed = kernel-deduped bytes (each deduped copy frees its
@@ -737,8 +781,8 @@ static int cmp_dext_work(const void *pa, const void *pb)
 {
 	const struct dupe_extents *a = *(const struct dupe_extents **)pa;
 	const struct dupe_extents *b = *(const struct dupe_extents **)pb;
-	uint64_t wa = a->de_len * (a->de_num_dupes - 1);
-	uint64_t wb = b->de_len * (b->de_num_dupes - 1);
+	uint64_t wa = dext_work(a);
+	uint64_t wb = dext_work(b);
 
 	return wa > wb ? -1 : wa < wb ? 1 : 0;
 }
@@ -778,7 +822,9 @@ static int push_extents(struct results_tree *res)
 	qsort(sorted, nr, sizeof(*sorted), cmp_dext_work);
 
 	for (i = 0; i < nr; i++) {
-		g_thread_pool_push(dedupe_pool, sorted[i], &err);
+		struct dupe_extents *d = sorted[i];
+
+		g_thread_pool_push(dedupe_pool, d, &err);
 		if (err) {
 			eprintf("Fatal error while deduping: %s\n",
 				err->message);
@@ -786,6 +832,9 @@ static int push_extents(struct results_tree *res)
 			return 1;
 		}
 		pdedupe_add_queued(1);
+		/* Byte analog of add_queued: lets the renderer clamp the total
+		 * up for block-hash-discovered groups not in the upfront sum. */
+		pdedupe_add_pushed_work(dext_work(d));
 	}
 	return 0;
 }

--- a/tests/integration/test_progress_bytes.py
+++ b/tests/integration/test_progress_bytes.py
@@ -1,0 +1,145 @@
+"""Byte-weighted dedupe progress: work_done_bytes / work_total_bytes.
+
+The dedupe bar tracks the kernel byte-verify volume (de_len*(de_num_dupes-1)
+per group), not a fuzzy group count. The total is computed exactly up front by
+SQL, ticked every <=32 MiB ioctl round, credited in a settle-up lump for
+skipped work, and exposed raw on the --progress=json stream. These tests assert
+the total is byte-exact for the default whole-file config, that the raw fields
+never regress, that the upfront total is stable across passes, and that skipped
+work is still fully credited (settlement). Requires a reflink-capable fs.
+"""
+
+import json
+import os
+import subprocess
+
+from harness import DuperemoveTest, requires_reflink, DUPEREMOVE
+
+MiB = 1024 * 1024
+
+
+class ProgressBytesTest(DuperemoveTest):
+    def _run(self, *args, env=None):
+        """Run oans -rd with --progress=json; return (proc, events)."""
+        cmd = [DUPEREMOVE, "-q", "--io-threads=4", "--hashfile", self.hf,
+               "--progress=json", *args]
+        run_env = dict(os.environ, **env) if env else None
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           text=True, env=run_env)
+        events = [json.loads(ln) for ln in p.stderr.splitlines() if ln.strip()]
+        return p, events
+
+    @staticmethod
+    def _dedupe_evs(events):
+        return [e for e in events if e.get("phase") == "dedupe"]
+
+    @requires_reflink
+    def test_work_total_is_byte_exact_default_config(self):
+        # One 8 MiB pair (work 8 MiB) + one 4 MiB triple (work 8 MiB) => 16 MiB.
+        self.mkdup("tree/p_a", "tree/p_b", 8 * MiB)
+        d = os.urandom(4 * MiB)
+        for n in ("a", "b", "c"):
+            self.write(f"tree/t_{n}", d)
+        self.sync()
+
+        p, events = self._run("-r" + "d", self.path("tree"))
+        self.assertEqual(p.returncode, 0)
+        dedupe = self._dedupe_evs(events)
+        self.assertTrue(dedupe)
+
+        expected = 8 * MiB + 8 * MiB
+        totals = [e["work_total_bytes"] for e in dedupe]
+        # Whole-file groups are byte-exact: the upfront total hits it exactly.
+        self.assertEqual(max(totals), expected)
+
+        # Post-settlement, the last dedupe record has done == total.
+        last = dedupe[-1]
+        self.assertEqual(last["work_done_bytes"], last["work_total_bytes"])
+        self.assertEqual(last["work_done_bytes"], expected)
+
+    @requires_reflink
+    def test_raw_fields_never_regress(self):
+        for i in range(6):
+            self.mkdup(f"tree/a{i}", f"tree/b{i}", 512 * 1024)
+        self.sync()
+
+        _p, events = self._run("-rd", self.path("tree"))
+        dedupe = self._dedupe_evs(events)
+        self.assertTrue(dedupe)
+
+        done = [e["work_done_bytes"] for e in dedupe]
+        total = [e["work_total_bytes"] for e in dedupe]
+        # done is non-decreasing; total never shrinks (0 -> upfront sum, held).
+        self.assertEqual(done, sorted(done), f"work_done regressed: {done}")
+        self.assertEqual(total, sorted(total), f"work_total shrank: {total}")
+
+    @requires_reflink
+    def test_upfront_total_stable_across_passes(self):
+        # Small passes + small batchsize so the work spans several generations;
+        # the byte total is computed once up front and must not change per pass.
+        env = {"DUPEREMOVE_FILES_PER_PASS": "8"}
+        sizes = []
+        for i in range(20):
+            n = 32 * 1024 + i * 4096  # distinct sizes => distinct groups
+            self.mkdup(f"tree/a{i:02d}", f"tree/z{i:02d}", n)
+            sizes.append(n)
+        self.sync()
+
+        _p, events = self._run("-rd", "-B", "4", self.path("tree"), env=env)
+        dedupe = self._dedupe_evs(events)
+        self.assertTrue(dedupe)
+
+        expected = sum(sizes)  # each pair: size * (2 - 1)
+        nonzero = {e["work_total_bytes"] for e in dedupe
+                   if e["work_total_bytes"]}
+        # Exactly one nonzero total, equal to the whole-file work sum.
+        self.assertEqual(nonzero, {expected}, nonzero)
+
+        done = [e["work_done_bytes"] for e in dedupe]
+        self.assertEqual(done, sorted(done), f"work_done regressed: {done}")
+        self.assertEqual(dedupe[-1]["work_done_bytes"], expected)
+
+    @requires_reflink
+    def test_incremental_noop_rerun_zero_work(self):
+        for i in range(4):
+            self.mkdup(f"tree/a{i}", f"tree/b{i}", 256 * 1024)
+        self.sync()
+        self._run("-rd", self.path("tree"))  # first pass does the work
+
+        # Second run: nothing new to dedupe. No crash, zero work, zero groups.
+        p, events = self._run("-rd", self.path("tree"))
+        self.assertEqual(p.returncode, 0)
+        dedupe = self._dedupe_evs(events)
+        self.assertTrue(dedupe)
+        self.assertTrue(all(e["work_total_bytes"] == 0 for e in dedupe))
+        self.assertTrue(all(e["work_done_bytes"] == 0 for e in dedupe))
+        done = [e for e in events if e.get("event") == "done"]
+        self.assertEqual(len(done), 1)
+        self.assertEqual(done[0]["groups_deduped"], 0)
+
+    @requires_reflink
+    def test_skip_work_is_fully_credited(self):
+        # Dedupe once, then re-run against a FRESH hashfile: the tree is already
+        # shared on disk, so nearly all work is skip-credited (already-shared /
+        # clean_deduped) rather than done by the kernel. Settlement must still
+        # bring work_done up to work_total.
+        for i in range(5):
+            self.mkdup(f"tree/a{i}", f"tree/b{i}", 1 * MiB)
+        self.sync()
+        self._run("-rd", self.path("tree"))
+        self.sync()
+
+        # Fresh hashfile forces a full re-analysis of the (already shared) tree.
+        os.unlink(self.hf)
+        for sidecar in (self.hf + "-wal", self.hf + "-shm"):
+            if os.path.exists(sidecar):
+                os.unlink(sidecar)
+
+        _p, events = self._run("-rd", self.path("tree"))
+        dedupe = self._dedupe_evs(events)
+        self.assertTrue(dedupe)
+        expected = 5 * MiB  # five pairs, 1 MiB work each
+        last = dedupe[-1]
+        self.assertEqual(last["work_total_bytes"], expected)
+        self.assertEqual(last["work_done_bytes"], expected,
+                         "skipped work must be settled up to the total")


### PR DESCRIPTION
## What & why

The dedupe (`-d`) progress bar counted **groups** against a fuzzy, growing estimate, so it stalled, sprinted, and visibly ran *backwards* near the end (the denominator was `max(estimate, queued)` and both moved; `--dedupe-options=partial` made it worse by discovering groups mid-phase). This replaces it with a **byte-weighted** bar that tracks the kernel byte-verify volume — exactly like the hashing phase — and moves smoothly even *through* one giant group (ticked per ≤32 MiB ioctl round).

This is **Stage 1** of the dedupe progress/streaming rewrite from the handoff plan. It's independent and schema-free; Stages 2–3 (persistent pool / streaming producer) are separate PRs.

## How

- **`dbfile_count_dupe_bytes()`** sums the exact pending work up front: `de_len*(de_num_dupes-1)` per group — whole-file **+** extent, excluding extents owned by whole-file dup members (the whole-file pass deletes those rows first, so counting them would double-count). Passed `seq_lo = first_seq`, so it matches what the per-pass loaders hand the workers regardless of how generations split into passes — **the sum is batch-invariant**, which is what makes it exact where the old group count could only be `max()`-fudged.
- **Settlement contract:** workers tick `work_done_bytes` every round through a callback (replacing `dedupe_ctxt`'s bare `uint64_t *progress`, keeping `dedupe.c` free of `progress.h`), and each group settles up to its full `W0` once in `dedupe_worker()`. That single lump covers every skip path (`clean_deduped`, already-shared, changed-since-scan, ENOENT/EINVAL, the cleaned early return) without instrumenting each one. Over-ticking is absorbed by the 99% cap + monotone display clamp + exact upfront total.
- **Rendering** is monotone and never steps backwards; the bar itself uses the clamped fraction. Block-hash-discovered groups (off by default) aren't in the upfront total, so each is added via `pdedupe_add_pushed_work()` at push time and the renderer clamps `total = max(upfront, pushed)`.
- **`--progress=json`** gains raw `work_done_bytes` / `work_total_bytes` (no monotone clamp — machine consumers want truth); they're non-decreasing and reach equality on the final dedupe line, which `pdedupe_end()` now always emits (the ~1/s cadence otherwise never showed `done == total` on a fast run). Man page updated.

## Tests

New `tests/integration/test_progress_bytes.py`:
1. **Byte-exact total** for the default whole-file config (8 MiB pair + 4 MiB triple → 16 MiB), final record settled `done == total`.
2. **Monotonicity** — raw `work_done` non-decreasing, `work_total` never shrinks.
3. **Batch-invariance** — small `DUPEREMOVE_FILES_PER_PASS` + `-B`; the upfront total is computed once and stays constant across passes.
4. **Incremental no-op rerun** — zero pending work, no crash, 0 groups.
5. **Skip settlement** — re-run against a fresh hashfile on an already-shared tree; nearly all work is skip-credited yet `work_done` still reaches `work_total`.

Gate: `scripts/verify.sh` clean (build warnings-as-errors, `make check` 105 tests, valgrind scan+dedupe+replay smoke). No `DB_FILE_MINOR` bump — query- and code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)