### PR TITLE
dedupe: streaming pipeline with a persistent pool (Stage 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,49 @@ per-pass target drift (a group spanning passes used to converge to one cluster
 *per pass* instead of a single extent). Exercise with `DUPEREMOVE_FILES_PER_PASS`
 (`test_cross_pass.py`); don't reintroduce loading all `dedupe_seq <= ?2` members.
 
+## Streaming dedupe pipeline (Stage 2)
+
+The dedupe phase (`-d`) runs **one persistent thread pool** for the whole phase;
+the main thread is a **bounded producer** that loads generation batch *i+1* while
+batch *i* dedupes. No pool drain between batches or between the whole-file and
+extent passes. Lives in `run_dedupe.c` (`dedupe_phase_begin/end`,
+`dedupe_begin_batch`/`dedupe_push`/`dedupe_seal_batch`) driven by
+`stream_duplicates()` in `oans.c`. The report path (no `-d`) stays sequential
+(`report_duplicates()`).
+
+- **At most `DEDUPE_MAX_INFLIGHT` (2) batches in flight** — the RAM double
+  buffer. `dedupe_await_slot()` blocks the producer until a slot frees.
+- **Generation-ordered watermark.** Batches are reaped strictly in FIFO
+  (generation) order; `dedupe_seq` only advances to a batch's `seq_hi` once that
+  batch *and all earlier ones* are complete (`dedupe_advance_seq` callback, under
+  `dbfile_lock`). This preserves the **Ctrl+C invariant**: on kill, `dedupe_seq`
+  reflects only fully-processed generations. Empty windows still advance it.
+- **Filerec lifetime = batch-held refs (NOT per-extent).** `struct filerec.refs`
+  is a lifetime count separate from `fd_refs`. Each batch holds one ref per
+  filerec it loaded (taken in `push_results`, released in `free_batch` at reap).
+  **All get/put/new/find happen on the single producer thread**, so the filerec
+  registry (`filerec_by_fileid` tree / `filerec_head`) needs **no lock** and
+  workers never touch it — they only read `filerec` fields and mutate their
+  batch's own results tree (under the global `mutex`). A cross-window anchor is
+  referenced by two in-flight batches; each holds a ref, so it survives until
+  both reap. **Never free filerecs while a batch referencing them is live**
+  (`free_all_filerecs()` is teardown-only now; it's gone from between batches).
+  This is a deliberate, safer alternative to the plan's per-extent/worker-release
+  refcount — same lifetime guarantee, far less lock surface.
+- **Producer DB handle.** The producer loads on a **separate read connection**
+  (`dbfile_open_handle`) so it doesn't share a sqlite handle with the workers
+  writing on the global handle (WAL: readers don't block the writer). The
+  in-memory shared-cache db (no `--hashfile`) has no WAL, so there the producer
+  reuses the global handle and serializes loads with `dbfile_lock()` (`inmem`).
+- **Order-independence (Stage 2.1).** `GET_DUPLICATE_EXTENTS` excludes whole-file
+  dup members *statically* (the `filedup` CTE) instead of relying on the
+  whole-file pass having deleted their extent rows first — the prerequisite for
+  loading both passes without a barrier. As a bonus the two per-batch results
+  trees reference **disjoint** filerec sets. Pinned by
+  `test_extent_order_independent.py`; streaming by `test_streaming_dedupe.py`.
+- **Valgrind is the gate** (`make integration-valgrind`): this is the UAF-prone
+  area (see the "Valgrind" section / PR #105). Run it before any PR here.
+
 ## Dedupe progress is byte-weighted (not group-counted)
 
 The dedupe bar tracks the kernel **byte-verify volume**, not a fuzzy group

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,13 +338,31 @@ extent passes. Lives in `run_dedupe.c` (`dedupe_phase_begin/end`,
   in-memory shared-cache db (no `--hashfile`) has no WAL, so there the producer
   reuses the global handle and serializes loads with `dbfile_lock()` (`inmem`).
 - **Order-independence (Stage 2.1).** `GET_DUPLICATE_EXTENTS` excludes whole-file
-  dup members *statically* (the `filedup` CTE) instead of relying on the
-  whole-file pass having deleted their extent rows first — the prerequisite for
-  loading both passes without a barrier. As a bonus the two per-batch results
+  dup members *statically* (the `FILEDUP_MEMBER` predicate) instead of relying on
+  the whole-file pass having deleted their extent rows first — the prerequisite
+  for loading both passes without a barrier. As a bonus the two per-batch results
   trees reference **disjoint** filerec sets. Pinned by
   `test_extent_order_independent.py`; streaming by `test_streaming_dedupe.py`.
+  **Keep it a correlated probe, not a materialized set:** a `group by digest,
+  size` CTE here cost ~6 s per batch load on a 3.5M-file hashfile (the producer
+  stalls at "loading duplicate extents" while the pool idles; measured 21.7 s →
+  0.2 s per load after the switch).
+- **A pushed dext belongs to the worker.** The moment `g_thread_pool_push()`
+  hands a group to the pool, a worker can free it (an already-shared group is
+  cleaned in microseconds) — the producer must capture anything it needs
+  (`dext_work()` etc.) **before** the push. Reading after once fed
+  `len * (0 - 1)` from a freed dext into the pushed-work total (frozen bar,
+  multi-thousand-year ETA); `push_results` now asserts sane per-group work.
+- **Partial mode drains.** `find_additional_dedupe()` walks the **global**
+  filerec list, so with `--dedupe-options=partial` the producer calls
+  `dedupe_drain()` before the block-hash search — earlier batches are reaped
+  (filerecs freed) first, at the cost of cross-batch pipelining in that mode.
+  Default mode keeps the full overlap; don't add other drain points.
 - **Valgrind is the gate** (`make integration-valgrind`): this is the UAF-prone
-  area (see the "Valgrind" section / PR #105). Run it before any PR here.
+  area (see the "Valgrind" section / PR #105). Run it before any PR here — but
+  note it did **not** catch the pushed-dext race above (valgrind's serialization
+  makes a fast worker win too rarely); producer-vs-worker lifetime rules need
+  review, not just the suite.
 
 ## Dedupe progress is byte-weighted (not group-counted)
 

--- a/src/filerec.c
+++ b/src/filerec.c
@@ -30,7 +30,7 @@
 #include "filerec.h"
 
 static GMutex filerec_fd_mutex;
-struct filerec_list filerec_head = SLIST_HEAD_INITIALIZER(filerec_head);
+struct list_head filerec_head = LIST_HEAD_INIT(filerec_head);
 
 static struct rb_root filerec_by_fileid = RB_ROOT;
 unsigned long long num_filerecs = 0ULL;
@@ -41,7 +41,7 @@ declare_alloc_tracking(filerec_token);
 
 void init_filerec(void)
 {
-	SLIST_INIT(&filerec_head);
+	INIT_LIST_HEAD(&filerec_head);
 }
 
 struct filerec_token *find_filerec_token_rb(struct rb_root *root,
@@ -187,7 +187,7 @@ static struct filerec *filerec_alloc_insert(const char *filename,
 	file->size = size;
 
 	insert_filerec(file);
-	SLIST_INSERT_HEAD(&filerec_head, file, rec_list);
+	list_add(&file->rec_list, &filerec_head);
 	num_filerecs++;
 
 	return file;
@@ -211,7 +211,7 @@ static void filerec_free(struct filerec *file)
 		 * file_block's from free_all_filerecs()
 		 */
 //		abort_on(!RB_EMPTY_ROOT(&file->block_tree));
-		SLIST_REMOVE(&filerec_head, file, filerec, rec_list);
+		list_del(&file->rec_list);
 
 		if (!RB_EMPTY_NODE(&file->fileid_node))
 			rb_erase(&file->fileid_node, &filerec_by_fileid);
@@ -236,7 +236,7 @@ void free_all_filerecs(void)
 {
 	struct filerec *file, *tmp;
 
-	SLIST_FOREACH_SAFE(file, &filerec_head, rec_list, tmp) {
+	list_for_each_entry_safe(file, tmp, &filerec_head, rec_list) {
 		filerec_free(file);
 	}
 }

--- a/src/filerec.c
+++ b/src/filerec.c
@@ -220,6 +220,18 @@ static void filerec_free(struct filerec *file)
 	}
 }
 
+void filerec_get(struct filerec *file)
+{
+	file->refs++;
+}
+
+void filerec_put(struct filerec *file)
+{
+	abort_on(file->refs == 0);
+	if (--file->refs == 0)
+		filerec_free(file);
+}
+
 void free_all_filerecs(void)
 {
 	struct filerec *file, *tmp;

--- a/src/filerec.h
+++ b/src/filerec.h
@@ -23,8 +23,10 @@
 #include "rbtree.h"
 #include "results-tree.h"
 
-SLIST_HEAD(filerec_list, filerec);
-extern struct filerec_list filerec_head;
+/* Doubly-linked (kernel list_head) so an individual filerec can be removed in
+ * O(1): the streaming dedupe phase frees filerecs per batch, in load order, not
+ * head-first, so a singly-linked list's O(n) removal made teardown O(n^2). */
+extern struct list_head filerec_head;
 
 extern unsigned long long num_filerecs;
 extern unsigned int dedupe_seq; /* This is incremented on every dedupe pass */
@@ -49,7 +51,7 @@ struct filerec {
 	uint64_t		size;
 	struct rb_root		block_tree;	/* root for hash blocks tree */
 
-	SLIST_ENTRY(filerec)	rec_list;	/* all filerecs */
+	struct list_head	rec_list;	/* all filerecs */
 };
 
 void init_filerec(void);

--- a/src/filerec.h
+++ b/src/filerec.h
@@ -32,6 +32,14 @@ extern unsigned int dedupe_seq; /* This is incremented on every dedupe pass */
 struct filerec {
 	int		fd;			/* file descriptor */
 	unsigned int	fd_refs;			/* fd refcount */
+	/*
+	 * Lifetime refcount, distinct from fd_refs. In the streaming dedupe
+	 * phase a filerec can be referenced by more than one in-flight batch
+	 * (e.g. a cross-window anchor); each batch that loads it holds one ref
+	 * and drops it at batch completion. All get/put happen on the single
+	 * producer thread, so this needs no lock. filerec_new() starts at 0.
+	 */
+	unsigned int	refs;
 
 	char	*filename;		/* path to file */
 	int64_t fileid;
@@ -50,6 +58,13 @@ void free_all_filerecs(void);
 struct filerec *filerec_new(const char *filename, int64_t fileid,
 			    uint64_t size);
 struct filerec *filerec_find(int64_t fileid);
+
+/*
+ * Lifetime refcount (see struct filerec::refs). filerec_put() frees the filerec
+ * when its count reaches zero. Producer-thread only; not thread-safe by design.
+ */
+void filerec_get(struct filerec *file);
+void filerec_put(struct filerec *file);
 
 int filerec_open(struct filerec *file, bool quiet);
 void filerec_close(struct filerec *file);

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -363,7 +363,7 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 
 	psearch_run(num_filerec);
 
-	SLIST_FOREACH(file, &filerec_head, rec_list) {
+	list_for_each_entry(file, &filerec_head, rec_list) {
 		/*
 		 * This is an empty file - or maybe an error somewhere ?
 		 * Anyway, let's skip it and mark it as "processed"

--- a/src/oans.c
+++ b/src/oans.c
@@ -962,9 +962,12 @@ static void print_header(void)
 	 */
 }
 
-/* Process the dedupe generations in (seq_lo, seq_hi]. */
-static void __process_duplicates(struct dbhandle *db, unsigned int seq_lo,
-				 unsigned int seq_hi)
+/*
+ * Report-only path (no -d): load the dupe groups for generations (seq_lo,
+ * seq_hi] and print them. The dedupe path uses the streaming pipeline below.
+ */
+static void report_duplicates(struct dbhandle *db, unsigned int seq_lo,
+			      unsigned int seq_hi)
 {
 	int ret;
 	struct results_tree res;
@@ -974,25 +977,17 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq_lo,
 	init_hash_tree(&dups_tree);
 
 	vprintf("Loading identical files...\n");
-	pdedupe_set_activity("loading identical files");
 	ret = dbfile_load_same_files(db, &res, seq_lo, seq_hi);
 	if (ret)
 		goto out;
 
-	if (options.run_dedupe)
-		dedupe_results(&res, true);
-	else
-		print_dupes_table(&res, true);
-
-	/* Reset the results_tree before loading extents or blocks */
+	print_dupes_table(&res, true);
 	free_results_tree(&res);
 
 	if (!options.only_whole_files) {
 		init_results_tree(&res);
 
 		vprintf("Loading duplicated hashes...\n");
-		pdedupe_set_activity("loading duplicate extents");
-
 		ret = dbfile_load_extent_hashes(db, &res, seq_lo, seq_hi);
 		if (ret)
 			goto out;
@@ -1009,15 +1004,112 @@ static void __process_duplicates(struct dbhandle *db, unsigned int seq_lo,
 				goto out;
 		}
 
-		if (options.run_dedupe)
-			dedupe_results(&res, false);
-		else
-			print_dupes_table(&res, false);
+		print_dupes_table(&res, false);
 	}
 
 out:
 	free_results_tree(&res);
 	free_hash_tree(&dups_tree);
+}
+
+/*
+ * The streaming dedupe producer uses a separate read connection so its per-batch
+ * loads don't share a sqlite handle with the workers writing on the global
+ * handle. In WAL (hashfile) mode readers don't block the writer; the in-memory
+ * shared-cache db has no WAL, so there we reuse the global handle and serialize
+ * loads with dbfile_lock() (worker writes take the same lock).
+ */
+static struct dbhandle *g_dedupe_write_db;	/* global handle, for the watermark */
+
+/* Reaped-batch callback (producer thread): advance the durable dedupe_seq once a
+ * batch and all earlier generations are done. Serialized against worker writes
+ * on the shared write handle via dbfile_lock(). */
+static void dedupe_advance_seq(unsigned int seq_hi)
+{
+	dedupe_seq = seq_hi;
+	dbfile_cfg.dedupe_seq = dedupe_seq;
+	dbfile_cfg.blocksize = blocksize;
+	dbfile_lock();
+	dbfile_sync_config(g_dedupe_write_db, &dbfile_cfg);
+	dbfile_unlock();
+}
+
+/* Load one generation window's groups into a batch and submit them. */
+static void stream_load_batch(struct dbhandle *pdb, bool inmem,
+			      struct dedupe_batch *batch,
+			      unsigned int seq_lo, unsigned int seq_hi)
+{
+	pdedupe_set_activity("loading identical files");
+	if (inmem)
+		dbfile_lock();
+	dbfile_load_same_files(pdb, dedupe_batch_files(batch), seq_lo, seq_hi);
+	if (inmem)
+		dbfile_unlock();
+	dedupe_push(batch, true);
+
+	if (options.only_whole_files)
+		return;
+
+	pdedupe_set_activity("loading duplicate extents");
+	if (inmem)
+		dbfile_lock();
+	dbfile_load_extent_hashes(pdb, dedupe_batch_extents(batch),
+				  seq_lo, seq_hi);
+	if (inmem)
+		dbfile_unlock();
+
+	if (options.do_block_hash) {
+		struct hash_tree dups_tree;
+
+		init_hash_tree(&dups_tree);
+		if (inmem)
+			dbfile_lock();
+		dbfile_load_block_hashes(pdb, &dups_tree, seq_lo, seq_hi);
+		if (inmem)
+			dbfile_unlock();
+		find_additional_dedupe(dedupe_batch_extents(batch));
+		free_hash_tree(&dups_tree);
+	}
+	dedupe_push(batch, false);
+}
+
+/*
+ * Streaming dedupe: one persistent pool for the whole phase; the main thread is
+ * a bounded producer that loads batch i+1 while batch i dedupes (at most two
+ * batches in flight), so the pool never drains between generations or between
+ * the whole-file and extent passes. dedupe_seq advances in generation order as
+ * batches complete (see dedupe_advance_seq), preserving the Ctrl+C invariant.
+ */
+static void stream_duplicates(struct dbhandle *db, unsigned int first_seq,
+			      unsigned int max, unsigned int stride)
+{
+	bool inmem = !options.hashfile;
+	struct dbhandle *pdb = inmem ? db : dbfile_open_handle(options.hashfile);
+	unsigned int pass = 0;
+
+	if (!pdb) {
+		eprintf("Unable to open a read handle for the dedupe phase\n");
+		return;
+	}
+
+	g_dedupe_write_db = dbfile_get_handle();
+	dedupe_phase_begin(dedupe_advance_seq);
+
+	for (unsigned int i = first_seq; i < max; i += stride) {
+		unsigned int hi = i + stride < max ? i + stride : max;
+		struct dedupe_batch *batch;
+
+		dedupe_await_slot();		/* bound to 2 batches in flight */
+		pdedupe_set_batch(++pass);
+		batch = dedupe_begin_batch(hi);
+		stream_load_batch(pdb, inmem, batch, i, hi);
+		dedupe_seal_batch(batch);
+	}
+
+	dedupe_phase_end();
+
+	if (!inmem)
+		dbfile_close_handle(pdb);
 }
 
 /*
@@ -1035,7 +1127,7 @@ static void process_duplicates(struct dbhandle *db)
 	unsigned int max = get_max_dedupe_seq(db);
 	unsigned int first_seq = dedupe_seq;	/* bumped inside the loop */
 	unsigned int files_per_pass = DEDUPE_FILES_PER_PASS;
-	unsigned int stride, passes, pass = 0;
+	unsigned int stride, passes;
 	/* Tests force many small passes to exercise the cross-generation path. */
 	const char *env = getenv("DUPEREMOVE_FILES_PER_PASS");
 	int env_val = env ? atoi(env) : 0;
@@ -1100,32 +1192,24 @@ static void process_duplicates(struct dbhandle *db)
 						options.only_whole_files));
 	}
 
-	for (unsigned int i = first_seq; i < max; i += stride) {
-		unsigned int hi = i + stride < max ? i + stride : max;
-
-		if (options.run_dedupe)
-			pdedupe_set_batch(++pass);
-
-		/* Drop all filerecs from the previous iteration. Needed filerecs will be
-		 * recreated by __process_duplicates()
+	if (options.run_dedupe) {
+		/*
+		 * Streaming producer: it owns the per-batch loads, advances
+		 * dedupe_seq as batches complete (in generation order), and
+		 * prints the summary. Filerecs are held per batch and released
+		 * at batch completion - no free_all_filerecs() between batches.
 		 */
-		free_all_filerecs();
-		__process_duplicates(db, i, hi);
+		stream_duplicates(db, first_seq, max, stride);
+	} else {
+		for (unsigned int i = first_seq; i < max; i += stride) {
+			unsigned int hi = i + stride < max ? i + stride : max;
 
-		if (options.run_dedupe) {
-			/*
-			 * Bump dedupe_seq, this effectively marks the files
-			 * in our hashfile as having been through dedupe.
-			 */
-			dedupe_seq = hi;
-			dbfile_cfg.dedupe_seq = dedupe_seq;
-			dbfile_cfg.blocksize = blocksize;
-			dbfile_sync_config(db, &dbfile_cfg);
+			/* Report path is sequential; drop the previous window's
+			 * filerecs, which report_duplicates() recreates. */
+			free_all_filerecs();
+			report_duplicates(db, i, hi);
 		}
 	}
-
-	if (options.run_dedupe)
-		dedupe_end();
 
 	if (options.do_block_hash)
 		extents_search_free();

--- a/src/oans.c
+++ b/src/oans.c
@@ -1048,10 +1048,16 @@ static void stream_load_batch(struct dbhandle *pdb, bool inmem,
 			      struct dedupe_batch *batch,
 			      unsigned int seq_lo, unsigned int seq_hi)
 {
+	int ret;
+
 	pdedupe_set_activity("loading identical files");
 	load_lock(inmem);
-	dbfile_load_same_files(pdb, dedupe_batch_files(batch), seq_lo, seq_hi);
+	ret = dbfile_load_same_files(pdb, dedupe_batch_files(batch),
+				     seq_lo, seq_hi);
 	load_unlock(inmem);
+	if (ret)
+		eprintf("Error loading whole-file duplicates for generations "
+			"(%u, %u]; deduping what was loaded\n", seq_lo, seq_hi);
 	dedupe_push(batch, true);
 
 	if (options.only_whole_files)
@@ -1059,18 +1065,35 @@ static void stream_load_batch(struct dbhandle *pdb, bool inmem,
 
 	pdedupe_set_activity("loading duplicate extents");
 	load_lock(inmem);
-	dbfile_load_extent_hashes(pdb, dedupe_batch_extents(batch),
-				  seq_lo, seq_hi);
+	ret = dbfile_load_extent_hashes(pdb, dedupe_batch_extents(batch),
+					seq_lo, seq_hi);
 	load_unlock(inmem);
+	if (ret)
+		eprintf("Error loading duplicate extents for generations "
+			"(%u, %u]; deduping what was loaded\n", seq_lo, seq_hi);
 
 	if (options.do_block_hash) {
 		struct hash_tree dups_tree;
 
+		/*
+		 * The block-hash search walks the GLOBAL filerec list, so the
+		 * previous window's batches must be reaped (their filerecs
+		 * freed) first or it would rescan those files. This gives up
+		 * cross-batch pipelining in partial mode; the default mode
+		 * keeps the full overlap.
+		 */
+		dedupe_drain();
+
 		init_hash_tree(&dups_tree);
 		load_lock(inmem);
-		dbfile_load_block_hashes(pdb, &dups_tree, seq_lo, seq_hi);
+		ret = dbfile_load_block_hashes(pdb, &dups_tree, seq_lo, seq_hi);
 		load_unlock(inmem);
-		find_additional_dedupe(dedupe_batch_extents(batch));
+		if (ret)
+			eprintf("Error loading block hashes for generations "
+				"(%u, %u]; partial dedupe may be incomplete\n",
+				seq_lo, seq_hi);
+		else
+			find_additional_dedupe(dedupe_batch_extents(batch));
 		free_hash_tree(&dups_tree);
 	}
 	dedupe_push(batch, false);

--- a/src/oans.c
+++ b/src/oans.c
@@ -1034,39 +1034,42 @@ static void dedupe_advance_seq(unsigned int seq_hi)
 	dbfile_unlock();
 }
 
+/*
+ * The in-memory shared-cache db (no WAL) shares its handle with the dedupe
+ * workers, so the producer must serialize its loads against worker writes with
+ * dbfile_lock(); the hashfile path loads on a separate WAL read connection that
+ * doesn't block the writer, so there these are no-ops.
+ */
+static void load_lock(bool inmem)   { if (inmem) dbfile_lock(); }
+static void load_unlock(bool inmem) { if (inmem) dbfile_unlock(); }
+
 /* Load one generation window's groups into a batch and submit them. */
 static void stream_load_batch(struct dbhandle *pdb, bool inmem,
 			      struct dedupe_batch *batch,
 			      unsigned int seq_lo, unsigned int seq_hi)
 {
 	pdedupe_set_activity("loading identical files");
-	if (inmem)
-		dbfile_lock();
+	load_lock(inmem);
 	dbfile_load_same_files(pdb, dedupe_batch_files(batch), seq_lo, seq_hi);
-	if (inmem)
-		dbfile_unlock();
+	load_unlock(inmem);
 	dedupe_push(batch, true);
 
 	if (options.only_whole_files)
 		return;
 
 	pdedupe_set_activity("loading duplicate extents");
-	if (inmem)
-		dbfile_lock();
+	load_lock(inmem);
 	dbfile_load_extent_hashes(pdb, dedupe_batch_extents(batch),
 				  seq_lo, seq_hi);
-	if (inmem)
-		dbfile_unlock();
+	load_unlock(inmem);
 
 	if (options.do_block_hash) {
 		struct hash_tree dups_tree;
 
 		init_hash_tree(&dups_tree);
-		if (inmem)
-			dbfile_lock();
+		load_lock(inmem);
 		dbfile_load_block_hashes(pdb, &dups_tree, seq_lo, seq_hi);
-		if (inmem)
-			dbfile_unlock();
+		load_unlock(inmem);
 		find_additional_dedupe(dedupe_batch_extents(batch));
 		free_hash_tree(&dups_tree);
 	}

--- a/src/progress.c
+++ b/src/progress.c
@@ -574,7 +574,13 @@ static unsigned int print_bar_line(void)
 	render_bar(frac, indet, acc);
 	if (!indet) {
 		printf("  %s%u%%%s", col_bold, pct, col_reset);
-		if (eta > 0.0) {
+		/*
+		 * An ETA beyond a year means the inputs are off (a stalled
+		 * rate sample or a corrupt total), not a real forecast; the
+		 * string is also long enough to wrap the bar line and desync
+		 * the block redraw. Show nothing until it becomes sane.
+		 */
+		if (eta > 0.0 && eta < 365.0 * 86400) {
 			detail_sep();
 			printf("ETA ~%s", human_duration(eta));
 		}

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -908,9 +908,11 @@ static void push_results(struct dedupe_batch *batch, struct results_tree *res,
 		 */
 		uint64_t w0 = dext_work(sorted[i]);
 
-		/* A single group can't verify an exbibyte; a value this big is
-		 * a corrupt dext, not work. */
-		abort_on(w0 > 1ULL << 60);
+		/* A single group can't verify a pebibyte; a value this big is
+		 * a corrupt dext, not work. (The freed-dext read this guards
+		 * against fed len * (0 - 1): 128 MiB * (2^32 - 1) ~= 2^59, so
+		 * the cap must sit well below that.) */
+		abort_on(w0 > 1ULL << 50);
 
 		abort_on(!item);	/* OOM */
 		item->dext = sorted[i];

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -1067,10 +1067,15 @@ void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi))
 	dedupe_pool = g_thread_pool_new((GFunc) dedupe_worker, NULL,
 					options.io_threads, TRUE, &err);
 	if (err) {
+		/*
+		 * Fatal: the phase cannot run without a pool, and limping on
+		 * would push items into a NULL pool - never run, so their
+		 * batches never complete and dedupe_phase_end() waits forever.
+		 */
 		eprintf("Unable to create dedupe thread pool: %s\n",
 			err->message);
 		g_error_free(err);
-		dedupe_pool = NULL;
+		abort_on(1);
 	}
 }
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -896,6 +896,21 @@ static void push_results(struct dedupe_batch *batch, struct results_tree *res,
 
 	for (i = 0; i < nr; i++) {
 		struct dedupe_work_item *item = malloc(sizeof(*item));
+		/*
+		 * The group's byte work, captured BEFORE the push: the moment
+		 * the item is in the pool a worker owns the dext and can free
+		 * it (an already-shared group is cleaned and freed in
+		 * microseconds), so sorted[i] must not be dereferenced after
+		 * g_thread_pool_push(). Reading it afterwards once fed
+		 * len * (0 - 1) from a freed dext into the pushed-work total,
+		 * blowing the progress denominator up to ~2^59 (a frozen bar
+		 * and a multi-thousand-year ETA).
+		 */
+		uint64_t w0 = dext_work(sorted[i]);
+
+		/* A single group can't verify an exbibyte; a value this big is
+		 * a corrupt dext, not work. */
+		abort_on(w0 > 1ULL << 60);
 
 		abort_on(!item);	/* OOM */
 		item->dext = sorted[i];
@@ -918,7 +933,7 @@ static void push_results(struct dedupe_batch *batch, struct results_tree *res,
 		pdedupe_add_queued(1);
 		/* Byte analog of add_queued: lets the renderer clamp the total
 		 * up for block-hash-discovered groups not in the upfront sum. */
-		pdedupe_add_pushed_work(dext_work(sorted[i]));
+		pdedupe_add_pushed_work(w0);
 	}
 }
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -867,29 +867,29 @@ static void push_results(struct dedupe_batch *batch, struct results_tree *res,
 	unsigned int nr = 0, i;
 	GError *err = NULL;
 
+	sorted = malloc((size_t)res->num_dupes * sizeof(*sorted));
+	abort_on(!sorted);	/* OOM: the whole program is out of memory */
+
+	/*
+	 * One walk: hold a ref on every filerec the tree references (all dexts -
+	 * free_results_tree frees them all at reap), and collect the >=2-member
+	 * groups to sort and push.
+	 */
 	for (node = rb_first(&res->root); node; node = rb_next(node)) {
 		dext = rb_entry(node, struct dupe_extents, de_node);
+
 		list_for_each_entry(extent, &dext->de_extents, e_list) {
 			filerec_get(extent->e_file);
 			g_ptr_array_add(batch->held, extent->e_file);
 		}
-	}
-
-	sorted = malloc((size_t)res->num_dupes * sizeof(*sorted));
-	if (!sorted)
-		abort_on(1);	/* OOM: the whole program is out of memory */
-
-	for (node = rb_first(&res->root); node; node = rb_next(node)) {
-		dext = rb_entry(node, struct dupe_extents, de_node);
 
 		if (dext->de_num_dupes < 2) {
 			qprintf("Skipping extent - insufficient duplicates (%u)\n",
 				   dext->de_num_dupes);
 			continue;
 		}
-		if (nr >= res->num_dupes)	/* should not happen */
-			break;
-		sorted[nr++] = dext;
+		if (nr < res->num_dupes)	/* nr > num_dupes can't happen */
+			sorted[nr++] = dext;
 	}
 
 	qsort(sorted, nr, sizeof(*sorted), cmp_dext_work);
@@ -936,13 +936,11 @@ struct dedupe_batch *dedupe_begin_batch(unsigned int seq_hi)
 {
 	struct dedupe_batch *b = calloc(1, sizeof(*b));
 
-	abort_on(!b);	/* OOM */
+	abort_on(!b);	/* OOM; calloc zeroed outstanding/fully_pushed */
 	init_results_tree(&b->res_files);
 	init_results_tree(&b->res_extents);
 	b->held = g_ptr_array_new();
 	b->seq_hi = seq_hi;
-	b->outstanding = 0;
-	b->fully_pushed = false;
 	INIT_LIST_HEAD(&b->list);
 	return b;
 }

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -1084,10 +1084,16 @@ void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi))
  * order so the watermark lands on the last completed generation), tear down the
  * pool, then print one aggregated summary spanning the whole phase.
  */
-void dedupe_phase_end(void)
+/*
+ * Wait until every sealed batch has completed and been reaped (producer
+ * thread). Needed by the block-hash search (--dedupe-options=partial):
+ * find_additional_dedupe() walks the GLOBAL filerec list, so earlier batches'
+ * filerecs must be reaped first or the search would rescan the previous
+ * window's files. Everywhere else the pipeline overlap is the whole point -
+ * don't add drain points.
+ */
+void dedupe_drain(void)
 {
-	uint64_t groups, reclaimed, net_shared;
-
 	g_mutex_lock(&producer_mutex);
 	while (inflight_count > 0) {
 		reap_ready_locked();
@@ -1095,6 +1101,13 @@ void dedupe_phase_end(void)
 			g_cond_wait(&producer_cond, &producer_mutex);
 	}
 	g_mutex_unlock(&producer_mutex);
+}
+
+void dedupe_phase_end(void)
+{
+	uint64_t groups, reclaimed, net_shared;
+
+	dedupe_drain();
 
 	if (dedupe_pool) {
 		g_thread_pool_free(dedupe_pool, FALSE, TRUE);	/* waits for exit */

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -47,18 +47,58 @@
 
 static GMutex mutex;
 static GMutex console_mutex;
-static struct results_tree *results_tree;
 static volatile unsigned long long total_dedupe_passes;
 static volatile unsigned long long curr_dedupe_pass;
 static unsigned int leading_spaces;
-static bool whole_file_dedup;
 /*
  * Whether to measure the fiemap "net change in shared extents". It feeds only
- * the machine-readable line (non-tty or -q; see dedupe_end), so on an
+ * the machine-readable line (non-tty or -q; see dedupe_phase_end), so on an
  * interactive run the per-group post-dedupe FIEMAP is pure waste. Set once when
  * the phase starts, from the same condition that governs that line.
  */
 static bool report_net_shared;
+
+/*
+ * Streaming dedupe pipeline (Stage 2). One thread pool serves the whole phase;
+ * the main thread is a bounded producer that loads batch i+1 while batch i
+ * dedupes, so the pool never drains between generation batches or between the
+ * whole-file and extent passes.
+ *
+ * A batch owns its two results trees (whole-file + extent; disjoint filerec
+ * sets thanks to the static whole-file exclusion in GET_DUPLICATE_EXTENTS) and
+ * holds one lifetime ref on every filerec it loaded, released at completion.
+ * The producer admits at most DEDUPE_MAX_INFLIGHT batches (RAM double buffer)
+ * and reaps them strictly in generation order, so the durable dedupe_seq
+ * watermark only advances past a generation once that batch and all earlier
+ * ones are done - preserving the Ctrl+C invariant.
+ */
+#define DEDUPE_MAX_INFLIGHT	2
+
+struct dedupe_batch {
+	struct results_tree	res_files;	/* whole-file groups */
+	struct results_tree	res_extents;	/* extent groups */
+	GPtrArray		*held;		/* filerecs to put at completion */
+	unsigned int		seq_hi;		/* generation watermark on completion */
+	_Atomic int		outstanding;	/* work items not yet finished */
+	bool			fully_pushed;	/* producer has pushed every item */
+	struct list_head	list;		/* in-flight FIFO, generation order */
+};
+
+/* One unit of pool work: dedupe this group, then account against its batch. */
+struct dedupe_work_item {
+	struct dupe_extents	*dext;
+	struct dedupe_batch	*batch;
+	bool			whole_file;
+};
+
+static GThreadPool	*dedupe_pool;
+static GMutex		producer_mutex;	/* guards the in-flight list + counts */
+static GCond		producer_cond;	/* producer waits; workers/seal signal */
+static struct list_head	inflight_batches = LIST_HEAD_INIT(inflight_batches);
+static unsigned int	inflight_count;
+/* Called on the producer thread when a batch (and all earlier ones) complete,
+ * to advance the durable dedupe_seq. Provided by the caller of the phase. */
+static void		(*batch_complete_cb)(unsigned int seq_hi);
 
 void print_dupes_table(struct results_tree *res, bool whole_file)
 {
@@ -219,7 +259,8 @@ static int disk_extent_grew(struct dupe_extents *dext, struct extent *extent)
  * Removes extents which it believes have already been deduped. We err
  * on the side of more deduping here.
  */
-static void clean_deduped(struct dupe_extents **ret_dext)
+static void clean_deduped(struct dupe_extents **ret_dext,
+			  struct results_tree *res)
 {
 	int left;
 	int extents_kept = 0;
@@ -281,8 +322,7 @@ static void clean_deduped(struct dupe_extents **ret_dext)
 					extent_plen(inner_extent));
 
 				g_mutex_lock(&mutex);
-				left = remove_extent(results_tree,
-						     inner_extent);
+				left = remove_extent(res, inner_extent);
 				g_mutex_unlock(&mutex);
 				if (left == 0) {
 					*ret_dext = dext = NULL;
@@ -365,7 +405,8 @@ static void group_tick(void *arg, uint64_t bytes)
 
 #define	DEDUPE_EXTENTS_CLEANED	(-1)
 static int dedupe_extent_list(struct dupe_extents *dext,
-			      struct group_progress *gp,
+			      struct group_progress *gp, bool whole_file_dedup,
+			      struct results_tree *res,
 			      uint64_t *fiemap_bytes, uint64_t *kern_bytes,
 			      unsigned long long passno)
 {
@@ -404,7 +445,7 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	 * goes below 2. If that happens, we return a special value so
 	 * the caller knows not to reference dext any more.
 	 */
-	clean_deduped(&dext);
+	clean_deduped(&dext, res);
 	if (!dext) {
 		vprintf("[%p] Skipping - extents are already deduped.\n",
 		       g_thread_self());
@@ -666,7 +707,8 @@ out:
 }
 
 static int extent_dedupe_worker(struct dupe_extents *dext,
-				struct group_progress *gp,
+				struct group_progress *gp, bool whole_file_dedup,
+				struct results_tree *res,
 				uint64_t *fiemap_bytes, uint64_t *kern_bytes)
 {
 	int ret;
@@ -676,7 +718,8 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 	struct pscan_thread *slot = gp->slot;
 	struct dbhandle *db = dbfile_get_handle();
 
-	ret = dedupe_extent_list(dext, gp, fiemap_bytes, kern_bytes, passno);
+	ret = dedupe_extent_list(dext, gp, whole_file_dedup, res, fiemap_bytes,
+				 kern_bytes, passno);
 	if (ret) {
 		if (ret == DEDUPE_EXTENTS_CLEANED)
 			return 0;
@@ -716,18 +759,32 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 
 	if (!list_empty(&dext->de_extents)) {
 		g_mutex_lock(&mutex);
-		dupe_extents_free(dext, results_tree);
+		dupe_extents_free(dext, res);
 		g_mutex_unlock(&mutex);
 	}
 
 	return 0;
 }
 
+/* Signal the producer when a batch has no work left to run. Caller must hold
+ * producer_mutex. A batch is complete only once every item finished AND the
+ * producer finished pushing (so an all-fast batch isn't reaped early). */
+static void batch_maybe_complete_locked(struct dedupe_batch *batch)
+{
+	if (batch->outstanding == 0 && batch->fully_pushed)
+		g_cond_signal(&producer_cond);
+}
+
 static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 {
 	uint64_t fiemap_bytes = 0ULL;
 	uint64_t kern_bytes = 0ULL;
-	struct dupe_extents *dext = priv;
+	struct dedupe_work_item *item = priv;
+	struct dupe_extents *dext = item->dext;
+	struct dedupe_batch *batch = item->batch;
+	bool whole_file = item->whole_file;
+	struct results_tree *res = whole_file ? &batch->res_files
+					      : &batch->res_extents;
 	_cleanup_(pscan_reset_thread) struct pscan_thread *slot =
 				pscan_claim_slot(gettid(), thread_deduping);
 	struct group_progress gp = { .slot = slot, .ticked = 0 };
@@ -738,6 +795,8 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	 */
 	uint64_t w0 = dext_work(dext);
 
+	free(item);	/* the item is consumed; dext/batch captured above */
+
 	/*
 	 * Seed the display line from the group before any work: first member
 	 * as the (provisional) target path, and the data the kernel has to
@@ -746,7 +805,8 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	 */
 	slot_show_group(slot, dext);
 
-	extent_dedupe_worker(dext, &gp, &fiemap_bytes, &kern_bytes);
+	extent_dedupe_worker(dext, &gp, whole_file, res, &fiemap_bytes,
+			     &kern_bytes);
 
 	/*
 	 * Settle up the byte bar: credit whatever work never reached the kernel
@@ -766,9 +826,13 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	 * shared extents" diagnostic, not as space reclaimed.
 	 */
 	pdedupe_group_done(kern_bytes, fiemap_bytes);
-}
 
-static GThreadPool *dedupe_pool = NULL;
+	/* Last one out of this batch wakes the producer to reap it. */
+	g_mutex_lock(&producer_mutex);
+	batch->outstanding--;
+	batch_maybe_complete_locked(batch);
+	g_mutex_unlock(&producer_mutex);
+}
 
 /*
  * The kernel byte-verifies group length times (copies - 1), so that product
@@ -787,24 +851,33 @@ static int cmp_dext_work(const void *pa, const void *pb)
 	return wa > wb ? -1 : wa < wb ? 1 : 0;
 }
 
-/* Errors from this function are fatal. */
-static int push_extents(struct results_tree *res)
+/*
+ * Hold one lifetime ref on every filerec this tree references (released when the
+ * batch is reaped), then LPT-sort the groups and push one work item each. The
+ * tree is stable here: this runs on the producer thread before any of this
+ * batch's items can be dequeued. Errors are fatal.
+ */
+static void push_results(struct dedupe_batch *batch, struct results_tree *res,
+			 bool whole_file)
 {
 	struct rb_node *node;
 	struct dupe_extents *dext;
+	struct extent *extent;
 	_cleanup_(freep) struct dupe_extents **sorted = NULL;
 	unsigned int nr = 0, i;
 	GError *err = NULL;
 
-	/*
-	 * Nothing is pushed until the array is complete, so no worker owns any
-	 * group yet and the tree is stable while we collect and sort.
-	 */
-	sorted = malloc((size_t)res->num_dupes * sizeof(*sorted));
-	if (!sorted) {
-		eprintf("Out of memory while sorting dupe groups.\n");
-		return 1;
+	for (node = rb_first(&res->root); node; node = rb_next(node)) {
+		dext = rb_entry(node, struct dupe_extents, de_node);
+		list_for_each_entry(extent, &dext->de_extents, e_list) {
+			filerec_get(extent->e_file);
+			g_ptr_array_add(batch->held, extent->e_file);
+		}
 	}
+
+	sorted = malloc((size_t)res->num_dupes * sizeof(*sorted));
+	if (!sorted)
+		abort_on(1);	/* OOM: the whole program is out of memory */
 
 	for (node = rb_first(&res->root); node; node = rb_next(node)) {
 		dext = rb_entry(node, struct dupe_extents, de_node);
@@ -822,31 +895,193 @@ static int push_extents(struct results_tree *res)
 	qsort(sorted, nr, sizeof(*sorted), cmp_dext_work);
 
 	for (i = 0; i < nr; i++) {
-		struct dupe_extents *d = sorted[i];
+		struct dedupe_work_item *item = malloc(sizeof(*item));
 
-		g_thread_pool_push(dedupe_pool, d, &err);
+		abort_on(!item);	/* OOM */
+		item->dext = sorted[i];
+		item->batch = batch;
+		item->whole_file = whole_file;
+
+		/*
+		 * Reserve the slot before the push so a fast worker can't drive
+		 * outstanding to 0 (and race completion) before its item is
+		 * counted. Completion is still gated on fully_pushed, so the
+		 * count only matters once the producer has sealed the batch.
+		 */
+		atomic_fetch_add(&batch->outstanding, 1);
+		g_thread_pool_push(dedupe_pool, item, &err);
 		if (err) {
-			eprintf("Fatal error while deduping: %s\n",
-				err->message);
+			eprintf("Fatal error while deduping: %s\n", err->message);
 			g_error_free(err);
-			return 1;
+			abort_on(1);
 		}
 		pdedupe_add_queued(1);
 		/* Byte analog of add_queued: lets the renderer clamp the total
 		 * up for block-hash-discovered groups not in the upfront sum. */
-		pdedupe_add_pushed_work(dext_work(d));
+		pdedupe_add_pushed_work(dext_work(sorted[i]));
 	}
-	return 0;
+}
+
+struct results_tree *dedupe_batch_files(struct dedupe_batch *b)
+{
+	return &b->res_files;
+}
+
+struct results_tree *dedupe_batch_extents(struct dedupe_batch *b)
+{
+	return &b->res_extents;
+}
+
+struct dedupe_batch *dedupe_begin_batch(unsigned int seq_hi)
+{
+	struct dedupe_batch *b = calloc(1, sizeof(*b));
+
+	abort_on(!b);	/* OOM */
+	init_results_tree(&b->res_files);
+	init_results_tree(&b->res_extents);
+	b->held = g_ptr_array_new();
+	b->seq_hi = seq_hi;
+	b->outstanding = 0;
+	b->fully_pushed = false;
+	INIT_LIST_HEAD(&b->list);
+	return b;
+}
+
+void dedupe_push(struct dedupe_batch *b, bool whole_file)
+{
+	struct results_tree *res = whole_file ? &b->res_files : &b->res_extents;
+
+	pdedupe_set_activity(whole_file ? "deduplicating identical files"
+					: "deduplicating duplicate extents");
+
+	/* The pre-dedupe listing is a wall of text; show it only with -v. */
+	if (verbose)
+		print_dupes_table(res, whole_file);
+
+	if (RB_EMPTY_ROOT(&res->root))
+		return;
+
+	total_dedupe_passes += res->num_dupes;
+	leading_spaces = num_digits(total_dedupe_passes);
+
+	push_results(b, res, whole_file);
+}
+
+/* Reap a completed batch (producer thread): advance the durable watermark, then
+ * free its results trees and drop its filerec refs. */
+static void free_batch(struct dedupe_batch *b)
+{
+	unsigned int i;
+
+	if (batch_complete_cb)
+		batch_complete_cb(b->seq_hi);
+
+	free_results_tree(&b->res_files);
+	free_results_tree(&b->res_extents);
+	for (i = 0; i < b->held->len; i++)
+		filerec_put(g_ptr_array_index(b->held, i));
+	g_ptr_array_free(b->held, TRUE);
+	free(b);
 }
 
 /*
- * Close the dedupe phase (the live status is started by pdedupe_begin() and
- * fed from the workers; see progress.c) and print one aggregated summary
- * spanning every dedupe_results() call.
+ * Reap completed batches from the front of the in-flight FIFO, in generation
+ * order, advancing dedupe_seq only as far as a fully-completed prefix. Called
+ * with producer_mutex held; drops it around the per-batch teardown (which does
+ * DB I/O) and re-takes it. Producer thread only.
  */
-void dedupe_end(void)
+static void reap_ready_locked(void)
+{
+	while (!list_empty(&inflight_batches)) {
+		struct dedupe_batch *b = list_first_entry(&inflight_batches,
+							  struct dedupe_batch,
+							  list);
+
+		if (b->outstanding != 0 || !b->fully_pushed)
+			break;	/* front not done; FIFO order => stop here */
+
+		list_del(&b->list);
+		inflight_count--;
+		g_mutex_unlock(&producer_mutex);
+		free_batch(b);
+		g_mutex_lock(&producer_mutex);
+	}
+}
+
+/* Block the producer until an in-flight slot is free (the RAM double buffer),
+ * reaping completed batches while it waits. */
+void dedupe_await_slot(void)
+{
+	g_mutex_lock(&producer_mutex);
+	reap_ready_locked();
+	while (inflight_count >= DEDUPE_MAX_INFLIGHT) {
+		g_cond_wait(&producer_cond, &producer_mutex);
+		reap_ready_locked();
+	}
+	g_mutex_unlock(&producer_mutex);
+}
+
+/* Finish a batch: mark it fully pushed, enqueue it in generation order, and
+ * reap it (and any earlier ready batch) if it is already complete. */
+void dedupe_seal_batch(struct dedupe_batch *b)
+{
+	g_mutex_lock(&producer_mutex);
+	b->fully_pushed = true;
+	list_add_tail(&b->list, &inflight_batches);
+	inflight_count++;
+	reap_ready_locked();
+	g_mutex_unlock(&producer_mutex);
+}
+
+/*
+ * Open the streaming dedupe phase: one pool for the whole phase. on_complete is
+ * invoked (producer thread) as each batch is reaped, in generation order, to
+ * advance the durable dedupe_seq watermark.
+ */
+void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi))
+{
+	GError *err = NULL;
+
+	batch_complete_cb = on_complete;
+	report_net_shared = !isatty(STDOUT_FILENO) || quiet;
+	curr_dedupe_pass = 0;
+	total_dedupe_passes = 0;
+	inflight_count = 0;
+	INIT_LIST_HEAD(&inflight_batches);
+
+	vprintf("Using %u threads for dedupe phase\n", options.io_threads);
+
+	dedupe_pool = g_thread_pool_new((GFunc) dedupe_worker, NULL,
+					options.io_threads, TRUE, &err);
+	if (err) {
+		eprintf("Unable to create dedupe thread pool: %s\n",
+			err->message);
+		g_error_free(err);
+		dedupe_pool = NULL;
+	}
+}
+
+/*
+ * Close the dedupe phase: drain every in-flight batch (reaping in generation
+ * order so the watermark lands on the last completed generation), tear down the
+ * pool, then print one aggregated summary spanning the whole phase.
+ */
+void dedupe_phase_end(void)
 {
 	uint64_t groups, reclaimed, net_shared;
+
+	g_mutex_lock(&producer_mutex);
+	while (inflight_count > 0) {
+		reap_ready_locked();
+		if (inflight_count > 0)
+			g_cond_wait(&producer_cond, &producer_mutex);
+	}
+	g_mutex_unlock(&producer_mutex);
+
+	if (dedupe_pool) {
+		g_thread_pool_free(dedupe_pool, FALSE, TRUE);	/* waits for exit */
+		dedupe_pool = NULL;
+	}
 
 	pdedupe_end();
 	pdedupe_counters(&groups, &reclaimed, &net_shared);
@@ -885,48 +1120,4 @@ void dedupe_end(void)
 	if (!isatty(STDOUT_FILENO) || quiet)
 		printf("Comparison of extent info shows a net change in "
 		       "shared extents of: %s\n", pretty_size(net_shared));
-}
-
-void dedupe_results(struct results_tree *res, bool whole_file)
-{
-	GError *err = NULL;
-
-	/*
-	 * dedupe_results() could be called multiple times, so we reset that bit
-	 * to its initial value every time
-	 */
-	curr_dedupe_pass = 0;
-	results_tree = res;
-
-	whole_file_dedup = whole_file;
-	report_net_shared = !isatty(STDOUT_FILENO) || quiet;
-
-	/* The pre-dedupe listing is a wall of text; show it only with -v. */
-	if (verbose)
-		print_dupes_table(res, whole_file);
-
-	if (RB_EMPTY_ROOT(&res->root))
-		return;
-
-	vprintf("Using %u threads for dedupe phase\n", options.io_threads);
-
-	pdedupe_set_activity(whole_file ? "deduplicating identical files"
-					: "deduplicating duplicate extents");
-
-	dedupe_pool = g_thread_pool_new((GFunc) dedupe_worker, NULL,
-					options.io_threads, TRUE, &err);
-	if (err) {
-		eprintf("Unable to create dedupe thread pool: %s\n",
-			err->message);
-		g_error_free(err);
-		return;
-	}
-
-	total_dedupe_passes = res->num_dupes;
-	leading_spaces = num_digits(total_dedupe_passes);
-
-	/* On failure push_extents() has already reported the error. */
-	push_extents(res);
-
-	g_thread_pool_free(dedupe_pool, FALSE, TRUE);	/* waits for all work */
 }

--- a/src/run_dedupe.h
+++ b/src/run_dedupe.h
@@ -32,6 +32,9 @@ void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi));
 void dedupe_phase_end(void);
 
 void dedupe_await_slot(void);
+/* Wait for every sealed batch to complete + reap. Only for the block-hash
+ * search, which walks the global filerec list; see run_dedupe.c. */
+void dedupe_drain(void);
 struct dedupe_batch *dedupe_begin_batch(unsigned int seq_hi);
 struct results_tree *dedupe_batch_files(struct dedupe_batch *b);
 struct results_tree *dedupe_batch_extents(struct dedupe_batch *b);

--- a/src/run_dedupe.h
+++ b/src/run_dedupe.h
@@ -5,10 +5,37 @@
 #include "opt.h"
 
 void print_dupes_table(struct results_tree *res, bool whole_file);
-void dedupe_results(struct results_tree *res, bool whole_file);
 
-/* Close the dedupe phase (which runs dedupe_results() many times): stops the
- * live status (see pdedupe_begin()) and prints one aggregated summary. */
-void dedupe_end(void);
+/*
+ * Streaming dedupe phase (Stage 2). One thread pool serves the whole phase; the
+ * caller is a bounded producer that loads batch i+1 while batch i dedupes.
+ *
+ * Lifecycle:
+ *   dedupe_phase_begin(on_complete);
+ *   for each generation window (lo, hi]:
+ *       dedupe_await_slot();                 // block until an in-flight slot frees
+ *       batch = dedupe_begin_batch(hi);
+ *       // load whole-file groups into dedupe_batch_files(batch), then:
+ *       dedupe_push(batch, true);
+ *       // load extent groups into dedupe_batch_extents(batch), then:
+ *       dedupe_push(batch, false);
+ *       dedupe_seal_batch(batch);            // enqueue + reap completed batches
+ *   dedupe_phase_end();                      // drain, tear down, print summary
+ *
+ * on_complete(seq_hi) is called on the producer thread as each batch is reaped,
+ * in generation order, to advance the durable dedupe_seq. All the batch calls
+ * must happen on the single producer thread.
+ */
+struct dedupe_batch;
+
+void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi));
+void dedupe_phase_end(void);
+
+void dedupe_await_slot(void);
+struct dedupe_batch *dedupe_begin_batch(unsigned int seq_hi);
+struct results_tree *dedupe_batch_files(struct dedupe_batch *b);
+struct results_tree *dedupe_batch_extents(struct dedupe_batch *b);
+void dedupe_push(struct dedupe_batch *b, bool whole_file);
+void dedupe_seal_batch(struct dedupe_batch *b);
 
 #endif	/* __RUN_DEDUPE_H__ */

--- a/tests/integration/test_streaming_dedupe.py
+++ b/tests/integration/test_streaming_dedupe.py
@@ -1,0 +1,123 @@
+"""Streaming dedupe pipeline (Stage 2).
+
+The dedupe phase runs one persistent thread pool while a bounded producer loads
+the next generation batch as the current one dedupes (at most two batches in
+flight). dedupe_seq advances in generation order as batches complete, so an
+interrupt leaves only fully-processed generations marked. These tests drive many
+groups across many generations (small DUPEREMOVE_FILES_PER_PASS), and check that
+everything still converges, the durable watermark lands on the last generation,
+a rerun is a no-op, and the in-memory (no-hashfile) path works too.
+"""
+
+import os
+from harness import (DuperemoveTest, requires_reflink, phys_extents,
+                     files_share, BTRFS)
+
+MiB = 1 << 20
+
+
+@requires_reflink
+class StreamingDedupeTest(DuperemoveTest):
+    # tiny passes + small batchsize => work spans many generation batches, so
+    # the producer/watermark and cross-batch anchor paths are all exercised.
+    ENV = {"DUPEREMOVE_FILES_PER_PASS": "8"}
+    BOPT = ("-B", "4")
+
+    def _max_file_seq(self):
+        return self.hf_scalar("select max(dedupe_seq) from files")
+
+    def _config_seq(self):
+        return self.hf_scalar(
+            "select keyval from config where keyname='dedupe_sequence'")
+
+    def test_many_groups_across_generations(self):
+        pairs = []
+        for i in range(40):
+            d = os.urandom(20000 + i)  # distinct sizes => distinct groups
+            a = self.write(f"tree/a{i:02d}", d)
+            b = self.write(f"tree/b{i:02d}", d)
+            pairs.append((a, b))
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        for a, b in pairs:
+            self.assertTrue(files_share(a, b),
+                            f"{os.path.basename(a)} pair deduped")
+
+        # The watermark advanced all the way to the last scanned generation.
+        self.assertEqual(self._config_seq(), self._max_file_seq(),
+                         "dedupe_seq watermark reached the final generation")
+
+        # Rerun is a no-op.
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.assertNoNewSharing()
+
+    def test_cross_window_group_converges_to_one_extent(self):
+        # 120 identical copies whose members land in many different generation
+        # windows must still converge onto a single physical extent (the
+        # cross-batch anchor path), not one cluster per batch.
+        data = os.urandom(96 * 1024)
+        paths = [self.write(f"tree/c{i:03d}", data) for i in range(120)]
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        allphys = set()
+        for p in paths:
+            allphys |= phys_extents(p)
+        self.assertEqual(len(allphys), 1,
+                         f"all copies converge to one extent, got {len(allphys)}")
+        self.assertEqual(self._config_seq(), self._max_file_seq())
+
+    def test_whole_file_and_extent_passes_stream_together(self):
+        # A whole-file triple plus an independent extent-only pair in the same
+        # run: both passes feed the one pool without a drain between them.
+        t = os.urandom(2 * MiB)
+        wf = [self.write(f"tree/w{i}", t) for i in range(3)]
+        # extent-only sharers: distinct heads, shared tail (btrfs boundary)
+        tail = os.urandom(2 * MiB)
+        ext = []
+        for name in ("x", "y"):
+            p = self.path(f"tree/{name}")
+            with open(p, "wb") as f:
+                f.write(os.urandom(64 * 1024))
+                f.flush()
+                os.fsync(f.fileno())
+                f.write(tail)
+            ext.append(p)
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        self.assertShared(wf[0], wf[1], "whole-file triple deduped")
+        self.assertShared(wf[1], wf[2], "whole-file triple deduped")
+        # The shared-tail extent boundary only forms under btrfs copy-on-write.
+        if BTRFS:
+            self.assertShared(ext[0], ext[1], "extent tail deduped")
+
+    def test_in_memory_dedupe_streams(self):
+        # No --hashfile: the producer shares the in-memory handle and serializes
+        # loads with the write lock. Dedupe must still happen on disk.
+        pairs = []
+        for i in range(12):
+            d = os.urandom(30000 + i)
+            a = self.write(f"tree/a{i}", d)
+            b = self.write(f"tree/b{i}", d)
+            pairs.append((a, b))
+        self.sync()
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV,
+                hashfile=False)
+        self.assertDmOk()
+        self.sync()
+        for a, b in pairs:
+            self.assertTrue(files_share(a, b),
+                            f"{os.path.basename(a)} deduped in-memory run")

--- a/tests/integration/test_streaming_dedupe.py
+++ b/tests/integration/test_streaming_dedupe.py
@@ -103,6 +103,38 @@ class StreamingDedupeTest(DuperemoveTest):
         if BTRFS:
             self.assertShared(ext[0], ext[1], "extent tail deduped")
 
+    def test_partial_mode_streams(self):
+        # --dedupe-options=partial: the block-hash search walks the GLOBAL
+        # filerec list, so the producer drains prior batches before running it
+        # (partial mode gives up cross-batch pipelining). Many small windows
+        # exercise that drain path; everything must still converge and a rerun
+        # must be a no-op.
+        pairs = []
+        for i in range(24):
+            d = os.urandom(200000 + i)
+            a = self.write(f"tree/a{i:02d}", d)
+            b = self.write(f"tree/b{i:02d}", d)
+            pairs.append((a, b))
+        self.sync()
+
+        opts = ("-rd", "--dedupe-options=partial", *self.BOPT)
+        self.dm(*opts, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        # partial was actually active: block hashes were stored
+        self.assertGreater(
+            self.hf_scalar("select count(*) from blocks"), 0,
+            "block hashes stored under --dedupe-options=partial")
+        for a, b in pairs:
+            self.assertTrue(files_share(a, b),
+                            f"{os.path.basename(a)} pair deduped")
+        self.assertEqual(self._config_seq(), self._max_file_seq())
+
+        self.dm(*opts, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.assertNoNewSharing()
+
     def test_in_memory_dedupe_streams(self):
         # No --hashfile: the producer shares the in-memory handle and serializes
         # loads with the write lock. Dedupe must still happen on disk.


### PR DESCRIPTION
## What & why

Stage 2 of the dedupe rewrite. Replaces the per-batch, per-pass thread pool — created and **drained** inside every `dedupe_results()` call — with **one pool for the whole dedupe phase** and a **bounded streaming producer**. The main thread loads generation batch *i+1* while batch *i* dedupes, so the pool never drains between generation batches or between the whole-file and extent passes. That removes the barriers that left workers idle at every 1024-file generation boundary and while the next batch loaded.

> **Stacked on #112** (Stage 2.1, order-independent extent loader) — this PR targets that branch, so its diff is only the streaming change. Merge #112 first, then this.

## Design

- **Phase-global pool + batch model** (`run_dedupe.c`). Each `dedupe_batch` owns its two results trees (whole-file + extent); the producer admits at most `DEDUPE_MAX_INFLIGHT` (2) batches — the RAM double buffer. New API: `dedupe_phase_begin/end`, `dedupe_await_slot`, `dedupe_begin_batch`, `dedupe_push`, `dedupe_seal_batch`, driven by `stream_duplicates()` in `oans.c`.
- **Generation-ordered watermark.** Batches are reaped strictly in FIFO (generation) order; `dedupe_seq` advances to a batch's `seq_hi` only once it *and all earlier batches* complete (`dedupe_advance_seq`, under `dbfile_lock`). Preserves the **Ctrl+C invariant**: on kill, `dedupe_seq` reflects only fully-processed generations. Empty windows still advance it.
- **Filerec lifetime = batch-held refs** (`filerec_get`/`filerec_put`). Each batch holds one ref per filerec it loaded and drops them at completion. **All get/put/new/find run on the single producer thread**, so the filerec registry needs *no lock* and workers never touch it — they only read filerec fields and mutate their own batch's results tree (under the existing global mutex). `free_all_filerecs()` is gone from between batches. This is a deliberate, safer alternative to the plan's per-extent refs released on workers — same lifetime guarantee, far less lock surface (approved with the maintainer).
- **Producer DB handle.** Loads run on a **separate read connection** (WAL readers don't block the writer). The in-memory shared-cache db (no `--hashfile`) has no WAL, so there the producer reuses the global handle and serializes loads with `dbfile_lock()`.

## Tests & measurement

- New `tests/integration/test_streaming_dedupe.py`: many groups across generations + watermark reaches the final generation + rerun nets 0; cross-window group converges to one physical extent; whole-file and extent passes streaming together; in-memory (no-hashfile) path.
- `make check` clean (111 tests). **`make integration-valgrind` clean** (`valgrind: no findings`) — this is the UAF-prone area, so it's the gate.
- Isolated multi-batch dedupe A/B vs the `origin/master` build (16k files, ~16 batches, cold, interleaved): new **~3-4% faster in every round** (0.84–0.86s vs 0.87–0.89s), **peak RSS unchanged** (~27 MB, the double-buffer bound held). `bigfile` is kernel-serial-bound (`FIDEDUPERANGE` holds both inode locks), so no change is expected there — consistent with the existing measured notes.

No schema change. CLAUDE.md updated with the streaming/watermark design and the batch-held-refs rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)