### PR TITLE
dedupe: fix pushed-work read-after-free (frozen bar, absurd ETA)

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -574,7 +574,13 @@ static unsigned int print_bar_line(void)
 	render_bar(frac, indet, acc);
 	if (!indet) {
 		printf("  %s%u%%%s", col_bold, pct, col_reset);
-		if (eta > 0.0) {
+		/*
+		 * An ETA beyond a year means the inputs are off (a stalled
+		 * rate sample or a corrupt total), not a real forecast; the
+		 * string is also long enough to wrap the bar line and desync
+		 * the block redraw. Show nothing until it becomes sane.
+		 */
+		if (eta > 0.0 && eta < 365.0 * 86400) {
 			detail_sep();
 			printf("ETA ~%s", human_duration(eta));
 		}

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -823,6 +823,23 @@ static int push_extents(struct results_tree *res)
 
 	for (i = 0; i < nr; i++) {
 		struct dupe_extents *d = sorted[i];
+		/*
+		 * The group's byte work, captured BEFORE the push: the moment
+		 * the group is in the pool a worker owns it and can free it
+		 * (an already-shared group is cleaned and freed in
+		 * microseconds), so d must not be dereferenced after
+		 * g_thread_pool_push(). Reading it afterwards once fed
+		 * len * (0 - 1) from a freed dext into the pushed-work total,
+		 * blowing the progress denominator up to ~2^59 (a frozen bar
+		 * and a multi-thousand-year ETA).
+		 */
+		uint64_t w0 = dext_work(d);
+
+		/* A single group can't verify a pebibyte; a value this big is
+		 * a corrupt dext, not work. (The freed-dext read this guards
+		 * against fed len * (0 - 1): 128 MiB * (2^32 - 1) ~= 2^59, so
+		 * the cap must sit well below that.) */
+		abort_on(w0 > 1ULL << 50);
 
 		g_thread_pool_push(dedupe_pool, d, &err);
 		if (err) {
@@ -834,7 +851,7 @@ static int push_extents(struct results_tree *res)
 		pdedupe_add_queued(1);
 		/* Byte analog of add_queued: lets the renderer clamp the total
 		 * up for block-hash-discovered groups not in the upfront sum. */
-		pdedupe_add_pushed_work(dext_work(d));
+		pdedupe_add_pushed_work(w0);
 	}
 	return 0;
 }


### PR DESCRIPTION
## What & why

Field report on a 3.5M-file hashfile: dedupe bar frozen at its high-water mark with `ETA ~3864017h05m`. Root cause: `push_extents()` read `dext_work(d)` **after** `g_thread_pool_push()`. A worker that gets an already-shared group cleans and frees the dext in microseconds, so on rerun-heavy trees the producer reliably read a freed dext and fed `len * (0 - 1)` (~2^59) into `pdedupe_add_pushed_work()` — the grow-only total clamp then pinned the denominator, freezing the raw percent near 0 (the monotone display holds the last good value) and making the ETA astronomical. The over-long ETA string also wraps the bar line and desyncs the live block redraw, leaving stale duplicated idle-slot lists in scrollback.

Diagnosed by factoring the reported ETA: `elapsed × (total−done)/done` resolves to `128 MiB × (2^32−1)` exactly — the freed-read signature.

Latent since #111 (the byte-weighted bar). **valgrind cannot catch this class:** under memcheck's serialization the fast worker essentially never wins the race, which is why `integration-valgrind` stayed green.

Fix: capture `w0` before the push, assert per-group work is sane (> 2^50 = corrupt dext, not work), and don't render an ETA beyond a year (bad inputs, and the string breaks the redraw).

Note: #113 (streaming rewrite) already carries the same fix in its rewritten `push_results()`; whichever lands second resolves as a trivial conflict in favor of the same ordering. This standalone fix is for master / #112-only builds, which show the same field symptom.

## Tests

`make check` relevant suites pass (`ProgressBytesTest` 5/5, full check below); the race workload (fresh hashfile over an already-deduped tree — every group instant-frees) settles `work_done == work_total` byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)