### PR TITLE
scan: warn instead of silently skipping paths over PATH_MAX

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1019,10 +1019,22 @@ static void process_dir(const char *path, struct dbhandle *db)
 		    !(options.recurse_dirs && entry->d_type == DT_DIR))
 			continue;
 
-		if (dirlen + strlen(entry->d_name) > PATH_MAX)
-			continue;
+		/*
+		 * PATH_MAX bounds the path any syscall (statx/open/dedupe ioctl)
+		 * will accept, so we cannot hash a file we can only name with a
+		 * longer absolute path. Warn instead of silently ignoring it; the
+		 * child buffer is oversized (PATH_MAX + 257) so we can still form
+		 * the full name for the message. See issue #108.
+		 */
+		size_t namelen = strlen(entry->d_name);
 
 		strcpy(child + dirlen, entry->d_name);
+
+		if (dirlen + namelen > PATH_MAX) {
+			eprintf("Skipping \"%s\": absolute path length %zu exceeds PATH_MAX (%d)\n",
+				child, dirlen + namelen, PATH_MAX);
+			continue;
+		}
 
 		if (statx(0, child, 0, STATX_BASIC_STATS, &st) ||
 		    !(st.stx_mask & STATX_BASIC_STATS)) {

--- a/tests/integration/test_long_path.py
+++ b/tests/integration/test_long_path.py
@@ -1,0 +1,82 @@
+"""A file whose absolute path exceeds PATH_MAX is skipped with a warning, not
+silently ignored, and the rest of the scan proceeds normally (issue #108).
+
+PATH_MAX bounds the path any syscall (statx/open/the dedupe ioctl) accepts, so
+oans cannot hash a file it can only name with a longer absolute path. The
+kernel *filesystem* allows such paths though - a deep enough directory chain
+built with relative chdir()s reaches names longer than PATH_MAX. oans must warn
+about each one it skips (so the omission is visible) while still hashing and
+deduplicating every in-range file it walks past.
+"""
+
+import os
+
+from harness import DuperemoveTest, requires_reflink
+
+# The kernel PATH_MAX on Linux; a single path component maxes out at NAME_MAX
+# (255). Chaining 255-char directories steps the absolute path in ~256-byte
+# jumps, so a handful of levels clears 4096.
+PATH_MAX = 4096
+NAME_MAX = 255
+
+
+class LongPathTest(DuperemoveTest):
+    def _build_over_pathmax_file(self):
+        """Create, under a deep chain of max-length directories, one file whose
+        absolute path exceeds PATH_MAX. Returns (top_dir, victim_basename).
+
+        The chain is built with incremental chdir()s because the leaf's own
+        absolute path is too long to pass to mkdir()/open() directly.
+        """
+        top = self.path("deep")           # short, in-range root to point oans at
+        os.makedirs(top, exist_ok=True)
+        cwd = os.getcwd()
+        self.addCleanup(os.chdir, cwd)    # never leave the test in the deep tree
+        os.chdir(top)
+
+        comp = "d" * NAME_MAX
+        cur_len = len(top)
+        # Descend while the *directory* path stays in range (each level adds the
+        # separator + 255 chars). Stop one short so a 255-char filename here
+        # tips just over PATH_MAX.
+        while cur_len + 1 + NAME_MAX <= PATH_MAX:
+            os.mkdir(comp)
+            os.chdir(comp)
+            cur_len += 1 + NAME_MAX
+
+        victim = "v" * NAME_MAX           # cur_len + 1 + 255 > PATH_MAX
+        assert cur_len + 1 + len(victim) > PATH_MAX, "victim path not over PATH_MAX"
+        with open(victim, "wb") as f:
+            f.write(b"over-the-limit contents\n")
+        os.chdir(cwd)
+        return top, victim
+
+    @requires_reflink
+    def test_long_path_reported_not_silently_skipped(self):
+        top, victim = self._build_over_pathmax_file()
+        self.scan(top)
+
+        # The core of issue #108: the skip is announced, not silent.
+        self.assertIn("exceeds PATH_MAX", self.out,
+                      "over-PATH_MAX path must be reported, not silently dropped")
+        # And the un-hashable file is genuinely absent from the hashfile.
+        recorded = self.hf_scalar(
+            "select count(*) from files where filename like ?",
+            (f"%{victim}",))
+        self.assertEqual(0, recorded,
+                         "a file past PATH_MAX cannot be hashed, so it is not stored")
+
+    @requires_reflink
+    def test_scan_continues_past_long_path(self):
+        # A deep, un-hashable branch must not derail the rest of the run: an
+        # ordinary duplicate pair sitting beside it still deduplicates.
+        self._build_over_pathmax_file()
+        a, b = self.mkdup("pair/a.bin", "pair/b.bin", 128 * 1024)
+        self.sync()
+
+        self.dedupe(self.work)
+        self.assertDmOk()
+        self.assertIn("exceeds PATH_MAX", self.out)
+        self.sync()
+        self.assertShared(a, b,
+                          "in-range duplicates dedupe despite an over-PATH_MAX sibling")


### PR DESCRIPTION
## Summary

Fixes #108. Files whose absolute path exceeds `PATH_MAX` are no longer silently dropped from the scan — oans now prints a clear warning for each one it skips.

`PATH_MAX` bounds the path every syscall in the pipeline accepts (`statx`/`open`/`FIDEDUPERANGE`), and the hashfile schema stores the absolute name (`filename[PATH_MAX + 1]`), so such a file genuinely can't be hashed or deduped. The walk already skipped these entries at the one place child paths are built (`process_dir`), but did so with a bare `continue`, so a file could vanish from dedupe consideration with no indication.

## Change

- **`src/file_scan.c`** — emit `Skipping "<path>": absolute path length N exceeds PATH_MAX (4096)` before skipping. The full over-length name is included in the message (the `child` buffer is already oversized at `PATH_MAX + 257`, so it fits). This mirrors the existing stdin-path-list `Path max exceeded` handling in `oans.c`. The rest of the scan proceeds unaffected.
- **`tests/integration/test_long_path.py`** — new test that builds a `> PATH_MAX` directory chain via relative `chdir()`s (the leaf's own absolute path is too long to pass to `mkdir`/`open` directly) and asserts: the skip is reported (not silent), the over-length file is absent from the hashfile, and an in-range duplicate pair sitting beside it still deduplicates.

## Scope note

The issue's title also floats *actually* hashing such files via relative-path/`chdir` access. That is deliberately deferred: it would be a cross-cutting rewrite (per-thread dirfd plumbing through the walk/hash/dedupe queues plus a hashfile-schema change to store non-absolute names), not a local fix. This PR implements the "at a minimum, notify instead of silently skipping" ask from the issue.

## Testing

- `make test` (C unit tests): 11 tests, 5085 assertions, 0 failures.
- New integration test verified end-to-end on a supported-fs smoke run: the warning fires naming the full path, the over-length file is not stored, and in-range files are still recorded/deduped. It's gated on a reflink fs like the other dedupe tests, so it runs in CI (btrfs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJJ5rgGLzhQGZrg3KMpJST)_