### PR TITLE
progress: show hashing throughput during the scanning phase

### DIFF
--- a/docs/progress-ui-spec.md
+++ b/docs/progress-ui-spec.md
@@ -205,7 +205,8 @@ work continues.
 One line, current stage's concrete numbers, coloured per §7 (numbers stand out
 from labels). Reuses today's strings, minus the `\t`-prefixed multi-line blocks:
 
-- **scanning** (before listing done): `Scanning: 48,120 files found · 12,340 need hashing`
+- **scanning** (before listing done): `48,120 files · 12,340 need hashing · 210 MiB/s`
+  (the throughput appears once hashing, which overlaps the walk, has moved >1 s of data)
 - **hashing**: `Hashing 12,340 / 20,000 files · 6.1 GiB / 9.8 GiB · 210 MiB/s`
 - **dedupe**: `Deduping 512 / ~1,900 groups · batch 2/5 · reclaimed 3.4 GiB`
   - while the per-pass block-level extent search runs, it appends here so the work

--- a/src/progress.c
+++ b/src/progress.c
@@ -590,6 +590,22 @@ static unsigned int print_bar_line(void)
 }
 
 /*
+ * Append " · <throughput>/s" to the detail line once >1 s of data has been
+ * hashed (below that the rate is too noisy to be useful). Hashing overlaps the
+ * listing walk, so both the scanning and hashing lines show this same live
+ * rate from one definition. bytes_scanned is the file-scope per-run sum.
+ */
+static void print_hash_rate(void)
+{
+	double elapsed = elapsed_seconds();
+
+	if (bytes_scanned && elapsed > 1.0) {
+		detail_sep();
+		printf("%s/s", human_size((uint64_t)(bytes_scanned / elapsed)));
+	}
+}
+
+/*
  * One line of concrete numbers for the current stage. Indented to line up under
  * the bar (the stage-name prefix + its two spaces) and with no leading word -
  * the stage line above already names the phase.
@@ -659,23 +675,21 @@ static unsigned int print_detail_line(void)
 		printf("%s%s%s files", col_bold,
 		       group_u64(pscan.files_examined), col_reset);
 		detail_sep();
-		printf("%s%s%s need hashing\n", col_bold,
+		printf("%s%s%s need hashing", col_bold,
 		       group_u64(pscan.total_files_count), col_reset);
+		print_hash_rate();	/* hashing overlaps the walk */
+		putchar('\n');
 		return 1;
 	}
 
 	{
 		uint64_t tf = pscan.total_files_count, tb = pscan.total_bytes_count;
-		double elapsed = elapsed_seconds();
 
 		printf("%s%s%s / %s files", col_bold,
 		       group_u64(files_scanned), col_reset, group_u64(tf));
 		detail_sep();
 		printf("%s / %s", human_size(bytes_scanned), human_size(tb));
-		if (bytes_scanned && elapsed > 1.0) {
-			detail_sep();
-			printf("%s/s", human_size((uint64_t)(bytes_scanned / elapsed)));
-		}
+		print_hash_rate();
 		putchar('\n');
 		return 1;
 	}


### PR DESCRIPTION
## What

A one-line UI tweak: show the live **hashing throughput on the scanning line**, the same `<size>/s` the hashing stage already shows.

Hashing overlaps the directory-listing walk, so bytes are already being hashed while the detail line still reads `N files · M need hashing`. This surfaces that rate there too:

```
before:  48,120 files · 12,340 need hashing
after:   48,120 files · 12,340 need hashing · 210 MiB/s
```

## Details

- Reuses the exact rate expression and guard from the hashing-stage branch (`bytes_scanned && elapsed > 1.0`), so it stays quiet during the noisy first second and matches units/format.
- Most visible on large/slow trees (a NAS, millions of files) where the listing phase lasts many seconds. On a small fast tree the listing finishes inside the 1 s guard window, so nothing changes there.
- Spec (`docs/progress-ui-spec.md` §6) updated to match.

## Verified

- `scripts/verify.sh` green (build warnings-as-errors, `make check`, valgrind smoke).
- Observed live under a pty on a cold ~470k-file tree: early frames (<1 s) correctly show no rate, later scanning frames show e.g. `457,637 files · 457,636 need hashing · 2.3 GiB/s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)