### PR TITLE
build: rebuild the version object when git describe changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ test
 .vglogs/
 __pycache__/
 version
+.version-stamp
 .pandoc/

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,19 @@ all: oans
 
 -include $(DEPENDS)
 
+# Rebuild the version-stamped object when the version *string* changes, not only
+# when its source does. A release is just a tag plus a man-page bump, so `make`
+# would otherwise leave the previous VERSTRING baked into src/oans.o and
+# `oans --version` would report the old version on an otherwise-current build.
+# The stamp records $(VERSION) and is rewritten only when it actually changes
+# (the cmp guard), so it never churns the build otherwise. VERSTRING is used
+# only in src/oans.c; if another source uses it, add its object here too.
+.PHONY: force-version
+.version-stamp: force-version
+	@printf '%s\n' '$(VERSION)' | cmp -s - $@ 2>/dev/null || printf '%s\n' '$(VERSION)' > $@
+
+src/oans.o: .version-stamp
+
 # oans is the only program: src/oans.c has main(), the rest is its library.
 oans: $(OBJECTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBRARY_FLAGS)
@@ -161,4 +174,4 @@ tarball: clean $(DIST_SOURCES)
 	rm -fr "$$tmp"
 
 clean:
-	rm -f $(OBJECTS) $(DEPENDS) oans test test.d $(DIST_TARBALL) *~
+	rm -f $(OBJECTS) $(DEPENDS) oans test test.d $(DIST_TARBALL) .version-stamp *~


### PR DESCRIPTION
## Problem

`oans --version` is baked into `src/oans.o` at compile time via `-DVERSTRING="$(git describe …)"` (Makefile), and `VERSTRING` is used only in `src/oans.c`. `make` recompiles that object only when `src/oans.c` changes — but **a release is just a tag plus a man-page bump, no `.c` change**. So after pulling a new release and running `make`, `make` leaves the previous version string baked into an otherwise up-to-date `oans.o`, and `oans --version` reports the **old** version (e.g. still `v1.3.0` after `v1.4.0`). Today the only workaround was `make clean && make`.

## Fix

A `.version-stamp` file records `$(VERSION)` and is rewritten **only when it actually changes** (a `cmp` guard driven by a phony `force-version` prerequisite). `src/oans.o` depends on the stamp, so:

- a version change (new commit/tag/`-dirty`) rebuilds **exactly** `src/oans.o` and relinks — nothing else;
- an unchanged version doesn't churn the build (the stamp isn't rewritten, so its mtime doesn't move).

`make clean` removes the stamp; `.gitignore` ignores it. `VERSTRING` is used only in `src/oans.c`; a comment notes to add other objects here if that ever changes.

## Verified

```
$ make clean && make && ./oans --version         # v1.4.0-2-g….
$ make                                            # up to date, no recompile
$ make VERSION=v9.9.9-test                        # version changed, NO source touched
  cc … -DVERSTRING=\"v9.9.9-test\" -c -o src/oans.o src/oans.c   # ← rebuilds!
$ ./oans --version                                # v9.9.9-test
$ make VERSION=v9.9.9-test                         # no-op (idempotent)
$ make && ./oans --version                        # back to the real version
```

`scripts/verify.sh` green (build, `make check`, valgrind smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)