### PR TITLE
ci: fail on warnings, add stricter flags, clang leg and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+# The only third-party dependencies pinned in this repo are the GitHub Actions
+# used by the CI and release workflows (the C build deps come from the distro's
+# packages, so there is no manifest here for dependabot to track). This opens a
+# PR when an action publishes a new release, which is also what keeps commit-SHA
+# pins current if the workflows move to pinning by SHA.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,30 @@ on:
   push:
   pull_request:
 
+# Read-only by default; no job here needs to write back to the repo.
+permissions:
+  contents: read
+
+# Every job builds with WERROR=1 so a new compiler warning fails CI rather than
+# scrolling past in the log (scripts/verify.sh greps the build output locally,
+# but CI never runs it - without this a warning could land unnoticed).
+env:
+  WERROR: 1
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        # Both compilers: they disagree on plenty (clang's -Wcast-align fires on
+        # the container_of idiom, gcc has no -Wgnu-* checks), so building each at
+        # -O2 catches warnings and codegen the other misses. The sanitizer jobs
+        # below only cover clang at -O1.
         scratch_fs: [btrfs, xfs]
+        cc: [gcc, clang]
+    env:
+      CC: ${{ matrix.cc }}
     steps:
       - uses: actions/checkout@v4
 
@@ -18,7 +35,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config \
+            build-essential clang pkg-config \
             libsqlite3-dev libglib2.0-dev libblkid-dev libmount-dev \
             uuid-dev libbsd-dev libxxhash-dev \
             btrfs-progs xfsprogs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,15 @@ on a fresh hashfile.
 Install the build dependencies listed in the [README](README.md), then:
 
 ```sh
-make -j$(nproc)     # build (warnings are treated as failures)
-make check          # C unit tests + Python integration suite
+make -j$(nproc)              # build
+make check                   # C unit tests + Python integration suite
+make -j$(nproc) WERROR=1     # ...with any warning treated as an error, as CI builds
 ```
+
+`WERROR=1` is how every CI job builds, so a warning fails the build rather than
+scrolling past in the log. The tree is warning-free under both gcc and clang;
+the Makefile probes `$(CC)` for each extra warning flag it enables, since the two
+compilers accept different sets (`-Wduplicated-cond` and friends are GCC-only).
 
 The integration suite is stdlib-only Python `unittest`. Dedupe test cases need a
 **reflink-capable filesystem** (btrfs or xfs) as the scratch dir — see

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,29 @@ CFLAGS ?= -Wall -Wextra -Wno-unused-parameter -ggdb -std=gnu11 \
 	-Werror=strict-prototypes -MMD
 PKG_CONFIG ?= pkg-config
 
+# Extra warnings the tree is already clean under. Not every compiler knows every
+# flag (-Wduplicated-cond, -Wduplicated-branches, -Wlogical-op and
+# -Wjump-misses-init are GCC-only), and clang turns an unknown -W into an error
+# once -Werror is on, so probe each against $(CC) and keep what it accepts.
+# Assigned with := so the probes run once, not on every CFLAGS expansion.
+cc-option = $(shell $(CC) -Werror $(1) -E -x c /dev/null >/dev/null 2>&1 && echo $(1))
+WARN_EXTRA := $(foreach w,-Wundef -Wvla -Wstrict-overflow=2 \
+	-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wjump-misses-init \
+	-Wold-style-definition -Wmissing-include-dirs,$(call cc-option,$(w)))
+
+# src/fiemap.c embeds a variable-sized `struct fiemap` ahead of its extent array
+# - the layout the ioctl wants, and a deliberate GNU extension under -std=gnu11.
+# clang diagnoses it, gcc does not. Probe the *positive* flag (gcc rejects it) so
+# only clang is handed the -Wno- form instead of gcc carrying a dead option.
+WARN_EXTRA += $(if $(call cc-option,-Wgnu-variable-sized-type-not-at-end),\
+	-Wno-gnu-variable-sized-type-not-at-end)
+
+# make WERROR=1 to make any warning fatal. CI builds this way so a warning can
+# never land silently; locally `scripts/verify.sh` greps the build log instead.
+ifdef WERROR
+	override CFLAGS += -Werror
+endif
+
 MANPAGE    = docs/man/oans.8
 COMPLETION = completion/zsh/_oans
 
@@ -59,7 +82,7 @@ else
 	LIBRARY_FLAGS += -Wl,-z,relro -Wl,-z,now
 endif
 
-override CFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \
+override CFLAGS += $(WARN_EXTRA) -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE \
 	-DVERSTRING=\"$(VERSION)\" $(EXTRA_CFLAGS) $(DEBUG_FLAGS)
 LIBRARY_FLAGS += -Wl,--as-needed -latomic -lm $(EXTRA_LIBS)
 

--- a/src/memstats.h
+++ b/src/memstats.h
@@ -60,7 +60,7 @@ static inline void decrement_counters(unsigned long long *num_type,
 static GMutex alloc_##_type##_mutex;					\
 unsigned long long num_##_type = 0;					\
 unsigned long long max_##_type = 0;					\
-static inline struct _type *malloc_##_type(void)			\
+[[maybe_unused]] static inline struct _type *malloc_##_type(void)	\
 {									\
 	struct _type *t = malloc(sizeof(struct _type));			\
 	if (t)								\
@@ -68,7 +68,7 @@ static inline struct _type *malloc_##_type(void)			\
 				   &alloc_##_type##_mutex);		\
 	return t;							\
 }									\
-static inline struct _type *calloc_##_type(int n)			\
+[[maybe_unused]] static inline struct _type *calloc_##_type(int n)	\
 {									\
 	struct _type *t = calloc(n, sizeof(struct _type));		\
 	if (t)								\


### PR DESCRIPTION
Follow-up to #125. Closes three gaps found while reviewing the build.

## 1. CI did not actually fail on warnings

CI never runs `scripts/verify.sh`, and the only `-Werror` in the tree was `-Werror=strict-prototypes` — so `make`, `make test` and `make integration` all passed on a build that merely warned. A warning-introducing PR went green.

Adds a `WERROR=1` make knob and builds every CI job with it. **Verified against an injected warning:** the build returns `0` without the knob and fails with it.

`verify.sh`'s grep-the-log approach stays as the local convenience, but it was never the CI gate it looked like.

## 2. Stricter warning flags the tree is already clean under

Enabled: `-Wundef` `-Wvla` `-Wstrict-overflow=2` `-Wduplicated-cond` `-Wduplicated-branches` `-Wlogical-op` `-Wjump-misses-init` `-Wold-style-definition` `-Wmissing-include-dirs`. Zero source churn — the tree was already clean under all of them.

gcc and clang accept **different** sets (the four `-Wduplicated-*` / `-Wlogical-op` / `-Wjump-misses-init` are GCC-only), and clang turns an unknown `-W` into an *error* once `-Werror` is on — so a `cc-option` probe keeps only what `$(CC)` accepts.

`-Wcast-align` is deliberately **not** included: it is clean on gcc but clang applies it to the `container_of` idiom behind `list_for_each_entry`, the same disagreement that keeps it out of the kernel's clang builds.

Two clang-only diagnostics blocked `-Werror` there, both addressed at the source rather than blanket-suppressed:
- the alloc helpers generated by `declare_alloc_tracking()` aren't all used in every TU → marked `[[maybe_unused]]`, the idiom already used in that header;
- `src/fiemap.c`'s embedded variable-sized `struct fiemap` is the layout the ioctl wants and a deliberate GNU extension under `-std=gnu11` → the `-Wno-` form is probed via the *positive* flag, so gcc (which rejects it) isn't handed a dead option.

## 3. CI/supply-chain gaps

- Build the matrix with **both gcc and clang** at `-O2` — the sanitizer jobs only cover clang at `-O1`, and the two compilers diagnose different things.
- Add a read-only default `permissions:` block to `ci.yml` (`release.yml` already had one; `ci.yml` had none).
- Add `.github/dependabot.yml` for the `github-actions` ecosystem.

Not done: pinning actions to commit SHAs, which needs the upstream action repos' SHAs — outside this session's repository scope. Dependabot is configured such that it would keep SHA pins current if you adopt them.

## Verification

| Config | `WERROR=1` build | Unit | Integration |
|---|---|---|---|
| gcc | clean | 11 tests / 5085 assertions | 114 passed |
| clang | clean | 11 tests / 5085 assertions | 114 passed |
| clang + ASAN | clean | — | — |
| clang + UBSAN | clean | — | — |
| gcc `DEBUG=1` | clean | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4)_