### PR TITLE
Fix the flaky partial-mode UAF (#123), plus three PATH_MAX leftovers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,14 @@ extent passes. Lives in `run_dedupe.c` (`dedupe_phase_begin/end`,
   `dedupe_drain()` before the block-hash search — earlier batches are reaped
   (filerecs freed) first, at the cost of cross-batch pipelining in that mode.
   Default mode keeps the full overlap; don't add other drain points.
+- **The search must outlive nothing.** `find_additional_dedupe()` waits for
+  every worker it pushed (its own counter/cond in `find_dupes.c`) before
+  returning, because the caller reaps batches — freeing filerecs — right after.
+  Don't route that wait through `psearch_join()`: that's a *progress* concern
+  and no-ops during the dedupe phase, which was #123 (a UAF that reproduced in
+  ~5% of memcheck runs). `free_batch()` asserts `extents_search_idle()`, and
+  `DUPEREMOVE_SEARCH_DELAY_MS` makes the race deterministic for the regression
+  test (`test_partial_search_waits_for_its_workers`).
 - **Valgrind is the gate** (`make integration-valgrind`): this is the UAF-prone
   area (see the "Valgrind" section / PR #105). Run it before any PR here — but
   note it did **not** catch the pushed-dext race above (valgrind's serialization

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2170,12 +2170,15 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	atomic_fetch_add(&scan_hashed_bytes, ctxt.off);
 }
 
+/*
+ * An exclude pattern is only ever matched with fnmatch()/strcmp() against a
+ * path -- it is never handed to a syscall -- so nothing here needs to fit
+ * PATH_MAX. It used to, which meant a relative --exclude naming a deep subtree
+ * was rejected with "cannot prepend cwd to ...": you could not exclude the very
+ * trees #117 made scannable. Build the expansion on the heap instead.
+ */
 int add_exclude_pattern(const char *pattern)
 {
-	char cwd[PATH_MAX] = { 0, };
-
-	/* Overallocate to peace the compiler. */
-	char exp_pattern[PATH_MAX * 2 + 1] = { 0, };
 	struct exclude_file *exclude = malloc(sizeof(*exclude));
 
 	if (!exclude)
@@ -2184,20 +2187,22 @@ int add_exclude_pattern(const char *pattern)
 	if (pattern[0] == '/') {
 		exclude->pattern = strdup(pattern);
 	} else {
-		if (!getcwd(cwd, PATH_MAX)) {
+		_cleanup_(freep) char *cwd = get_current_dir_name();
+
+		if (!cwd) {
 			eprintf("Error: cannot read cwd for pattern %s\n", pattern);
 			free(exclude);
 			return 1;
 		}
+		if (asprintf(&exclude->pattern, "%s/%s", cwd, pattern) < 0)
+			exclude->pattern = NULL;
+	}
 
-		if (strlen(cwd) + strlen(pattern) > PATH_MAX) {
-			eprintf("Error: cannot prepend cwd to %s\n", pattern);
-			free(exclude);
-			return 1;
-		}
-
-		sprintf(exp_pattern, "%s/%s", cwd, pattern);
-		exclude->pattern = strdup(exp_pattern);
+	if (!exclude->pattern) {
+		eprintf("Error: out of memory adding exclude pattern %s\n",
+			pattern);
+		free(exclude);
+		return 1;
 	}
 
 	exclude->is_glob = strpbrk(exclude->pattern, "*?[\\") != NULL;

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -41,6 +41,34 @@
 
 static struct threads_pool search_pool;
 
+/*
+ * Completion tracking for one find_additional_dedupe() round.
+ *
+ * This is a *lifetime* guarantee, not bookkeeping. The caller
+ * (stream_load_batch, --dedupe-options=partial) reaps earlier dedupe batches
+ * right after the search returns, and reaping frees their filerecs -- the very
+ * filerecs these workers hold in cmp_ctxt. So find_additional_dedupe() must not
+ * return until every worker it pushed has finished.
+ *
+ * The pool is persistent across batches (extents_search_init/free), so it
+ * cannot be waited on by freeing it, and psearch_join() is a *progress* concern
+ * that no-ops during the dedupe phase. Relying on it was the bug (#123): in the
+ * streaming phase nothing waited, and a worker could still be dereferencing a
+ * filerec that free_batch() had already freed.
+ */
+static GMutex	search_done_mutex;
+static GCond	search_done_cond;
+static uint64_t	search_target;		/* items pushed this round */
+static uint64_t	search_finished;	/* items completed this round */
+
+/*
+ * Test hook (DUPEREMOVE_SEARCH_DELAY_MS): hold each worker back so the producer
+ * reliably wins the race the wait above exists to prevent. Without it the
+ * window is microseconds wide and reproduces in only a few percent of runs.
+ * Unset in normal use, so this costs a predictable-branch load per file.
+ */
+static useconds_t search_delay_us;
+
 static inline unsigned long block_len(struct file_block *block)
 {
 	/* Block is not near the end of file */
@@ -342,6 +370,9 @@ static void find_dupes_thread(struct cmp_ctxt *ctxt, void *priv [[maybe_unused]]
 
 	free(ctxt);
 
+	if (search_delay_us)
+		usleep(search_delay_us);	/* test hook, see above */
+
 	search_file_extents(file, dupe_extents);
 
 	/*
@@ -349,6 +380,15 @@ static void find_dupes_thread(struct cmp_ctxt *ctxt, void *priv [[maybe_unused]]
 	 * the function's outcome.
 	 */
 	psearch_update_processed_count(1);
+
+	/*
+	 * Signal completion last: after this the producer may free `file`, so
+	 * nothing below may touch it.
+	 */
+	g_mutex_lock(&search_done_mutex);
+	search_finished++;
+	g_cond_broadcast(&search_done_cond);
+	g_mutex_unlock(&search_done_mutex);
 }
 
 int find_additional_dedupe(struct results_tree *dupe_extents)
@@ -356,12 +396,17 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 	int ret = 0;
 	GError *err = NULL;
 	struct filerec *file;
+	uint64_t pushed = 0;
 
 	qprintf("Using %u threads to search within extents for "
 		"additional dedupe. This process will take some time, during "
 		"which oans can safely be ctrl-c'd.\n", options.cpu_threads);
 
 	psearch_run(num_filerec);
+
+	g_mutex_lock(&search_done_mutex);
+	search_target = search_finished = 0;
+	g_mutex_unlock(&search_done_mutex);
 
 	list_for_each_entry(file, &filerec_head, rec_list) {
 		/*
@@ -375,8 +420,10 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 
 		struct cmp_ctxt *ctxt = malloc(sizeof(*ctxt));
 
-		if (!ctxt)
-			return ENOMEM;
+		if (!ctxt) {
+			ret = ENOMEM;
+			break;		/* still wait for what we pushed */
+		}
 
 		ctxt->file = file;
 		ctxt->dupe_extents = dupe_extents;
@@ -386,17 +433,51 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 			eprintf("Error from thread pool: %s\n ",
 				err->message);
 			g_error_free(err);
-			return ENOMEM;
+			free(ctxt);
+			ret = ENOMEM;
+			break;
 		}
+		pushed++;
 	}
+
+	/*
+	 * Wait for every worker we pushed. Breaking out of the loop above is not
+	 * an escape hatch: those workers are still holding filerecs the caller
+	 * is about to free, so the error paths have to wait too.
+	 */
+	g_mutex_lock(&search_done_mutex);
+	search_target = pushed;
+	while (search_finished < search_target)
+		g_cond_wait(&search_done_cond, &search_done_mutex);
+	g_mutex_unlock(&search_done_mutex);
 
 	psearch_join();
 
 	return ret;
 }
 
+/*
+ * True when no search worker is running. The dedupe producer asserts this
+ * before freeing a batch's filerecs -- see the comment on search_done_mutex.
+ */
+bool extents_search_idle(void)
+{
+	bool idle;
+
+	g_mutex_lock(&search_done_mutex);
+	idle = search_finished >= search_target;
+	g_mutex_unlock(&search_done_mutex);
+
+	return idle;
+}
+
 void extents_search_init(void)
 {
+	const char *delay = getenv("DUPEREMOVE_SEARCH_DELAY_MS");
+
+	if (delay)
+		search_delay_us = (useconds_t)strtoul(delay, NULL, 10) * 1000;
+
 	setup_pool(&search_pool, find_dupes_thread, NULL, options.cpu_threads);
 }
 

--- a/src/find_dupes.h
+++ b/src/find_dupes.h
@@ -1,6 +1,8 @@
 #ifndef	__FIND_DUPES_H__
 #define	__FIND_DUPES_H__
 
+#include <stdbool.h>
+
 #include "opt.h"
 #include "results-tree.h"
 
@@ -8,6 +10,11 @@
 extern unsigned int blocksize;
 
 int find_additional_dedupe(struct results_tree *extents);
+
+/* True when no block-hash search worker is still running. find_additional_
+ * dedupe() guarantees this on return; the dedupe producer asserts it before
+ * freeing filerecs those workers would be reading (#123). */
+bool extents_search_idle(void);
 
 void extents_search_init(void);
 void extents_search_free(void);

--- a/src/oans.c
+++ b/src/oans.c
@@ -1438,8 +1438,20 @@ static void persist_scan_config(struct dbhandle *db, char **roots, int nroots)
 
 		/* longpath-ok: a scan root; see scan_file() for the limit and
 		 * the message a user gets when a root exceeds it. */
-		if (realpath(roots[i], buf))
+		if (realpath(roots[i], buf)) {
 			abs[sc.nroots++] = strdup(buf);
+			continue;
+		}
+		/*
+		 * Say so rather than dropping it. This config is what a bare
+		 * `oans --hashfile=X` replays, so an omitted root means a later
+		 * scheduled run silently covers less ground than this one did --
+		 * and the "all roots gone" guard never fires, because the root
+		 * was never stored to go missing.
+		 */
+		eprintf("Warning: not storing root \"%s\" in the hashfile: %s. "
+			"A later replay of this hashfile will not cover it.\n",
+			roots[i], strerror(errno));
 	}
 
 	sc.run_dedupe = options.run_dedupe;

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -42,6 +42,7 @@
 #include "debug.h"
 #include "dbfile.h"
 #include "fiemap.h"
+#include "find_dupes.h"
 
 #include "run_dedupe.h"
 
@@ -1009,6 +1010,17 @@ void dedupe_push(struct dedupe_batch *b, bool whole_file)
 static void free_batch(struct dedupe_batch *b)
 {
 	unsigned int i;
+
+	/*
+	 * Dropping the refs below can free these filerecs, and the block-hash
+	 * search (--dedupe-options=partial) reads filerecs on its own pool. It
+	 * must therefore be idle by now -- find_additional_dedupe() guarantees
+	 * that on return. Assert rather than trust it: this was #123, where the
+	 * search returned while its workers were still running and a worker
+	 * dereferenced a filerec freed right here. A silent UAF is far worse
+	 * than an abort.
+	 */
+	abort_on(!extents_search_idle());
 
 	if (batch_complete_cb)
 		batch_complete_cb(b->seq_hi);

--- a/src/storage.c
+++ b/src/storage.c
@@ -25,6 +25,7 @@
 #include <linux/magic.h>
 #include <linux/btrfs.h>
 
+#include "longpath.h"
 #include "storage.h"
 
 /*
@@ -117,22 +118,31 @@ int storage_detect(const char *path, struct storage_profile *p)
 	memset(p, 0, sizeof(*p));
 	p->num_devices = 1;
 
-	/* longpath-ok: a scan root, not a scanned file. NOTE: if the root
-	 * PATH_MAX limit is ever lifted, this function needs an fd and
-	 * fstat()/fstatfs() instead -- see src/longpath.h. */
-	if (stat(path, &st) != 0)
+	/*
+	 * Everything from one fd (fstat/fstatfs), not stat()+statfs()+open() on
+	 * the path: three path lookups become one, and it keeps working for a
+	 * path over PATH_MAX. This runs on a scan root, which today still has to
+	 * fit PATH_MAX -- but that is the one long-path limit left (#117), and
+	 * this function should not be another thing standing in the way of
+	 * lifting it.
+	 */
+	fd = longpath_open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
 		return -errno;
 
-		/* longpath-ok: a scan root; see the note above. */
-	if (statfs(path, &sfs) == 0 && sfs.f_type == BTRFS_SUPER_MAGIC) {
-		fd = open(path, O_RDONLY | O_CLOEXEC);
-		if (fd >= 0) {
-			detect_btrfs(fd, p);
-			close(fd);
-			return 0;
-		}
-		/* fall through: still report it as a single-device guess */
+	if (fstat(fd, &st) != 0) {
+		int err = errno;
+
+		close(fd);
+		return -err;
 	}
+
+	if (fstatfs(fd, &sfs) == 0 && sfs.f_type == BTRFS_SUPER_MAGIC) {
+		detect_btrfs(fd, p);
+		close(fd);
+		return 0;
+	}
+	close(fd);
 
 	/* Single-device filesystem: the file's st_dev is the block device. */
 	fold_rotational(p, st.st_dev);

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -229,7 +229,20 @@ class DuperemoveTest(unittest.TestCase):
         return self.dm("-rd", path, *extra)
 
     def assertDmOk(self, msg=None):
-        """Fail if the last run printed any error signature."""
+        """Fail if the last run exited non-zero or printed an error signature.
+
+        The exit code matters as much as the output: a crash (SIGABRT from an
+        abort_on(), SIGSEGV) still prints everything up to the point it died, so
+        an output-only check reads a fatal run as a clean one and the test only
+        fails later -- on some downstream assertion, with a misleading message
+        -- or not at all.
+        """
+        if self.rc != 0:
+            how = (f"killed by signal {-self.rc}" if self.rc < 0
+                   else f"exit status {self.rc}")
+            tail = "\n    ".join(self.out.splitlines()[-15:])
+            self.fail((msg or "oans failed") + f" ({how}):\n    " + tail)
+
         hits = [ln for ln in self.out.splitlines() if _ERROR_RE.search(ln)]
         if hits:
             detail = "\n    ".join(hits)

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -33,7 +33,11 @@ import unittest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_DIR = os.path.abspath(os.path.join(_HERE, "..", ".."))
-DUPEREMOVE = os.environ.get("DUPEREMOVE", os.path.join(REPO_DIR, "oans"))
+# Resolved now, while the cwd is still the repo: `make integration` passes a
+# relative DUPEREMOVE=./oans, and a test that chdir()s (to exercise a relative
+# --exclude, say) would otherwise fail to find the binary.
+DUPEREMOVE = os.path.abspath(
+    os.environ.get("DUPEREMOVE", os.path.join(REPO_DIR, "oans")))
 TEST_ROOT = os.environ.get("DUPEREMOVE_TEST_DIR", os.path.join(REPO_DIR, ".itest-scratch"))
 
 # oans exits 0 even after per-file failures, so we scan its output for

--- a/tests/integration/test_exclude.py
+++ b/tests/integration/test_exclude.py
@@ -1,5 +1,7 @@
 """Exclude patterns: literal paths and globs are skipped during listing."""
 
+import os
+
 from harness import DuperemoveTest
 
 
@@ -35,3 +37,40 @@ class ExcludeTest(DuperemoveTest):
         self.scan(self.path("tree"), "--exclude=" + self.path("tree/skip/*"))
         self.assertDmOk()
         self.assertEqual(1, self.hf_count("files"), "subtree contents excluded")
+
+    def test_relative_exclude_longer_than_path_max(self):
+        """A relative --exclude whose cwd-expansion exceeds PATH_MAX works.
+
+        An exclude pattern is only ever matched with fnmatch()/strcmp(); it is
+        never passed to a syscall, so PATH_MAX has no business bounding it. It
+        used to: add_exclude_pattern() built the expansion in a fixed buffer and
+        bailed with "cannot prepend cwd to ...", which meant you could not
+        exclude the deep subtrees #117 had just made scannable -- and excluding
+        one is the natural workaround for the remaining over-PATH_MAX root
+        limit.
+        """
+        deep = self.path("tree")
+        comp = "c" * 200
+        # A cwd long enough that cwd + pattern clears PATH_MAX, but short
+        # enough that getcwd() itself still works.
+        while len(deep) < 3000:
+            deep = os.path.join(deep, comp)
+        os.makedirs(os.path.join(deep, "drop"), exist_ok=True)
+        os.makedirs(os.path.join(deep, "keep"), exist_ok=True)
+        self.write(os.path.relpath(os.path.join(deep, "drop", "d.bin"),
+                                   self.work), b"d" * 8192)
+        self.write(os.path.relpath(os.path.join(deep, "keep", "k.bin"),
+                                   self.work), b"k" * 8192)
+
+        pattern = os.path.join("drop", "p" * 1400)  # expands past PATH_MAX
+        cwd = os.getcwd()
+        self.addCleanup(os.chdir, cwd)
+        os.chdir(deep)
+        self.dm("-r", "--exclude=" + pattern, ".")
+        os.chdir(cwd)
+
+        self.assertDmOk()
+        self.assertNotIn("cannot prepend cwd", self.out)
+        # The pattern does not match anything, so both files are still scanned;
+        # the point is that oans accepted it instead of refusing to start.
+        self.assertEqual(2, self.hf_count("files"))

--- a/tests/integration/test_streaming_dedupe.py
+++ b/tests/integration/test_streaming_dedupe.py
@@ -135,6 +135,45 @@ class StreamingDedupeTest(DuperemoveTest):
         self.assertDmOk()
         self.assertNoNewSharing()
 
+    def test_partial_search_waits_for_its_workers(self):
+        """find_additional_dedupe() must not return while its pool still holds
+        filerecs the producer is about to free (#123).
+
+        The block-hash search runs on a persistent pool, and the producer reaps
+        the previous batches right afterwards -- which frees their filerecs. The
+        search used to rely on psearch_join() to wait, but that is a *progress*
+        concern and no-ops during the dedupe phase, so nothing waited: a worker
+        could still be dereferencing a filerec that free_batch() had freed. The
+        window is microseconds wide, so it reproduced in only a few percent of
+        runs (and only under valgrind/ASAN, since a plain build reads the freed
+        memory silently).
+
+        DUPEREMOVE_SEARCH_DELAY_MS holds every worker back so the producer wins
+        the race every time, and free_batch() asserts the search is idle. On the
+        unfixed code this aborts on the first reap; fixed, it just runs slower.
+        """
+        pairs = []
+        for i in range(24):
+            d = os.urandom(200000 + i)
+            a = self.write(f"tree/a{i:02d}", d)
+            b = self.write(f"tree/b{i:02d}", d)
+            pairs.append((a, b))
+        self.sync()
+
+        env = dict(self.ENV, DUPEREMOVE_SEARCH_DELAY_MS="40")
+        self.dm("-rd", "--dedupe-options=partial", *self.BOPT,
+                self.path("tree"), env=env)
+        self.assertDmOk()   # SIGABRT here => the search returned too early
+        self.sync()
+
+        # The run still has to do its job, not just avoid the abort.
+        self.assertGreater(
+            self.hf_scalar("select count(*) from blocks"), 0,
+            "block hashes stored under --dedupe-options=partial")
+        for a, b in pairs:
+            self.assertTrue(files_share(a, b),
+                            f"{os.path.basename(a)} pair deduped")
+
     def test_in_memory_dedupe_streams(self):
         # No --hashfile: the producer shares the in-memory handle and serializes
         # loads with the write lock. Dedupe must still happen on disk.


### PR DESCRIPTION
## What

Two things, both fallout from reviewing #124:

1. **Fixes the flaky use-after-free** in the `--dedupe-options=partial` drain path (#123). `find_additional_dedupe()` could return while its workers were still running, and the caller frees the filerecs those workers are reading.
2. **Removes three pre-existing `PATH_MAX` leftovers** that the long-path work (#117) missed.

## 1. The search-pool UAF (#123)

The search runs on a **persistent** pool (`extents_search_init`/`free`), so it cannot be waited on by freeing the pool. The only thing that looked like a join was `psearch_join()` — a **progress** concern:

```c
void psearch_join(void)
{
        if (pdd.phase) {
                search_total = 0;
                search_processed = 0;
                return;          /* waits for nothing */
        }
        g_thread_join(printer);
}
```

Outside the dedupe phase this happens to be correct: it joins the progress printer, which loops until every worker has bumped the processed count. **Inside** the phase there is no printer (`psearch_run()` returns early), so `psearch_join()` resets two counters and returns immediately.

`stream_load_batch()` then moved on to the next batch, and `dedupe_drain()` → `reap_ready_locked()` → `free_batch()` freed filerecs out from under the live workers; one would dereference a freed filerec in `dbfile_load_nondupe_file_extents()`. That is exactly the reported stack.

So filerec lifetime correctness was resting on whether a display thread happened to exist. It only bites partial mode, because that is the only path that runs the search from inside the phase.

**Fix:** `find_additional_dedupe()` waits on its own completion counter, independent of the progress module. This also covers the two `ENOMEM` paths, which previously returned without waiting at all.

**Guarding it:**
- `free_batch()` asserts `extents_search_idle()` before dropping filerec refs, so this class of bug aborts at the point of the violation rather than silently reading freed memory.
- `DUPEREMOVE_SEARCH_DELAY_MS` (same pattern as the existing `DUPEREMOVE_FILES_PER_PASS` / `DUPEREMOVE_WALK_THREADS` hooks) holds each worker back so the producer wins the race every time.
- `test_partial_search_waits_for_its_workers` uses that hook: it aborts at the `run_dedupe.c` assertion on the unfixed code and passes on the fixed one — **without needing valgrind or a sanitizer**, so it runs in a plain `make check`.
- CLAUDE.md records the rule next to the existing "Partial mode drains" note.

| | findings / runs |
|---|---|
| `test_streaming_dedupe` loop under memcheck, **master** | 7 / 144 |
| same loop, **this branch** | **0 / 162** |

## 2. PATH_MAX leftovers

Places that still assumed a path fits `PATH_MAX` even though nothing there talks to the kernel, or that could be reached with a path that no longer does:

- **`add_exclude_pattern()`** built the cwd expansion in a fixed buffer and refused anything over `PATH_MAX` (*"cannot prepend cwd to ..."*). An exclude pattern only ever reaches `fnmatch()`/`strcmp()`, never a syscall, so the bound was inherited cargo — and it meant you **could not exclude the deep subtrees #117 had just made scannable**, which is the natural workaround for the one remaining over-`PATH_MAX` root limit. Now `get_current_dir_name()` + `asprintf()`, with allocation failure reported rather than dereferenced.
- **`storage_detect()`** did `stat()` + `statfs()` + `open()` on the path. One `longpath_open()` plus `fstat()`/`fstatfs()` gives the same three answers with one path lookup, and stops this being another obstacle if the root limit is ever lifted.
- **`persist_scan_config()`** dropped a root it could not `realpath()` with no message. That config is what a bare `oans --hashfile=X` replays, so an omitted root means a later scheduled run quietly covers less ground — and the "all roots gone" guard cannot fire for a root that was never stored. It warns now.

New `test_relative_exclude_longer_than_path_max` builds a ~3000-char cwd and a 1400-char relative pattern (expansion ~4.4 KB); it fails on the old binary with *"cannot prepend cwd"* and passes here.

## Harness fixes (both found by writing the tests)

- **`assertDmOk()` never checked the exit status**, only grepped output. A crash prints everything up to the point it died, so a SIGABRT read as a clean run — which is literally how the #123 regression test first failed: on a downstream `files_share` assertion with a misleading message, while the real event was `ERROR: src/run_dedupe.c:1023` and exit 134. This applied to every test in the suite. It now checks `rc` first and reports the signal plus the output tail.
- **`DUPEREMOVE` is resolved to an absolute path at import.** `make integration` passes a relative `./oans`, so any test that `chdir()`s — like the exclude test, which has to, to use a relative pattern — could not find the binary.

## Verification

`make lint`, `scripts/verify.sh` (build no warnings, full `make check`, valgrind smoke) all pass; full `make integration-valgrind` clean; **120 tests** pass. No existing test regressed under the stricter `assertDmOk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
