### PR TITLE
Make ThreadSanitizer usable, and fix the use-after-free it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # thread is the odd one out: it needs src/tsan.h's GLib annotations to
-        # produce a usable signal at all (libglib is uninstrumented and GMutex
-        # is futex-based, so TSAN sees no happens-before edge across a correctly
-        # locked section). The Makefile wires that up for SANITIZE=thread.
+        # thread additionally needs src/tsan.h's GLib annotations to say
+        # anything useful; the Makefile wires those up for SANITIZE=thread.
         sanitize: [address, undefined, thread]
     env:
       CC: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitize: [address, undefined]
+        # thread is the odd one out: it needs src/tsan.h's GLib annotations to
+        # produce a usable signal at all (libglib is uninstrumented and GMutex
+        # is futex-based, so TSAN sees no happens-before edge across a correctly
+        # locked section). The Makefile wires that up for SANITIZE=thread.
+        sanitize: [address, undefined, thread]
     env:
       CC: clang
       SANITIZE: ${{ matrix.sanitize }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test
 *.d
 .itest-scratch/
 .vglogs/
+.tsanlogs/
 __pycache__/
 version
 .version-stamp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,33 @@ fails the suite. LeakSanitizer's GLib false positives are filtered by
 [`tests/lsan.supp`](tests/lsan.supp) (the ASAN analogue of `tests/valgrind.supp`).
 CI runs ASAN and UBSAN as separate legs; combining them locally as above is fine.
 
+#### ThreadSanitizer
+
+```sh
+make check CC=clang SANITIZE=thread
+```
+
+TSAN needs one extra thing the other sanitizers do not, because the codebase
+synchronizes with GLib rather than pthreads. `libglib-2.0` is a system library
+built without instrumentation, and on Linux `GMutex`/`GCond` sit directly on
+futexes rather than on `pthread_mutex` (which TSAN intercepts), so TSAN sees no
+happens-before edge across a correctly locked critical section and reports it as
+a race — an unannotated run reported ~145 of them, and even a *provably* correct
+two-thread `GMutex` program reports one.
+
+[`src/tsan.h`](src/tsan.h) closes that gap: it publishes the edges TSAN cannot
+see (`__tsan_acquire`/`__tsan_release` keyed on each primitive, plus the
+pool/queue handoffs keyed on the item). The Makefile force-includes it with
+`-include` for `SANITIZE=thread`, so no call site changes, and it also defines
+`LOCK_MEMSTATS` — the allocation counters in `memstats.h` are deliberately
+unlocked outside `DEBUG_BUILD`, a genuine if benign race that would otherwise
+bury the reports worth reading.
+
+Keep the annotations tight and prefer fixing a race over widening one:
+over-annotating hides real bugs, which is the whole point of the tool.
+[`tests/tsan.supp`](tests/tsan.supp) is for the residue that genuinely cannot be
+annotated — synchronization that happens entirely inside GLib.
+
 ## Pull requests
 
 - Branch from `master`, keep the change focused, and describe what you measured.

--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,12 @@ else ifdef SANITIZE
 		UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 		LSAN_OPTIONS=suppressions=$(CURDIR)/tests/lsan.supp
 
-	# ThreadSanitizer needs two extra things (see src/tsan.h for the why):
-	#   - the GLib synchronization annotations, force-included so no call site
-	#     has to change. It must be -include'd rather than #include'd because it
-	#     has to sit ahead of every translation unit; it pulls in <glib.h>
-	#     itself so its macros cannot mangle GLib's own prototypes.
-	#   - LOCK_MEMSTATS: the allocation counters in memstats.h are deliberately
-	#     unlocked outside DEBUG_BUILD, which is a genuine (if benign) race that
-	#     would otherwise bury the reports worth reading.
+	# ThreadSanitizer needs two extra things (src/tsan.h explains why):
+	#   - the GLib annotations, -include'd rather than #include'd so they sit
+	#     ahead of every translation unit without touching any call site.
+	#   - LOCK_MEMSTATS: memstats.h's counters are deliberately unlocked
+	#     outside DEBUG_BUILD, a real if benign race that would bury the
+	#     reports worth reading.
 	ifneq (,$(findstring thread,$(SANITIZE)))
 		DEBUG_FLAGS += -include $(CURDIR)/src/tsan.h -DLOCK_MEMSTATS
 		SANITIZE_RUN += \

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,20 @@ else ifdef SANITIZE
 		ASAN_OPTIONS=abort_on_error=1:detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1 \
 		UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 		LSAN_OPTIONS=suppressions=$(CURDIR)/tests/lsan.supp
+
+	# ThreadSanitizer needs two extra things (see src/tsan.h for the why):
+	#   - the GLib synchronization annotations, force-included so no call site
+	#     has to change. It must be -include'd rather than #include'd because it
+	#     has to sit ahead of every translation unit; it pulls in <glib.h>
+	#     itself so its macros cannot mangle GLib's own prototypes.
+	#   - LOCK_MEMSTATS: the allocation counters in memstats.h are deliberately
+	#     unlocked outside DEBUG_BUILD, which is a genuine (if benign) race that
+	#     would otherwise bury the reports worth reading.
+	ifneq (,$(findstring thread,$(SANITIZE)))
+		DEBUG_FLAGS += -include $(CURDIR)/src/tsan.h -DLOCK_MEMSTATS
+		SANITIZE_RUN += \
+			TSAN_OPTIONS=suppressions=$(CURDIR)/tests/tsan.supp:halt_on_error=0:second_deadlock_stack=1
+	endif
 else
 	# Release hardening (needs optimization, hence not in the debug build).
 	# Override with HARDENING= to disable.

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1929,10 +1929,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 */
 	abort_on(!tprogress);
 	tprogress->status = thread_mapping;	/* open + do_fiemap: no bytes yet */
-	tprogress->file_scanned_bytes = 0;
-	tprogress->file_total_bytes = file->filesize;
-	progress_copy_path(tprogress->file_path, sizeof(tprogress->file_path),
-			   file->path);
+	pscan_set_file(tprogress, file->path, file->filesize);
 	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
 
 	/* Dummy variables used to trigger the cleanup code */

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -356,10 +356,6 @@ static void find_dupes_thread(void *item, void *priv [[maybe_unused]])
 {
 	struct cmp_ctxt *ctxt = item;
 
-	/* Close the handoff edge the producer opened at push (see src/tsan.h);
-	 * a no-op outside a ThreadSanitizer build. */
-	oans_tsan_work_acquire(ctxt);
-
 	struct results_tree *dupe_extents = ctxt->dupe_extents;
 	struct filerec *file = ctxt->file;
 
@@ -432,9 +428,8 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 	 * already freed (#123).
 	 *
 	 * psearch_join() does not cover this: in the dedupe phase it returns
-	 * immediately, and otherwise it joins the progress printer, not the pool.
-	 * (Before the streaming phase existed, that printer join happened to
-	 * outlast the workers, which is why this went unnoticed.)
+	 * immediately, and otherwise it joins the progress printer, not the pool
+	 * - it only ever outlasted the workers by accident.
 	 */
 	threads_pool_wait_idle(&search_pool);
 

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -36,6 +36,7 @@
 #include "debug.h"
 #include "progress.h"
 #include "threads.h"
+#include "tsan.h"
 
 #include "find_dupes.h"
 
@@ -365,6 +366,10 @@ struct cmp_ctxt {
 
 static void find_dupes_thread(struct cmp_ctxt *ctxt, void *priv [[maybe_unused]])
 {
+	/* Close the handoff edge the producer opened at push (see src/tsan.h);
+	 * a no-op outside a ThreadSanitizer build. */
+	oans_tsan_work_acquire(ctxt);
+
 	struct results_tree *dupe_extents = ctxt->dupe_extents;
 	struct filerec *file = ctxt->file;
 

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -42,25 +42,6 @@
 
 static struct threads_pool search_pool;
 
-/*
- * Completion tracking for one find_additional_dedupe() round.
- *
- * This is a *lifetime* guarantee, not bookkeeping. The caller
- * (stream_load_batch, --dedupe-options=partial) reaps earlier dedupe batches
- * right after the search returns, and reaping frees their filerecs -- the very
- * filerecs these workers hold in cmp_ctxt. So find_additional_dedupe() must not
- * return until every worker it pushed has finished.
- *
- * The pool is persistent across batches (extents_search_init/free), so it
- * cannot be waited on by freeing it, and psearch_join() is a *progress* concern
- * that no-ops during the dedupe phase. Relying on it was the bug (#123): in the
- * streaming phase nothing waited, and a worker could still be dereferencing a
- * filerec that free_batch() had already freed.
- */
-static GMutex	search_done_mutex;
-static GCond	search_done_cond;
-static uint64_t	search_target;		/* items pushed this round */
-static uint64_t	search_finished;	/* items completed this round */
 
 /*
  * Test hook (DUPEREMOVE_SEARCH_DELAY_MS): hold each worker back so the producer
@@ -364,8 +345,17 @@ struct cmp_ctxt {
 	struct results_tree *dupe_extents;
 };
 
-static void find_dupes_thread(struct cmp_ctxt *ctxt, void *priv [[maybe_unused]])
+/*
+ * Signature must match struct threads_pool's worker exactly: pool_trampoline()
+ * calls it through void (*)(void *, void *), and calling a function through a
+ * pointer of a different type is UB -- clang's -fsanitize=function traps it.
+ * It went unseen while GLib called the worker directly (an uninstrumented
+ * library), which is why the trampoline is what surfaced it.
+ */
+static void find_dupes_thread(void *item, void *priv [[maybe_unused]])
 {
+	struct cmp_ctxt *ctxt = item;
+
 	/* Close the handoff edge the producer opened at push (see src/tsan.h);
 	 * a no-op outside a ThreadSanitizer build. */
 	oans_tsan_work_acquire(ctxt);
@@ -385,15 +375,6 @@ static void find_dupes_thread(struct cmp_ctxt *ctxt, void *priv [[maybe_unused]]
 	 * the function's outcome.
 	 */
 	psearch_update_processed_count(1);
-
-	/*
-	 * Signal completion last: after this the producer may free `file`, so
-	 * nothing below may touch it.
-	 */
-	g_mutex_lock(&search_done_mutex);
-	search_finished++;
-	g_cond_broadcast(&search_done_cond);
-	g_mutex_unlock(&search_done_mutex);
 }
 
 int find_additional_dedupe(struct results_tree *dupe_extents)
@@ -401,17 +382,12 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 	int ret = 0;
 	GError *err = NULL;
 	struct filerec *file;
-	uint64_t pushed = 0;
 
 	qprintf("Using %u threads to search within extents for "
 		"additional dedupe. This process will take some time, during "
 		"which oans can safely be ctrl-c'd.\n", options.cpu_threads);
 
 	psearch_run(num_filerec);
-
-	g_mutex_lock(&search_done_mutex);
-	search_target = search_finished = 0;
-	g_mutex_unlock(&search_done_mutex);
 
 	list_for_each_entry(file, &filerec_head, rec_list) {
 		/*
@@ -433,7 +409,7 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 		ctxt->file = file;
 		ctxt->dupe_extents = dupe_extents;
 
-		g_thread_pool_push(search_pool.pool, ctxt, &err);
+		threads_pool_push(&search_pool, ctxt, &err);
 		if (err) {
 			eprintf("Error from thread pool: %s\n ",
 				err->message);
@@ -442,19 +418,25 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 			ret = ENOMEM;
 			break;
 		}
-		pushed++;
 	}
 
 	/*
-	 * Wait for every worker we pushed. Breaking out of the loop above is not
-	 * an escape hatch: those workers are still holding filerecs the caller
-	 * is about to free, so the error paths have to wait too.
+	 * Wait for the workers before returning - including on the error paths
+	 * above, hence the breaks rather than bare returns.
+	 *
+	 * Each worker holds a struct filerec * taken from the global list. Our
+	 * caller is the streaming dedupe producer, which goes straight back to
+	 * sealing and reaping batches, and reaping drops the batch's filerec refs
+	 * (free_batch -> filerec_put -> free). Returning with work still in
+	 * flight therefore lets a worker dereference a filerec the producer has
+	 * already freed (#123).
+	 *
+	 * psearch_join() does not cover this: in the dedupe phase it returns
+	 * immediately, and otherwise it joins the progress printer, not the pool.
+	 * (Before the streaming phase existed, that printer join happened to
+	 * outlast the workers, which is why this went unnoticed.)
 	 */
-	g_mutex_lock(&search_done_mutex);
-	search_target = pushed;
-	while (search_finished < search_target)
-		g_cond_wait(&search_done_cond, &search_done_mutex);
-	g_mutex_unlock(&search_done_mutex);
+	threads_pool_wait_idle(&search_pool);
 
 	psearch_join();
 
@@ -463,17 +445,14 @@ int find_additional_dedupe(struct results_tree *dupe_extents)
 
 /*
  * True when no search worker is running. The dedupe producer asserts this
- * before freeing a batch's filerecs -- see the comment on search_done_mutex.
+ * before freeing a batch's filerecs (#123): find_additional_dedupe() already
+ * guarantees it on return, and asserting turns a reintroduced early return into
+ * an abort at the point of the violation instead of a silent read of freed
+ * memory.
  */
 bool extents_search_idle(void)
 {
-	bool idle;
-
-	g_mutex_lock(&search_done_mutex);
-	idle = search_finished >= search_target;
-	g_mutex_unlock(&search_done_mutex);
-
-	return idle;
+	return threads_pool_is_idle(&search_pool);
 }
 
 void extents_search_init(void)

--- a/src/progress.c
+++ b/src/progress.c
@@ -93,7 +93,9 @@ static unsigned int drawn_lines;
 enum stage { STAGE_SCAN, STAGE_HASH, STAGE_DEDUPE, STAGE_DONE, STAGE_COUNT };
 enum stage_state { ST_PENDING, ST_RUNNING, ST_DONE };
 
-static enum stage_state stages[STAGE_COUNT];
+/* Written by whichever thread advances a stage and read every redraw by the
+ * progress thread, so atomic rather than plain. */
+static _Atomic enum stage_state stages[STAGE_COUNT];
 
 static void stage_set(enum stage s, enum stage_state st)
 {
@@ -177,13 +179,16 @@ static _Atomic uint64_t search_total, search_processed;
  * rendering.
  */
 static struct {
-	bool			phase;		/* rendering dedupe, not scan */
-	volatile int		running;
+	/* phase/running/activity/estimate are set by the main thread and read
+	 * every redraw by the progress thread; atomic for the same reason the
+	 * scan-side counters are (volatile orders nothing). */
+	_Atomic bool		phase;		/* rendering dedupe, not scan */
+	_Atomic int		running;
 	gint64			start_us;	/* phase start, monotonic */
 
 	_Atomic uint64_t	done;		/* groups finished */
 	_Atomic uint64_t	queued;		/* groups pushed to the pool */
-	uint64_t		estimate;	/* fuzzy total, see dbfile */
+	_Atomic uint64_t	estimate;	/* fuzzy total, see dbfile */
 	/*
 	 * Byte-weighted progress: the kernel byte-verify volume the phase will
 	 * do. work_total_bytes is the exact upfront SQL sum (grow-only, clamped
@@ -196,7 +201,7 @@ static struct {
 	_Atomic uint64_t	pushed_bytes;	/* sum of W0 pushed so far */
 	uint64_t		shown_pct;	/* printer thread only */
 	unsigned int		batch, batches;
-	const char		*activity;	/* static string */
+	const char *_Atomic	activity;	/* static string */
 	/* reclaimed: honest disk freed (kernel-deduped bytes). net_shared: fiemap
 	 * "net change in shared extents", a diagnostic for the machine-readable
 	 * line only (it counts the surviving copy as shared too, so ~2x for pairs). */

--- a/src/progress.c
+++ b/src/progress.c
@@ -1053,6 +1053,25 @@ void pscan_finish_file(struct pscan_thread **progress)
 }
 
 /*
+ * Point a claimed slot at its current unit of work. The path is a plain string
+ * the renderer reads under pscan.mutex, so the write takes that mutex too; the
+ * byte fields are atomic and need no lock.
+ */
+void pscan_set_file(struct pscan_thread *slot, const char *path,
+		    uint64_t total_bytes)
+{
+	if (!slot)
+		return;
+
+	g_mutex_lock(&pscan.mutex);
+	progress_copy_path(slot->file_path, sizeof(slot->file_path), path);
+	g_mutex_unlock(&pscan.mutex);
+
+	slot->file_total_bytes = total_bytes;
+	slot->file_scanned_bytes = 0;
+}
+
+/*
  * Park a persistently-held slot as idle once its worker has no more work (drain).
  * No per-file accounting - pscan_finish_file() already ran for the last file.
  */
@@ -1060,8 +1079,16 @@ void pscan_slot_idle(struct pscan_thread *slot)
 {
 	if (!slot)
 		return;
-	slot->status = thread_idle;
+	g_mutex_lock(&pscan.mutex);
 	slot->file_path[0] = '\0';
+	g_mutex_unlock(&pscan.mutex);
+	/*
+	 * Release: everything this worker wrote into the slot must be visible to
+	 * whichever worker claims it next. Parking it idle is the publish, so it
+	 * has to be the last store and it has to carry the ordering - the two
+	 * workers share no lock across the handoff.
+	 */
+	atomic_store_explicit(&slot->status, thread_idle, memory_order_release);
 }
 
 bool is_progress_printer_running(void)
@@ -1112,7 +1139,10 @@ struct pscan_thread *pscan_claim_slot(pid_t tid,
 
 	g_mutex_lock(&pscan.mutex);
 	for (unsigned int i = 0; i < pscan.thread_count; i++) {
-		if (pscan.threads[i]->status == thread_idle) {
+		/* Acquire: pairs with the release in pscan_slot_idle(), so the
+		 * previous owner's writes are visible before we reuse the slot. */
+		if (atomic_load_explicit(&pscan.threads[i]->status,
+					 memory_order_acquire) == thread_idle) {
 			slot = pscan.threads[i];
 			slot->tid = tid;
 			slot->status = status;

--- a/src/progress.c
+++ b/src/progress.c
@@ -1084,16 +1084,15 @@ void pscan_slot_idle(struct pscan_thread *slot)
 {
 	if (!slot)
 		return;
+	/*
+	 * Park the slot under the same mutex pscan_claim_slot() scans with, so
+	 * that lock is the handoff edge to whichever worker picks it up next.
+	 * (Every other slot field is either _Atomic or written under this mutex.)
+	 */
 	g_mutex_lock(&pscan.mutex);
 	slot->file_path[0] = '\0';
+	slot->status = thread_idle;
 	g_mutex_unlock(&pscan.mutex);
-	/*
-	 * Release: everything this worker wrote into the slot must be visible to
-	 * whichever worker claims it next. Parking it idle is the publish, so it
-	 * has to be the last store and it has to carry the ordering - the two
-	 * workers share no lock across the handoff.
-	 */
-	atomic_store_explicit(&slot->status, thread_idle, memory_order_release);
 }
 
 bool is_progress_printer_running(void)
@@ -1144,10 +1143,7 @@ struct pscan_thread *pscan_claim_slot(pid_t tid,
 
 	g_mutex_lock(&pscan.mutex);
 	for (unsigned int i = 0; i < pscan.thread_count; i++) {
-		/* Acquire: pairs with the release in pscan_slot_idle(), so the
-		 * previous owner's writes are visible before we reuse the slot. */
-		if (atomic_load_explicit(&pscan.threads[i]->status,
-					 memory_order_acquire) == thread_idle) {
+		if (pscan.threads[i]->status == thread_idle) {
 			slot = pscan.threads[i];
 			slot->tid = tid;
 			slot->status = status;

--- a/src/progress.h
+++ b/src/progress.h
@@ -36,13 +36,9 @@ struct pscan_thread {
 	_Atomic uint64_t		file_total_bytes;
 	char				file_path[PATH_MAX + 1];
 
-	/*
-	 * Published with release semantics when a slot is parked idle and read
-	 * with acquire semantics when one is claimed: that store/load pair is
-	 * the only thing ordering a slot's other fields between the worker that
-	 * finishes with it and the one that picks it up (pscan_slot_idle ->
-	 * pscan_claim_slot), which otherwise hand off with no lock in common.
-	 */
+	/* Workers advance this outside the progress mutex as they work, while
+	 * the renderer reads it every redraw - hence atomic. The idle/claim
+	 * handoff itself is ordered by the mutex, not by this field. */
 	_Atomic enum pscan_thread_status	status;
 };
 
@@ -191,8 +187,7 @@ void pdedupe_add_pushed_work(uint64_t bytes);
 
 /*
  * Claim a per-thread display line for one unit of work (file scan / dedupe
- * group) and mark it with `status`; fill in file_path / file_total_bytes /
- * file_scanned_bytes afterwards. Release it with pscan_reset_thread(). Claim
+ * group) and mark it with `status`; point it at the work with pscan_set_file(). Release it with pscan_reset_thread(). Claim
  * per work item, not per OS thread: pool threads get reaped and respawned,
  * which would strand dead threads' lines and grow the display unboundedly.
  */

--- a/src/progress.h
+++ b/src/progress.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdatomic.h>
 
 #include "glib.h"
 
@@ -20,22 +21,38 @@ struct pscan_thread {
 	pid_t				tid;
 
 	/* Tracks data for the entire thread lifetime */
-	uint64_t			total_scanned_files;
-	uint64_t			total_scanned_bytes;
+	/* Summed by the progress thread while their owning worker updates them
+	 * (sum_scanned), so they are atomic rather than plain. Per-file
+	 * granularity, so the default ordering costs nothing measurable. */
+	_Atomic uint64_t		total_scanned_files;
+	_Atomic uint64_t		total_scanned_bytes;
 
-	/* Tracks data for the file currently being processed */
-	uint64_t			file_scanned_bytes;
-	uint64_t			file_total_bytes;
+	/* Tracks data for the file currently being processed. Read by the
+	 * progress thread while the owning worker updates them, hence atomic;
+	 * updated per read chunk at worst, so the ordering costs nothing next to
+	 * the I/O. file_path is a string and cannot be atomic - it is written
+	 * via pscan_set_file() under the same mutex the renderer reads it. */
+	_Atomic uint64_t		file_scanned_bytes;
+	_Atomic uint64_t		file_total_bytes;
 	char				file_path[PATH_MAX + 1];
 
-	enum pscan_thread_status	status;
+	/*
+	 * Published with release semantics when a slot is parked idle and read
+	 * with acquire semantics when one is claimed: that store/load pair is
+	 * the only thing ordering a slot's other fields between the worker that
+	 * finishes with it and the one that picks it up (pscan_slot_idle ->
+	 * pscan_claim_slot), which otherwise hand off with no lock in common.
+	 */
+	_Atomic enum pscan_thread_status	status;
 };
 
 struct pscan_global {
-	uint64_t		total_files_count;
-	uint64_t		total_bytes_count;
-	uint64_t		files_examined;	/* visited during listing */
-	bool			listing_completed;
+	/* Written by the listing/scan producer and read concurrently by the
+	 * progress thread to render the bar, so these are atomic too. */
+	_Atomic uint64_t	total_files_count;
+	_Atomic uint64_t	total_bytes_count;
+	_Atomic uint64_t	files_examined;	/* visited during listing */
+	_Atomic bool		listing_completed;
 
 	/* Each thread tracks its own progress separately */
 	GMutex			mutex;
@@ -181,6 +198,14 @@ void pdedupe_add_pushed_work(uint64_t bytes);
  */
 struct pscan_thread *pscan_claim_slot(pid_t tid,
 				      enum pscan_thread_status status);
+
+/*
+ * Point a claimed slot at the work it is now doing: copy the display path and
+ * set the byte total, resetting progress to zero. Takes the progress mutex, so
+ * the renderer never reads a half-written path out from under the worker.
+ */
+void pscan_set_file(struct pscan_thread *slot, const char *path,
+		    uint64_t total_bytes);
 
 /*
  * Read back the accumulated totals (for the end-of-run summary). reclaimed is

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -798,16 +798,11 @@ static void batch_maybe_complete_locked(struct dedupe_batch *batch)
 		g_cond_signal(&producer_cond);
 }
 
-static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
+static void dedupe_worker_body(void *priv)
 {
 	uint64_t fiemap_bytes = 0ULL;
 	uint64_t kern_bytes = 0ULL;
 	struct dedupe_work_item *item = priv;
-
-	/* Close the handoff edge the producer opened at push (see src/tsan.h);
-	 * a no-op outside a ThreadSanitizer build. */
-	oans_tsan_work_acquire(item);
-
 	struct dupe_extents *dext = item->dext;
 	struct dedupe_batch *batch = item->batch;
 	bool whole_file = item->whole_file;
@@ -860,6 +855,19 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	batch->outstanding--;
 	batch_maybe_complete_locked(batch);
 	g_mutex_unlock(&producer_mutex);
+}
+
+/*
+ * The pool entry point. The body's _cleanup_ handlers (the progress slot among
+ * them) run as it returns, so the ThreadSanitizer release has to sit out here
+ * to cover what they write; it pairs with the acquire in the
+ * g_thread_pool_free() wrapper. Both calls compile away outside a TSAN build.
+ */
+static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
+{
+	oans_tsan_work_acquire(priv);
+	dedupe_worker_body(priv);
+	oans_tsan_work_done(dedupe_pool);
 }
 
 /*

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -43,6 +43,7 @@
 #include "dbfile.h"
 #include "fiemap.h"
 #include "find_dupes.h"
+#include "tsan.h"
 
 #include "run_dedupe.h"
 
@@ -397,11 +398,10 @@ static void pick_least_fragmented_target(struct dupe_extents *dext)
  * member) plus the bytes the kernel still has to byte-verify as work total. */
 static void slot_show_group(struct pscan_thread *slot, struct dupe_extents *dext)
 {
-	progress_copy_path(slot->file_path, sizeof(slot->file_path),
-			   list_first_entry(&dext->de_extents, struct extent,
-					    e_list)->e_file->filename);
-	slot->file_total_bytes = dext_work(dext);
-	slot->file_scanned_bytes = 0;
+	pscan_set_file(slot,
+		       list_first_entry(&dext->de_extents, struct extent,
+					e_list)->e_file->filename,
+		       dext_work(dext));
 }
 
 /*
@@ -803,6 +803,11 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 	uint64_t fiemap_bytes = 0ULL;
 	uint64_t kern_bytes = 0ULL;
 	struct dedupe_work_item *item = priv;
+
+	/* Close the handoff edge the producer opened at push (see src/tsan.h);
+	 * a no-op outside a ThreadSanitizer build. */
+	oans_tsan_work_acquire(item);
+
 	struct dupe_extents *dext = item->dext;
 	struct dedupe_batch *batch = item->batch;
 	bool whole_file = item->whole_file;

--- a/src/threads.c
+++ b/src/threads.c
@@ -15,19 +15,86 @@
 #include "threads.h"
 #include "debug.h"
 
-void setup_pool(struct threads_pool *pool, void *function, void *arg, unsigned int max_threads)
+/*
+ * Every item runs through here so the outstanding count is dropped no matter
+ * how the real worker returns. GLib hands us the pool as the GFunc's user_data
+ * (see setup_pool), and the caller's original arg travels in worker_arg.
+ */
+static void pool_trampoline(gpointer item, gpointer user_data)
+{
+	struct threads_pool *pool = user_data;
+
+	pool->worker(item, pool->worker_arg);
+
+	g_mutex_lock(&pool->mutex);
+	pool->outstanding--;
+	if (pool->outstanding == 0)
+		g_cond_broadcast(&pool->idle_cond);
+	g_mutex_unlock(&pool->mutex);
+}
+
+void setup_pool(struct threads_pool *pool, threads_pool_worker function,
+		void *arg, unsigned int max_threads)
 {
 	GError *err = NULL;
 
 	pool->item_count = 0;
 	pool->items = NULL;
-	pool->pool = g_thread_pool_new((GFunc) function, arg, max_threads, FALSE,
+	pool->outstanding = 0;
+	pool->worker = function;
+	pool->worker_arg = arg;
+	g_mutex_init(&pool->mutex);
+	g_cond_init(&pool->idle_cond);
+	pool->pool = g_thread_pool_new(pool_trampoline, pool, max_threads, FALSE,
 					&err);
 	if (err != NULL) {
 		eprintf("Unable to create thread pool: %s\n", err->message);
 		g_error_free(err);
 		pool->pool = NULL;
 	}
+}
+
+void threads_pool_push(struct threads_pool *pool, void *item, GError **err)
+{
+	/* Count it before it can run: a worker may finish before push returns. */
+	g_mutex_lock(&pool->mutex);
+	pool->outstanding++;
+	g_mutex_unlock(&pool->mutex);
+
+	g_thread_pool_push(pool->pool, item, err);
+
+	if (err && *err) {
+		/* Never queued, so nothing will ever decrement it. */
+		g_mutex_lock(&pool->mutex);
+		pool->outstanding--;
+		if (pool->outstanding == 0)
+			g_cond_broadcast(&pool->idle_cond);
+		g_mutex_unlock(&pool->mutex);
+	}
+}
+
+/*
+ * Snapshot of "no work in flight". Callers use this to assert a lifetime
+ * invariant (see extents_search_idle), not to decide whether to wait - for
+ * that, use threads_pool_wait_idle(), which cannot race.
+ */
+bool threads_pool_is_idle(struct threads_pool *pool)
+{
+	bool idle;
+
+	g_mutex_lock(&pool->mutex);
+	idle = pool->outstanding == 0;
+	g_mutex_unlock(&pool->mutex);
+
+	return idle;
+}
+
+void threads_pool_wait_idle(struct threads_pool *pool)
+{
+	g_mutex_lock(&pool->mutex);
+	while (pool->outstanding > 0)
+		g_cond_wait(&pool->idle_cond, &pool->mutex);
+	g_mutex_unlock(&pool->mutex);
 }
 
 void register_cleanup(struct threads_pool *pool, void *function, void *ptr)
@@ -48,6 +115,13 @@ void free_pool(struct threads_pool *pool)
 {
 	g_thread_pool_free(pool->pool, FALSE, TRUE);
 
+	/*
+	 * The wait above means no worker can still be registering, but take the
+	 * mutex anyway: it is the same lock register_cleanup() writes under, so
+	 * the ordering is stated in the code rather than left to GLib internals
+	 * (which a race detector cannot see through).
+	 */
+	g_mutex_lock(&pool->mutex);
 	for (unsigned int i = 0; i < pool->item_count; i++) {
 		struct threads_cleanup_item *item;
 		item = pool->items[i];
@@ -58,6 +132,9 @@ void free_pool(struct threads_pool *pool)
 	if (pool->items)
 		free(pool->items);
 
-	pool->pool = NULL;
+	pool->items = NULL;
 	pool->item_count = 0;
+	g_mutex_unlock(&pool->mutex);
+
+	pool->pool = NULL;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -14,23 +14,37 @@
 
 #include "threads.h"
 #include "debug.h"
+#include "tsan.h"
 
-/*
- * Every item runs through here so the outstanding count is dropped no matter
- * how the real worker returns. GLib hands us the pool as the GFunc's user_data
- * (see setup_pool), and the caller's original arg travels in worker_arg.
- */
-static void pool_trampoline(gpointer item, gpointer user_data)
+static void pool_work_done(struct threads_pool *pool)
 {
-	struct threads_pool *pool = user_data;
-
-	pool->worker(item, pool->worker_arg);
-
 	g_mutex_lock(&pool->mutex);
 	pool->outstanding--;
 	if (pool->outstanding == 0)
 		g_cond_broadcast(&pool->idle_cond);
 	g_mutex_unlock(&pool->mutex);
+}
+
+/*
+ * Every item runs through here so the outstanding count is dropped no matter
+ * how the real worker returns. GLib hands us the pool as the GFunc's user_data
+ * (see setup_pool), and the caller's original arg travels in worker_arg.
+ *
+ * This is also the one place the push -> worker handoff is crossed for every
+ * pool item, so it is where the ThreadSanitizer edge is closed: doing it here
+ * rather than in each worker keeps it structural instead of a convention every
+ * future worker has to remember (see src/tsan.h).
+ */
+static void pool_trampoline(gpointer item, gpointer user_data)
+{
+	struct threads_pool *pool = user_data;
+
+	oans_tsan_work_acquire(item);
+
+	pool->worker(item, pool->worker_arg);
+
+	oans_tsan_work_done(pool->pool);
+	pool_work_done(pool);
 }
 
 void setup_pool(struct threads_pool *pool, threads_pool_worker function,
@@ -63,14 +77,9 @@ void threads_pool_push(struct threads_pool *pool, void *item, GError **err)
 
 	g_thread_pool_push(pool->pool, item, err);
 
-	if (err && *err) {
-		/* Never queued, so nothing will ever decrement it. */
-		g_mutex_lock(&pool->mutex);
-		pool->outstanding--;
-		if (pool->outstanding == 0)
-			g_cond_broadcast(&pool->idle_cond);
-		g_mutex_unlock(&pool->mutex);
-	}
+	/* Never queued, so nothing will ever decrement it. */
+	if (err && *err)
+		pool_work_done(pool);
 }
 
 /*
@@ -115,12 +124,10 @@ void free_pool(struct threads_pool *pool)
 {
 	g_thread_pool_free(pool->pool, FALSE, TRUE);
 
-	/*
-	 * The wait above means no worker can still be registering, but take the
-	 * mutex anyway: it is the same lock register_cleanup() writes under, so
-	 * the ordering is stated in the code rather than left to GLib internals
-	 * (which a race detector cannot see through).
-	 */
+	/* No worker can still be registering after that wait, but take the lock
+	 * register_cleanup() writes under anyway, so the ordering is stated in
+	 * the code rather than left to GLib internals a race detector cannot
+	 * see through. */
 	g_mutex_lock(&pool->mutex);
 	for (unsigned int i = 0; i < pool->item_count; i++) {
 		struct threads_cleanup_item *item;

--- a/src/threads.h
+++ b/src/threads.h
@@ -21,6 +21,14 @@
 #include "opt.h"
 #include "glib.h"
 
+/*
+ * The pool's worker signature. Typed rather than void *, so passing a function
+ * whose parameters differ is a compile error: pool_trampoline() calls through
+ * this exact type, and calling a function through a mismatched pointer is UB
+ * that only clang's -fsanitize=function catches, at runtime, in a suite run.
+ */
+typedef void (*threads_pool_worker)(void *item, void *arg);
+
 struct threads_cleanup_item {
 	void (*function)(void *ptr);
 	void *ptr;
@@ -31,9 +39,39 @@ struct threads_pool {
 	struct threads_cleanup_item** items;
 	unsigned int item_count;
 	GMutex mutex; /* Protect the cleanup items operations */
+
+	/*
+	 * Pushed-but-unfinished work, so a caller can wait for the pool to go
+	 * quiet *without* tearing it down (free_pool would, but the pool outlives
+	 * any single batch of work). The real worker runs behind a trampoline
+	 * that drops the count, which is why setup_pool stashes it here.
+	 */
+	GCond idle_cond;
+	unsigned int outstanding;
+	threads_pool_worker worker;
+	void *worker_arg;
 };
 
-void setup_pool(struct threads_pool *pool, void *function, void *arg, unsigned int max_threads);
+void setup_pool(struct threads_pool *pool, threads_pool_worker function,
+		void *arg, unsigned int max_threads);
 void register_cleanup(struct threads_pool *pool, void *function, void *ptr);
 void free_pool(struct threads_pool *pool);
+
+/*
+ * Queue one item. Use this rather than g_thread_pool_push() on pool->pool
+ * directly: it is what keeps the outstanding count - and therefore
+ * threads_pool_wait_idle() - honest.
+ */
+void threads_pool_push(struct threads_pool *pool, void *item, GError **err);
+
+/*
+ * Block until every item pushed so far has finished. Callers that hand workers
+ * pointers into memory they are about to release MUST call this first - the
+ * pool keeps running after the work is queued, and nothing else waits for it.
+ */
+void threads_pool_wait_idle(struct threads_pool *pool);
+
+/* True when nothing is in flight right now. For assertions; a caller that needs
+ * the pool to *become* idle must use threads_pool_wait_idle(). */
+bool threads_pool_is_idle(struct threads_pool *pool);
 #endif	/* __THREADS_H__ */

--- a/src/tsan.h
+++ b/src/tsan.h
@@ -124,12 +124,35 @@ static inline gpointer oans_tsan_queue_pop(GAsyncQueue *q)
 
 /*
  * A GThreadPool worker is entered by GLib itself, so there is no pop call to
- * wrap - the worker function calls this on its own argument instead.
+ * wrap - the pool trampoline (or the worker) calls this on the item instead.
  */
 static inline void oans_tsan_work_acquire(void *item)
 {
 	if (item)
 		__tsan_acquire(item);
+}
+
+/*
+ * The other end of the pool's lifetime: g_thread_pool_free(wait=TRUE) waits for
+ * every task, so whatever the workers wrote is safely visible to the thread that
+ * tears the pool down - but GLib recycles pool threads rather than joining them,
+ * so TSAN sees no edge and calls the teardown's frees a race. Each worker
+ * publishes on the pool once it is completely done (after any _cleanup_ handlers
+ * have run, which is why this cannot simply be the worker's last statement), and
+ * the free wrapper below collects it.
+ */
+static inline void oans_tsan_work_done(void *pool)
+{
+	if (pool)
+		__tsan_release(pool);
+}
+
+static inline void oans_tsan_pool_free(GThreadPool *pool, gboolean immediate,
+				       gboolean wait_)
+{
+	g_thread_pool_free(pool, immediate, wait_);
+	if (wait_ && pool)
+		__tsan_acquire(pool);
 }
 
 #define g_mutex_lock(m)			oans_tsan_mutex_lock(m)
@@ -139,12 +162,14 @@ static inline void oans_tsan_work_acquire(void *item)
 #define g_cond_signal(c)		oans_tsan_cond_signal(c)
 #define g_cond_broadcast(c)		oans_tsan_cond_broadcast(c)
 #define g_thread_pool_push(p, d, e)	oans_tsan_pool_push(p, d, e)
+#define g_thread_pool_free(p, i, w)	oans_tsan_pool_free(p, i, w)
 #define g_async_queue_push(q, d)	oans_tsan_queue_push(q, d)
 #define g_async_queue_pop(q)		oans_tsan_queue_pop(q)
 
 #else	/* not a TSAN build: nothing to annotate */
 
 static inline void oans_tsan_work_acquire(void *item) { (void)item; }
+static inline void oans_tsan_work_done(void *pool) { (void)pool; }
 
 #endif
 #endif	/* __OANS_TSAN_H__ */

--- a/src/tsan.h
+++ b/src/tsan.h
@@ -1,0 +1,142 @@
+/*
+ * tsan.h - teach ThreadSanitizer about GLib's synchronization primitives.
+ *
+ * TSAN derives happens-before edges by instrumenting the code that performs the
+ * synchronization. libglib-2.0 is a system library built *without* -fsanitize=
+ * thread, and on Linux GMutex/GCond are implemented directly on futex syscalls
+ * rather than on pthread_mutex (which TSAN intercepts), so TSAN sees no edge at
+ * all across a g_mutex_lock()/g_mutex_unlock() pair. Every correctly-locked
+ * critical section then looks like a data race: an unannotated oans scan
+ * reported ~145 of them, and a *provably* correct two-thread GMutex program
+ * reports one too, which is how this was pinned down.
+ *
+ * The fix is to publish the edges TSAN cannot see. __tsan_release(addr) on
+ * unlock and __tsan_acquire(addr) on lock, keyed by the primitive's own address,
+ * reproduce exactly the ordering the primitive already guarantees. Same idea for
+ * the pool/queue handoffs, keyed by the item pointer so the edge is no wider
+ * than the real one.
+ *
+ * This is force-included (-include) by the Makefile's SANITIZE=thread build, so
+ * no call site changes. It pulls in <glib.h> itself first: the macros below
+ * would otherwise mangle GLib's own prototypes, since -include puts this ahead
+ * of everything. Outside a TSAN build the whole file is empty.
+ *
+ * Over-annotating hides real races, so keep the edges tight: annotate the
+ * primitive that actually orders the accesses and nothing broader.
+ */
+#ifndef __OANS_TSAN_H__
+#define __OANS_TSAN_H__
+
+#if defined(__SANITIZE_THREAD__) || \
+	(defined(__has_feature) && __has_feature(thread_sanitizer))
+
+#include <glib.h>
+#include <sanitizer/tsan_interface.h>
+
+/* --- GMutex ------------------------------------------------------------- */
+
+static inline void oans_tsan_mutex_lock(GMutex *m)
+{
+	g_mutex_lock(m);
+	__tsan_acquire(m);
+}
+
+static inline gboolean oans_tsan_mutex_trylock(GMutex *m)
+{
+	gboolean got = g_mutex_trylock(m);
+
+	if (got)
+		__tsan_acquire(m);
+	return got;
+}
+
+static inline void oans_tsan_mutex_unlock(GMutex *m)
+{
+	__tsan_release(m);
+	g_mutex_unlock(m);
+}
+
+/* --- GCond -------------------------------------------------------------- */
+
+/*
+ * g_cond_wait() drops the mutex, blocks, and re-takes it, so mirror that:
+ * release before handing the mutex back, acquire once we hold it again. The
+ * condition variable itself carries the signaller -> waiter edge.
+ */
+static inline void oans_tsan_cond_wait(GCond *c, GMutex *m)
+{
+	__tsan_release(m);
+	g_cond_wait(c, m);
+	__tsan_acquire(m);
+	__tsan_acquire(c);
+}
+
+static inline void oans_tsan_cond_signal(GCond *c)
+{
+	__tsan_release(c);
+	g_cond_signal(c);
+}
+
+static inline void oans_tsan_cond_broadcast(GCond *c)
+{
+	__tsan_release(c);
+	g_cond_broadcast(c);
+}
+
+/* --- Work handoff: GThreadPool and GAsyncQueue --------------------------- */
+
+/*
+ * Keyed on the item, not the pool/queue: a worker only needs to see what the
+ * thread that handed it *that* item wrote. Keying on the container instead
+ * would order every push against every pop and could bury a real race.
+ * The matching acquire happens in the worker/popper via the pop wrapper and
+ * oans_tsan_work_acquire().
+ */
+static inline void oans_tsan_pool_push(GThreadPool *pool, gpointer data,
+				       GError **error)
+{
+	__tsan_release(data);
+	g_thread_pool_push(pool, data, error);
+}
+
+static inline void oans_tsan_queue_push(GAsyncQueue *q, gpointer data)
+{
+	__tsan_release(data);
+	g_async_queue_push(q, data);
+}
+
+static inline gpointer oans_tsan_queue_pop(GAsyncQueue *q)
+{
+	gpointer data = g_async_queue_pop(q);
+
+	if (data)
+		__tsan_acquire(data);
+	return data;
+}
+
+/*
+ * A GThreadPool worker is entered by GLib itself, so there is no pop call to
+ * wrap - the worker function calls this on its own argument instead.
+ */
+static inline void oans_tsan_work_acquire(void *item)
+{
+	if (item)
+		__tsan_acquire(item);
+}
+
+#define g_mutex_lock(m)			oans_tsan_mutex_lock(m)
+#define g_mutex_trylock(m)		oans_tsan_mutex_trylock(m)
+#define g_mutex_unlock(m)		oans_tsan_mutex_unlock(m)
+#define g_cond_wait(c, m)		oans_tsan_cond_wait(c, m)
+#define g_cond_signal(c)		oans_tsan_cond_signal(c)
+#define g_cond_broadcast(c)		oans_tsan_cond_broadcast(c)
+#define g_thread_pool_push(p, d, e)	oans_tsan_pool_push(p, d, e)
+#define g_async_queue_push(q, d)	oans_tsan_queue_push(q, d)
+#define g_async_queue_pop(q)		oans_tsan_queue_pop(q)
+
+#else	/* not a TSAN build: nothing to annotate */
+
+static inline void oans_tsan_work_acquire(void *item) { (void)item; }
+
+#endif
+#endif	/* __OANS_TSAN_H__ */

--- a/src/tsan.h
+++ b/src/tsan.h
@@ -27,8 +27,16 @@
 #ifndef __OANS_TSAN_H__
 #define __OANS_TSAN_H__
 
-#if defined(__SANITIZE_THREAD__) || \
-	(defined(__has_feature) && __has_feature(thread_sanitizer))
+/*
+ * GCC has no __has_feature, and a #if expression is expanded whole - guarding it
+ * with defined(__has_feature) in the same expression does not save us, GCC still
+ * chokes on the call. Define it away first, the portable spelling.
+ */
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if defined(__SANITIZE_THREAD__) || __has_feature(thread_sanitizer)
 
 #include <glib.h>
 #include <sanitizer/tsan_interface.h>

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -16,13 +16,3 @@
 # place the matching acquire.
 race:g_queue_pop_tail
 
-# Progress-slot teardown. dedupe_phase_end() drains the pool and calls
-# g_thread_pool_free(pool, FALSE, TRUE), which waits for every task to finish,
-# before pdedupe_end() -> pscan_free_threads() releases the slots, so the frees
-# genuinely happen after the last worker write. GLib recycles its pool threads
-# instead of joining them, though, so from TSAN's point of view the worker is
-# still "running" and the ordering lives entirely inside uninstrumented GLib.
-# Unlike the races src/tsan.h annotates, there is no point in oans code after
-# the worker's cleanup handlers at which to publish the edge - the writes happen
-# in a _cleanup_ handler that runs after the function body.
-race:pscan_free_threads

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -1,0 +1,28 @@
+# ThreadSanitizer suppressions for oans.
+#
+# Used by the SANITIZE=thread build; see src/tsan.h for why GLib needs help from
+# us at all. Keep this file as close to empty as possible: unlike a leak
+# suppression, a `race:` entry hides a whole class of report, so an entry has to
+# be a library artefact we cannot annotate rather than an oans race worth fixing.
+# Everything TSAN found in oans's own code was fixed rather than listed here.
+#
+# GThreadPool/GAsyncQueue internal queue nodes: the pushing thread g_malloc()s a
+# node and the worker thread frees it in g_queue_pop_tail(). GLib orders that
+# with its own mutex, but libglib-2.0 is not built with -fsanitize=thread, so
+# TSAN cannot see the edge and reports the malloc/free pair as a race on
+# glib-internal memory. We cannot annotate our way out of this one the way
+# src/tsan.h does for the rest: the node is freed inside GLib *before* our
+# worker function is entered, so there is no point in oans code at which to
+# place the matching acquire.
+race:g_queue_pop_tail
+
+# Progress-slot teardown. dedupe_phase_end() drains the pool and calls
+# g_thread_pool_free(pool, FALSE, TRUE), which waits for every task to finish,
+# before pdedupe_end() -> pscan_free_threads() releases the slots, so the frees
+# genuinely happen after the last worker write. GLib recycles its pool threads
+# instead of joining them, though, so from TSAN's point of view the worker is
+# still "running" and the ordering lives entirely inside uninstrumented GLib.
+# Unlike the races src/tsan.h annotates, there is no point in oans code after
+# the worker's cleanup handlers at which to publish the edge - the writes happen
+# in a _cleanup_ handler that runs after the function body.
+race:pscan_free_threads


### PR DESCRIPTION
ThreadSanitizer was unusable here: a scan reported **~145 data races**, nearly all of them inside *correctly locked* critical sections. Making it usable turned up a real use-after-free that valgrind never caught.

## Why TSAN was blind

oans synchronizes with GLib, not pthreads. `libglib-2.0` is a system library built without instrumentation, and on Linux `GMutex`/`GCond` sit directly on futexes rather than `pthread_mutex` (which TSAN intercepts) — so TSAN sees no happens-before edge across `g_mutex_lock`/`g_mutex_unlock` at all.

Confirmed by negative control: a *provably correct* two-thread `GMutex` program reports a race too.

`src/tsan.h` publishes the edges TSAN cannot see — `__tsan_acquire`/`__tsan_release` keyed on each primitive, and on the item pointer for pool/queue handoffs (keyed on the item, not the container, so the edge is no wider than the real one — over-annotating hides real bugs). It is force-included with `-include` for `SANITIZE=thread`, so no call site changes, and it pulls in `<glib.h>` itself so its macros cannot mangle GLib's prototypes.

Progression: **145 → 59 → 23 → 9 → 0**.

## The real races that were hiding underneath

Once the noise was gone, the remainder were genuine — all "producer writes plainly, the progress thread reads concurrently":

- **`pscan_slot_idle()` published a slot for reuse with a plain unlocked store** while `pscan_claim_slot()` claimed it under the mutex, so a slot's contents were handed between workers with no ordering at all. Parking the slot now happens inside that mutex.
- Display counters, and the dedupe-phase state (`stages[]`, `pdd.phase/running/estimate/activity`), are now `_Atomic`. `pdd.running` was `volatile int`, which orders nothing.
- `file_path` is a string and cannot be atomic, so its two writers go through the new `pscan_set_file()`, under the same mutex the renderer reads it with.

## The use-after-free (`--dedupe-options=partial`)

```
heap-use-after-free  dbfile_load_nondupe_file_extents (dbfile.c)
  read by  search-pool worker  ← find_dupes_thread
  freed by main thread: free_batch → filerec_put → filerec_free
```

`find_additional_dedupe()` pushes every filerec to `search_pool` and returns; nothing waits for those workers. `psearch_join()` *looks* like the wait but isn't — in the dedupe phase it returns immediately, and otherwise it joins the progress **printer** thread, not the pool. Before the streaming dedupe phase existed that printer join outlasted the workers by accident. Now the caller is the streaming producer, which goes straight back to sealing and reaping batches — and reaping frees the filerecs those workers are still walking.

`struct threads_pool` gains an outstanding-work count and a condition variable so a caller can wait for the pool to go quiet *without* tearing it down (`free_pool` would, but the pool outlives any single batch). The real worker runs behind a trampoline that drops the count; `find_additional_dedupe()` waits before returning, on the error paths too.

Reproduced **3 of 14** TSAN runs before the fix, **0 of 14** after. Only `search_pool` uses `struct threads_pool`, so the blast radius is that one path. Valgrind never caught it — its serialization makes the losing interleaving far too rare, which is exactly the gap TSAN closes.

## CI

`thread` joins `address` and `undefined` in the sanitizers matrix, running the same unit + integration suites on btrfs. A race exits 66, which fails the suite (verified against a deliberately racy program).

## Suppressions

Only `race:g_queue_pop_tail` remains, for GLib's own thread-pool queue nodes — freed inside GLib *before* our worker is entered, so there is no point in oans code at which to put the matching acquire. The teardown suppression that was initially needed is gone: wrapping `g_thread_pool_free` with the matching acquire, and publishing from each worker once its `_cleanup_` handlers have run, makes that edge visible instead. Everything TSAN found in oans's own code was fixed, not suppressed.

## Verification

| | |
|---|---|
| Builds (`WERROR=1`) | gcc, clang, +ASAN, +UBSAN, +TSAN, `DEBUG=1` — all clean |
| Unit tests | 14 tests / 5183 assertions |
| Integration | 118 passed, plain and under TSAN |
| TSAN findings | 0 across the full suite |
| valgrind | partial-mode scan+dedupe smoke clean |
| `make lint` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4)_