### PR TITLE
ci: run once per commit, not twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 name: CI
 
+# A PR branch would otherwise match both triggers and run the whole matrix
+# twice for one commit: double the CI spend, and double the exposure to a
+# wedged runner. Restrict push to the branches that have no PR to cover them --
+# in practice just master, for post-merge validation. (This has to be an
+# allowlist: GitHub rejects `branches` and `branches-ignore` on the same event,
+# and a denylist cannot express "every branch that has an open PR".)
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 # Read-only by default; no job here needs to write back to the repo.


### PR DESCRIPTION
## What

`on: push` and `on: pull_request` with no filters both match a PR branch, so every commit ran the full matrix **twice** — 8 jobs where 4 would do.

## Why now

Two costs, one of which just bit:

- **Double the CI spend** on every commit.
- **Double the exposure to a flaky runner.** On #129 a `sanitizers (address)` job hung for 12 minutes on the `pull_request` run while the `push` run passed the *identical SHA* in 64 seconds. Half those jobs were never needed.

## How

Push is restricted to `master` (post-merge validation); PR branches are covered by the `pull_request` trigger.

It has to be an allowlist rather than `branches-ignore`: GitHub rejects `branches` alongside `branches-ignore` on the same event, and a denylist cannot express "every branch that has an open PR".

**Trade-off worth knowing:** a branch pushed *without* a PR now gets no CI until the PR is opened. That is the usual arrangement, and it is what makes the deduplication possible at all — but if you want CI on WIP branches before opening a PR, this is the change to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)