### PR TITLE
tsan: make the GLib suppression match on current distros too

### DIFF
--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -7,12 +7,32 @@
 # Everything TSAN found in oans's own code was fixed rather than listed here.
 #
 # GThreadPool/GAsyncQueue internal queue nodes: the pushing thread g_malloc()s a
-# node and the worker thread frees it in g_queue_pop_tail(). GLib orders that
-# with its own mutex, but libglib-2.0 is not built with -fsanitize=thread, so
-# TSAN cannot see the edge and reports the malloc/free pair as a race on
-# glib-internal memory. We cannot annotate our way out of this one the way
-# src/tsan.h does for the rest: the node is freed inside GLib *before* our
-# worker function is entered, so there is no point in oans code at which to
-# place the matching acquire.
+# node and the worker thread frees it after popping. GLib orders that with its
+# own mutex, but libglib-2.0 is not built with -fsanitize=thread, so TSAN cannot
+# see the edge and reports the malloc/free pair as a race on glib-internal
+# memory. We cannot annotate our way out of this one the way src/tsan.h does for
+# the rest: the node is freed inside GLib *before* our worker function is
+# entered, so there is no point in oans code at which to place the matching
+# acquire -- and the release cannot cover it either, since the node is allocated
+# *by* the push, after the release that precedes it.
+#
+# Two entries, because which frames carry a symbol depends on the GLib build:
+#
+#   g_queue_pop_tail  the pop path itself; resolves where libglib's own frame
+#                     for the free is an exported symbol.
+#   g_free*           the allocator entry point. Needed where that intermediate
+#                     glib frame is internal and prints as `<null>` with only an
+#                     address, which is what a current distro does (seen on
+#                     Fedora 44, glib 2.88 + glibc 2.43, where the free runs
+#                     through the C23 g_free_sized). Without it the whole suite
+#                     fails there -- ~85 tests, since a race exits 66.
+#
+# Both are GLib-internal by construction: oans calls no GLib allocator itself
+# (`grep -rE '\bg_(free|malloc|new|new0|strdup|slice_)' src/` is empty), so
+# neither entry can hide a race on memory oans owns. Checked the other way too,
+# by injecting an unsynchronized write into the csum workers and confirming TSAN
+# still reports it with both entries active -- do that again before adding a
+# third.
 race:g_queue_pop_tail
+race:g_free*
 


### PR DESCRIPTION
## Problem

`SANITIZE=thread` is unusable outside CI. On this box (Fedora 44 — glib 2.88, glibc 2.43) a plain scan reports GLib-internal races, so the whole integration suite fails: **85 of 120 tests**.

Not a regression, and not new — the commit that introduced `tests/tsan.supp` fails the same way here. It only became loud because #128 made `assertDmOk()` check the exit status, and a TSAN race exits 66. (Which also means the TSAN gate was not previously enforcing on the integration suite at all: a race exited 66 and nothing looked.)

## Cause

`race:g_queue_pop_tail` matches on a **function name**. It resolves on the CI runner's older GLib, but here the free runs through the C23 `g_free_sized` and the intervening glib frame has no symbol:

```
Write of size 8 by thread T5:
  #0 free_sized  <null> (oans+0x434bfe)
  #1 g_free_sized <null> (libglib-2.0.so.0+0x44be4)
  #2 <null>       <null> (libglib-2.0.so.0+0x7dc51)   <-- would be g_queue_pop_tail
Previous write by main thread:
  #0 malloc   <null> (oans+0x433f04)
  #1 g_malloc <null> (libglib-2.0.so.0+0x45579)
  #2 scan_files src/oans.c:1319
```

Nothing in either stack says `g_queue_pop_tail`, so the entry cannot match.

## Fix

Add `race:g_free*`, which matches at the allocator entry point regardless of which intermediate glib frame happens to resolve. Kept `race:g_queue_pop_tail` for the environments where it does.

Both are GLib-internal **by construction**: oans calls no GLib allocator itself — `grep -rE '\bg_(free|malloc|new|new0|strdup|slice_)' src/` is empty — so neither entry can hide a race on memory oans owns.

## Checking it is not too broad

A suppression that hides real bugs is worse than none, so I verified the other direction rather than assuming. Injected an unsynchronized `deliberate_race_counter++` into `csum_whole_file()` (runs on every csum worker) and ran the same binary both ways:

| | races reported | injected race caught | exit |
|---|---|---|---|
| no suppressions | 2 | yes | 66 |
| with this file | **1** | **yes** | **66** |

The GLib pair is suppressed; the real race is still reported and still fails the run.

Worth recording that my first two attempts at this validation showed "not caught" and looked damning — both were an inadequate workload (3 files never produced two concurrent csum workers), not the suppression. It needed 60 files and 8 threads to fire.

## Verification

`make integration SANITIZE=thread` locally: **120 tests OK** (was 85 failures). Normal build clean, `make lint`, `scripts/verify.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)