### PR TITLE
make: add check-all, running every CI leg in one command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,37 @@ lint:
 .PHONY: check
 check: lint test integration
 
+# Everything CI runs, in one command. Each leg rebuilds from scratch on purpose:
+# the sanitizer builds use incompatible flags, and a stale object from a previous
+# leg fails to link (undefined __ubsan_handle_* / __tsan_* symbols). Ordered
+# fastest-failing first, so a plain compile error costs seconds rather than the
+# whole run (~7 min with -j on 16 cores; TSAN and valgrind are most of it).
+#
+# Sanitizer legs must go through make, not a bare `python3 tests/run.py`: the
+# SANITIZE_RUN above is what exports the ASAN/UBSAN/LSAN/TSAN options, and
+# without them TSAN runs with no suppressions and reports GLib's internals as
+# races. Use SAN_CC= to override the sanitizer compiler (clang by default; gcc
+# has no ThreadSanitizer support for this configuration).
+SAN_CC ?= clang
+
+.PHONY: check-all
+check-all:
+	@command -v $(SAN_CC) >/dev/null 2>&1 || \
+		{ echo "check-all needs $(SAN_CC) for the sanitizer legs (override with SAN_CC=)"; exit 1; }
+	@command -v valgrind >/dev/null 2>&1 || { echo "check-all needs valgrind"; exit 1; }
+	@echo "=== [1/5] build + lint + unit + integration ==="
+	$(MAKE) clean && $(MAKE) check
+	@echo "=== [2/5] AddressSanitizer ==="
+	$(MAKE) clean && $(MAKE) integration SANITIZE=address CC=$(SAN_CC)
+	@echo "=== [3/5] UndefinedBehaviorSanitizer ==="
+	$(MAKE) clean && $(MAKE) integration SANITIZE=undefined CC=$(SAN_CC)
+	@echo "=== [4/5] ThreadSanitizer ==="
+	$(MAKE) clean && $(MAKE) integration SANITIZE=thread CC=$(SAN_CC)
+	@echo "=== [5/5] valgrind memcheck ==="
+	$(MAKE) clean && $(MAKE) integration-valgrind
+	@echo
+	@echo "check-all: all 5 legs passed"
+
 # Install oans plus a backward-compatible 'duperemove' symlink, the man page,
 # and the zsh completion. `install -D` creates the target directories.
 install: oans $(MANPAGE) $(COMPLETION)


### PR DESCRIPTION
## What

`make check-all` runs the five configurations CI runs — plain, ASAN, UBSAN, TSAN, valgrind — in one command.

```
=== [1/5] build + lint + unit + integration ===
=== [2/5] AddressSanitizer ===
=== [3/5] UndefinedBehaviorSanitizer ===
=== [4/5] ThreadSanitizer ===
=== [5/5] valgrind memcheck ===

check-all: all 5 legs passed
```

## Why

Reproducing CI locally meant five hand-written invocations, with two traps that both cost real time this week:

- **Forgetting `make clean` between sanitizer legs.** The flags are incompatible, so a stale object fails to link with `undefined reference to __ubsan_handle_type_mismatch_v1_abort` — which reads like a broken toolchain, not a dirty tree.
- **Running `python3 tests/run.py` directly under a sanitizer.** That bypasses `SANITIZE_RUN`, so TSAN starts with *no suppressions* and reports GLib's internals as races — 85 of 120 tests "failing" for no reason. I lost a cycle to exactly this and briefly believed a rebase had introduced 85 data races.

The target's job is to encode the invocations that are correct, so nobody has to remember them.

## Details

- Legs are ordered **fastest-failing first**: a plain compile error costs seconds, not the whole run.
- Each leg rebuilds from scratch — required, not defensive.
- `$(MAKE)` recursion inherits the jobserver, so `make -j$(nproc) check-all` parallelises each leg's build. **~7 min** on 16 cores; TSAN and valgrind are most of it.
- Prerequisites are checked up front with a clear message rather than failing four minutes in.
- `SAN_CC` (default `clang`) overrides the sanitizer compiler. gcc has no working ThreadSanitizer for this configuration, hence the separate knob rather than reusing `CC`.
- Not wired into `check`, which stays the fast pre-commit gate.

## Verification

Both directions, since a check target that cannot fail is worse than none:

| | result |
|---|---|
| clean tree | all 5 legs pass, 7m17s |
| injected lint violation | **exit 2**, stops before leg 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)