### PR TITLE
scan: fix quadratic extent scan on fragmented files (2x on 65k-extent file)

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1465,34 +1465,52 @@ static int add_block_hash(struct hashes *hashes,
 
 /*
  * Check if the area should be scanned.
+ *
+ * `cursor` is the caller's get_extent() resume hint (see fiemap.c). The walk
+ * below queries strictly increasing offsets, so without a hint every iteration
+ * rescans the extent array from index 0 - quadratic in the extent count. On a
+ * heavily fragmented file (65k extents in 1 GiB is ordinary for btrfs CoW, and
+ * dedupe itself fragments) that dominated the scan at ~49% of CPU. Threading
+ * the hint through makes one pass over a file O(extents). A stale hint stays
+ * correct: get_extent() validates it and falls back to a full scan.
  */
-static bool is_area_ignored(struct fiemap *fiemap, size_t start, size_t len)
+static bool is_area_ignored(struct fiemap *fiemap, size_t start, size_t len,
+			    unsigned int *cursor)
 {
 	size_t end = start + len;
 	struct fiemap_extent *current_extent;
+	unsigned int cur = cursor ? *cursor : 0;
+	bool ignored = false;
+
 	while (start < end) {
-		current_extent = get_extent(fiemap, start, NULL);
+		current_extent = get_extent(fiemap, start, &cur);
 
 		/* File changed since we fiemap */
 		if (!current_extent)
-			return false;
+			break;
 
-		if (current_extent->fe_flags & FIEMAP_SKIP_FLAGS)
-			return true;
+		if (current_extent->fe_flags & FIEMAP_SKIP_FLAGS) {
+			ignored = true;
+			break;
+		}
 
 		if (current_extent->fe_flags & FIEMAP_EXTENT_LAST)
 			break;
 		start = current_extent->fe_logical + current_extent->fe_length + 1;
 	}
-	return false;
+
+	if (cursor)
+		*cursor = cur;
+	return ignored;
 }
 
 /*
  * Check if the block starting at off should be ignored.
  */
-static inline bool is_block_ignored(struct fiemap *fiemap, size_t off)
+static inline bool is_block_ignored(struct fiemap *fiemap, size_t off,
+				    unsigned int *cursor)
 {
-	return is_area_ignored(fiemap, off, blocksize);
+	return is_area_ignored(fiemap, off, blocksize, cursor);
 }
 
 /*
@@ -1584,7 +1602,8 @@ static ssize_t process_blocks(struct scan_ctxt *ctxt, struct buffer *buffer,
 		return buffer->dl_len;
 
 	for (unsigned int i = 0; i < nb_blocks; i++) {
-		if (!is_block_ignored(ctxt->fiemap, curr_file_off) &&
+		if (!is_block_ignored(ctxt->fiemap, curr_file_off,
+				      &ctxt->extent_cursor) &&
 		    !(options.skip_zeroes &&
 		      is_block_zeroed(buffer->buf + i * blocksize))) {
 			ret = process_block(buffer->buf + i * blocksize,
@@ -1713,7 +1732,8 @@ static int fill_buffer(struct scan_ctxt *ctxt, struct buffer *buffer)
 	 * The entire buffer could be ignored. Let's fast forward
 	 * and mark the buffer as faked
 	 */
-	if (is_area_ignored(ctxt->fiemap, ctxt->off, buffer->size)
+	if (is_area_ignored(ctxt->fiemap, ctxt->off, buffer->size,
+			    &ctxt->extent_cursor)
 			&& ctxt->off + buffer->size <= ctxt->filesize) {
 		memset(buffer->buf, 0, buffer->size);
 		buffer->dl_len = buffer->size;


### PR DESCRIPTION
## What

`is_area_ignored()` called `get_extent()` with a **NULL resume cursor from inside its own loop**, so every iteration rescanned the extent array from index 0 — quadratic in the extent count.

`get_extent()`'s cursor exists precisely to prevent this. From `src/fiemap.c:50`:

> a caller that queries monotonically increasing offsets (the scan of one file) can pass the previous result's index to avoid rescanning from 0 every call, **turning an O(extents^2) walk into O(extents)**

The hottest caller just never passed one.

## Why it was invisible until now

It's reached from `fill_buffer()` once per 1 MiB on **every** scan, and from `process_blocks()` per block under `--dedupe-options=partial`. The cost scales with *extents per file*, so ordinary source trees — few extents each — never expose it. `~/git` shows `get_extent` at ~5% and nothing looks wrong.

A fragmented file does expose it. And this is self-inflicted on the workload oans is built for: **dedupe fragments the files it shares**, so the re-run case walks exactly the files that trigger it.

## Measurements

1 GiB file, 65536 extents (btrfs CoW), `-rq`:

| | before | after |
|---|---|---|
| `get_extent` self time | **48.93%** | below the 2% cutoff (gone) |

Wall clock, 5 interleaved rounds, two distinctly-named binaries:

```
base: 1.76 1.76 1.76 1.77 1.82   median 1.76s
fix:  0.88 0.88 0.89 0.89 0.89   median 0.88s   -> 2.0x
```

Ordinary tree (`~/git/claude-rc`), warm, interleaved: base 7.88 / 7.95 / 9.49 vs fix 7.84 / 7.87 / 7.95 — unchanged, as expected when files have few extents.

Reproduce the fragmented file with random 16K rewrites at 32K stride over a 1 GiB file, then `filefrag` to confirm the extent count.

## Correctness

Checked before any speed claim:

- **Hashes byte-identical** over the fragmented file (65537 extent + file rows) and over the `--dedupe-options=partial` path that exercises `is_block_ignored` (73838 block + extent rows).
- `scripts/verify.sh` passes: build, 120 tests, valgrind scan+dedupe+replay smoke.
- A stale cursor stays correct — `get_extent()` validates the hint and falls back to a full scan, so the answer is identical either way. That is what makes sharing `ctxt->extent_cursor` across the buffer/block/extent walks safe.

## Open question: regression test

Nothing in the suite builds a file with enough extents to catch a reintroduction. I did **not** add one, because the obvious form is a timing assertion, which is exactly the kind of thing that goes flaky on CI loopback filesystems — and building a 65k-extent file in CI is not cheap. Options, if you want a guard:

1. A generous wall-clock bound (quadratic would blow past it by orders of magnitude, so the bound can be loose enough not to flake).
2. A unit test asserting `is_area_ignored` advances the cursor, which pins the mechanism rather than the timing.

Happy to add either — say which you prefer.
