### PR TITLE
ci: bound every job with a timeout, and warn on a TSAN run without suppressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,17 @@ permissions:
 env:
   WERROR: 1
 
+# Every job carries a timeout-minutes. GitHub's default is 360, so a hung test
+# holds a runner (and blocks the PR) for six hours before anything notices -- a
+# TSAN leg once wedged in the integration suite with oans and llvm-symbolizer
+# both live, and looked simply "in progress" the whole time. The bounds below
+# are ~8x the observed medians (build ~1 min, sanitizers ~1-2.6 min, valgrind
+# ~6.6 min): loose enough not to police normal runner variance, tight enough
+# that a wedge fails fast and visibly.
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +98,7 @@ jobs:
   # memory behaviour is fs-independent - so it runs on btrfs only.
   valgrind:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -136,6 +145,7 @@ jobs:
   # one filesystem is enough (the checks are fs-independent), so btrfs only.
   sanitizers:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/tests/run.py
+++ b/tests/run.py
@@ -30,6 +30,34 @@ def _matches(test_id, patterns):
     return not patterns or any(p in test_id for p in patterns)
 
 
+def _tsan_note():
+    """Describe the binary's ThreadSanitizer state, if it has one.
+
+    `make integration` exports TSAN_OPTIONS (suppressions=tests/tsan.supp,
+    halt_on_error=0). Running this script directly - which the usage above
+    invites - silently drops them, and without tsan.supp GLib's thread-pool
+    malloc/free pair reports as a data race: ~85 tests fail with reports that
+    look damning and are entirely artefacts of the missing options. Warn instead
+    of failing, since running the suite by hand is legitimate.
+
+    Returns None for a non-TSAN build; detection reads the binary rather than
+    guessing from the environment, because the build flags are not visible here.
+    """
+    try:
+        with open(harness.DUPEREMOVE, "rb") as f:
+            tsan_build = b"__tsan_init" in f.read()
+    except OSError:
+        return None
+    if not tsan_build:
+        return None
+    if "suppressions=" in os.environ.get("TSAN_OPTIONS", ""):
+        return "thread (suppressions active)"
+    return ("thread, but TSAN_OPTIONS has no suppressions= -- expect a wall of "
+            "false races from GLib internals.\n"
+            "           Use `make integration SANITIZE=thread` instead, which "
+            "sets them.")
+
+
 def main(argv):
     patterns = argv[1:]
 
@@ -41,6 +69,9 @@ def main(argv):
     print(f"  binary : {harness.DUPEREMOVE} ({version})")
     print(f"  scratch: {harness.TEST_ROOT} ({fstype})")
     print(f"  reflink: {'yes' if harness.REFLINK else 'no (dedupe tests will skip)'}")
+    tsan = _tsan_note()
+    if tsan:
+        print(f"  sanitize: {tsan}")
     print(flush=True)
 
     loader = unittest.TestLoader()


### PR DESCRIPTION
Two robustness fixes, both fallout from debugging a wedged ThreadSanitizer leg on #134.

## 1. Every CI job now has a `timeout-minutes`

There were none, so GitHub's **360-minute** default applied.

On #134 the TSAN leg hung inside the integration suite — the job's own orphan cleanup showed both `oans` and `llvm-symbolizer-18` still alive — and the only outward sign was a job that read "in progress" for 23 minutes, until I cancelled it by hand to get at the log. Unattended it would have held a runner and blocked the PR for **six hours** without failing.

Bounds are ~8x the observed medians, so normal runner variance is untouched but a wedge fails fast:

| job | median | timeout |
|---|---|---|
| `build-and-test` | ~1 min | 20 |
| `sanitizers` | 1.0–2.6 min | 20 |
| `valgrind` | ~6.6 min | 30 |

(The hang itself was a one-off: re-running the same commit on a fresh runner passed in 2m36s, and 10 suites in parallel locally passed 10/10. This change is about how long it takes to *find out*.)

## 2. `tests/run.py` reports the binary's TSAN state

`make integration` exports `TSAN_OPTIONS=suppressions=tests/tsan.supp:halt_on_error=0`. Running `tests/run.py` directly — which the script's own usage text invites — silently drops them. Without `tsan.supp`, GLib's thread-pool `malloc`/`free` pair reports as a data race and ~85 tests fail with reports that look damning and are entirely artefact.

That is not hypothetical: I hit it while hunting the hang, "reproduced" a `data race … in free_sized` across 8 parallel runs, and nearly reported a phantom bug in the GLib handling before spotting that `race:g_free*` (added in #131) simply wasn't loaded.

The banner now says which it is:

```
  sanitize: thread (suppressions active)
```
```
  sanitize: thread, but TSAN_OPTIONS has no suppressions= -- expect a wall of false races from GLib internals.
           Use `make integration SANITIZE=thread` instead, which sets them.
```

Detection reads `__tsan_init` out of the binary rather than guessing from the environment, because the build flags aren't visible to the script. It **warns rather than fails** — running the suite by hand is legitimate, it just needs the options.

## Checks

- `scripts/verify.sh` passes (build, 120 tests, valgrind smoke).
- Warning verified in all three states: TSAN build without options (warns), TSAN build with options (quiet, confirms active), non-TSAN build (no line at all).
- `ci.yml` parses and all three jobs carry a bound.
