### PR TITLE
scripts: make three silent tooling failures loud

### DIFF
--- a/scripts/perf-profile.sh
+++ b/scripts/perf-profile.sh
@@ -57,11 +57,20 @@ done
 
 [ $# -gt 0 ] || die "no duperemove arguments given; put them after '--'. See --help."
 
-# Resolve the binary.
+# Resolve the binary. ./oans first: this repo builds that name, and `make
+# install` puts a `duperemove` compatibility symlink on PATH, so preferring the
+# PATH lookup silently profiles whatever duperemove is installed - which on a
+# dev box is usually *upstream*, not your build. Falling back that far is worth
+# a warning rather than a silent substitution.
 if [ -z "$BINARY" ]; then
-	if [ -x ./duperemove ]; then BINARY=./duperemove
-	elif command -v duperemove >/dev/null 2>&1; then BINARY=$(command -v duperemove)
-	else die "no duperemove binary; build it or pass --binary PATH"
+	if [ -x ./oans ]; then BINARY=./oans
+	elif [ -x ./duperemove ]; then BINARY=./duperemove
+	elif command -v duperemove >/dev/null 2>&1; then
+		BINARY=$(command -v duperemove)
+		echo "perf-profile: warning: no ./oans or ./duperemove in $PWD;" >&2
+		echo "              profiling $BINARY, which is probably NOT your build." >&2
+		echo "              Build first, or pass -b/--binary explicitly." >&2
+	else die "no oans/duperemove binary; build it or pass --binary PATH"
 	fi
 fi
 [ -x "$BINARY" ] || die "not executable: $BINARY"
@@ -83,11 +92,17 @@ drop_caches() {
 	sync
 	if [ "$(id -u)" -eq 0 ]; then
 		echo 3 > /proc/sys/vm/drop_caches
-	elif sudo -n true 2>/dev/null; then
-		echo 3 | sudo -n tee /proc/sys/vm/drop_caches >/dev/null
-	else
-		die "--cold needs root or passwordless sudo to drop caches"
+		return
 	fi
+	# Probe the real command, not `sudo -n true`. The useful sudoers rule to
+	# grant here is exactly `tee /proc/sys/vm/drop_caches` and nothing else -
+	# which is what scripts/bench.py relies on - and under such a rule
+	# `sudo -n true` still demands a password. The old probe therefore disabled
+	# --cold on precisely the machines configured to support it.
+	if echo 3 | sudo -n tee /proc/sys/vm/drop_caches >/dev/null 2>&1; then
+		return
+	fi
+	die "--cold needs root, or a passwordless sudoers rule for 'tee /proc/sys/vm/drop_caches'"
 }
 
 run() { "$BINARY" "$@" >/dev/null 2>&1 || true; }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,6 +37,23 @@ if ! command -v valgrind >/dev/null 2>&1; then
 else
 	scratch=$(mktemp -d "${DUPEREMOVE_TEST_DIR:-${TMPDIR:-/tmp}}/verify-smoke.XXXXXX")
 	trap 'rm -rf "$scratch"' EXIT
+
+	# The smoke deduplicates, so the scratch has to be reflink-capable. With
+	# DUPEREMOVE_TEST_DIR unset it lands in /tmp, which is tmpfs on most
+	# distros: oans then correctly refuses the tree and exits 1 - but its
+	# message went to the >/dev/null below, so this script stopped dead with no
+	# output at all and looked like it had simply ended. Check up front instead.
+	fstype=$(stat -f -c %T "$scratch" 2>/dev/null || echo unknown)
+	case "$fstype" in
+	btrfs|xfs) ;;
+	*)
+		echo "verify: scratch '$scratch' is on '$fstype', but the valgrind smoke" >&2
+		echo "        deduplicates and needs btrfs or xfs. Point DUPEREMOVE_TEST_DIR" >&2
+		echo "        at a reflink-capable directory, e.g.:" >&2
+		echo "            DUPEREMOVE_TEST_DIR=\$HOME/.itest-scratch $0" >&2
+		exit 1 ;;
+	esac
+
 	head -c 1048576 /dev/urandom > "$scratch/a"
 	cp "$scratch/a" "$scratch/b"		# a real duplicate for dedupe to act on
 	hf="$scratch/hf.db"
@@ -44,8 +61,19 @@ else
 		valgrind -q --leak-check=full --error-exitcode=42 \
 			--suppressions=tests/valgrind.supp "$@"
 	}
-	vg ./oans -rd --hashfile="$hf" "$scratch" >/dev/null
-	vg ./oans --hashfile="$hf" >/dev/null	# bare replay of the stored config
+	# Keep the output instead of discarding it: on failure it is the only
+	# explanation of what went wrong, and swallowing it is what made the tmpfs
+	# case above so hard to read.
+	smoke() {
+		local out
+		if ! out=$(vg "$@" 2>&1); then
+			echo "$out" >&2
+			echo "verify: valgrind smoke failed: $*" >&2
+			exit 1
+		fi
+	}
+	smoke ./oans -rd --hashfile="$hf" "$scratch"
+	smoke ./oans --hashfile="$hf"		# bare replay of the stored config
 	echo "ok"
 fi
 


### PR DESCRIPTION
Three tooling bugs, all hit during the #134 work. What they have in common is that **each one failed in a way that looked like success** — no error, or an error nobody sees.

## 1. `verify.sh` silently stops when the scratch is tmpfs

The valgrind smoke takes its scratch from `${DUPEREMOVE_TEST_DIR:-${TMPDIR:-/tmp}}`. With the variable unset — the documented default — `make check` still passes, because the integration harness independently defaults to `.itest-scratch` next to the repo. But the smoke lands in `/tmp`, which is tmpfs on most distros. oans correctly refuses to dedupe there and exits 1 — and its message went straight into the smoke's `>/dev/null`.

The result: the script stopped mid-step with no output at all. My first v1.5.0 release attempt looked like it had simply ended, and the `| tail` I'd piped it through hid the non-zero exit too.

Now it checks the scratch filesystem before doing anything:

```
=== valgrind smoke (scan + dedupe + bare replay) ===
verify: scratch '/tmp/verify-smoke.UoZAK4' is on 'tmpfs', but the valgrind smoke
        deduplicates and needs btrfs or xfs. Point DUPEREMOVE_TEST_DIR
        at a reflink-capable directory, e.g.:
            DUPEREMOVE_TEST_DIR=$HOME/.itest-scratch scripts/verify.sh
```

and the smoke retains its output, so any other failure explains itself instead of vanishing.

## 2. `perf-profile.sh --cold` was refused on machines that support it

It probed `sudo -n true`. But the sensible sudoers rule to grant is exactly `tee /proc/sys/vm/drop_caches` and nothing else — which is what `scripts/bench.py` already relies on — and under such a rule `sudo -n true` still demands a password.

So `--cold` was disabled on precisely the boxes configured for it, while `bench.py` dropped caches happily. It now probes the real command.

## 3. `perf-profile.sh` profiled upstream duperemove by default

Binary resolution was `./duperemove`, then PATH — never `./oans`, which is what this repo builds. And since `make install` puts a `duperemove` compatibility symlink on PATH, a bare invocation cheerfully profiled the **installed upstream duperemove 0.15.2**, reporting it in the header where it reads as perfectly normal. My first profile of the O(n²) hotspot was of upstream, not the fork.

It now prefers `./oans`, and warns before falling back:

```
perf-profile: warning: no ./oans or ./duperemove in /tmp;
              profiling /usr/bin/duperemove, which is probably NOT your build.
              Build first, or pass -b/--binary explicitly.
```

This is the same trap `CLAUDE.md` already warns about in prose ("Confirm you're testing *this* `./oans`, not a system `duperemove`") — now enforced by the script rather than left to the reader.

## Verification

Each fix exercised against the failure it addresses:

- `verify.sh` with `DUPEREMOVE_TEST_DIR` unset → exits **1**, names the tmpfs and the fix (previously: silent stop).
- `--cold` → completes and records a real profile (previously: bailed on the sudo probe).
- bare `perf-profile.sh` in the repo → `binary : ./oans` (previously: `/usr/bin/duperemove`).
- bare run from a directory with no build → prints the fallback warning, then proceeds.
- `scripts/verify.sh` passes end to end.
