### PR TITLE
progress: end the scan thread on a flag, not on counters matching (fixes a hang)

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -58,7 +58,36 @@
  */
 
 struct pscan_global pscan = {};
+
+/*
+ * The one progress thread, and the only thing that ends it.
+ *
+ * Every render loop below exits on printer_running and nothing else. A loop
+ * must never infer that it is finished by comparing counters (say, scanned ==
+ * total): a single item counted into a total but not credited back leaves them
+ * unequal forever, the loop spins in usleep, and the join blocks for good with
+ * all the real work already done. Only the producer knows when the work is
+ * over. printer_stop() clears the flag and joins in one step so no caller can
+ * do one without the other.
+ */
 static GThread *printer = NULL;
+static _Atomic bool printer_running;
+
+static void printer_start(GThreadFunc fn)
+{
+	printer_running = true;
+	printer = g_thread_new("progress_printer", fn, NULL);	/* aborts on failure */
+}
+
+static void printer_stop(void)
+{
+	if (!printer)
+		return;
+	printer_running = false;
+	g_thread_join(printer);
+	printer = NULL;
+}
+
 bool tty;
 unsigned int w_col;
 
@@ -174,16 +203,15 @@ static _Atomic uint64_t search_total, search_processed;
 
 /*
  * Dedupe-phase status. The counters accumulate whether or not the live
- * display runs (they feed the final summary). `running` gates the printer
- * thread; `phase` switches the shared screen area between scan and dedupe
- * rendering.
+ * display runs (they feed the final summary). `phase` switches the shared
+ * screen area between scan and dedupe rendering; whether a printer thread is
+ * up at all is printer_running's business, not this struct's.
  */
 static struct {
-	/* phase/running/activity/estimate are set by the main thread and read
-	 * every redraw by the progress thread; atomic for the same reason the
+	/* phase/activity/estimate are set by the main thread and read every
+	 * redraw by the progress thread; atomic for the same reason the
 	 * scan-side counters are (volatile orders nothing). */
 	_Atomic bool		phase;		/* rendering dedupe, not scan */
-	_Atomic int		running;
 	gint64			start_us;	/* phase start, monotonic */
 
 	_Atomic uint64_t	done;		/* groups finished */
@@ -883,15 +911,18 @@ static void *pscan_progress_thread(void * p)
 			gint64 now = g_get_monotonic_time();
 			enum jphase phase = json_phase();
 
-			/* Refresh the per-run sums every tick so the loop's exit test
-			 * stays responsive (~100ms). Emit ~1/s, but always right away
-			 * on a phase change so every phase is reported even on a fast
-			 * run. */
-			g_mutex_lock(&pscan.mutex);
-			sum_scanned();
-			g_mutex_unlock(&pscan.mutex);
-
+			/* Emit ~1/s, but always right away on a phase change so every
+			 * phase is reported even on a fast run. The sums are refreshed
+			 * only for the emit that reads them: ticking them every 100ms
+			 * took pscan.mutex - which every worker contends for - to
+			 * produce a value that was overwritten unused nine times out of
+			 * ten, and never read at all outside the hashing phase. */
 			if (phase != json_last_phase || now - json_last >= 1000000) {
+				if (phase == JP_HASH) {
+					g_mutex_lock(&pscan.mutex);
+					sum_scanned();
+					g_mutex_unlock(&pscan.mutex);
+				}
 				emit_json_progress(phase);
 				json_last = now;
 				json_last_phase = phase;
@@ -917,16 +948,7 @@ static void *pscan_progress_thread(void * p)
 
 		/* Do not waste too much cpu */
 		usleep(1000 * (tty ? 100 : 1000));
-		/*
-		 * Both phases end when their producer says so, never when a counter
-		 * happens to match. The scan branch used to loop until
-		 * files_scanned/bytes_scanned reached the totals exactly; one file
-		 * counted into a total but not credited back (the invariant
-		 * test_skip_work_is_fully_credited pins) made that unreachable, so
-		 * this thread span in usleep forever and pscan_join() blocked in
-		 * g_thread_join() with all the actual work already finished.
-		 */
-	} while (pdd.phase ? pdd.running : pscan.scan_running);
+	} while (printer_running);
 
 	return NULL;
 }
@@ -973,17 +995,12 @@ void pscan_run(void)
 		prepare_screen_area();
 	}
 
-	/* Will abort on failure */
-	pscan.scan_running = true;
-	printer = g_thread_new("progress_printer", pscan_progress_thread, NULL);
+	printer_start(pscan_progress_thread);
 }
 
 void pscan_join(bool continues)
 {
-	/* Tell the thread to stop before waiting for it, or we wait forever. */
-	pscan.scan_running = false;
-	g_thread_join(printer);
-	printer = NULL;
+	printer_stop();
 
 	/* The listing is done (STAGE_SCAN) and the csum pool has drained. */
 	stage_set(STAGE_HASH, ST_DONE);
@@ -995,26 +1012,22 @@ void pscan_join(bool continues)
 		return;
 	}
 
-	/*
-	 * One final render, now that the counts are settled and hashing is
-	 * ticked. It is needed on every path, not just `continues`: the thread
-	 * now stops the moment the producer says so, which can be mid-tick, so
-	 * its last frame may show a bar short of 100%. The old counter-equality
-	 * exit gave that completeness as a side effect - at the cost of never
-	 * exiting at all when the counters could not meet.
-	 *
-	 * A live dedupe phase keeps drawing this same block, so leave it in
-	 * place - workers and all - rather than wiping it: nothing is stranded
-	 * above the dedupe view and the worker list never blinks away. Threads,
-	 * drawn_lines and the hidden cursor are kept for the dedupe phase, which
-	 * reuses the now-idle slots and redraws over this block.
-	 */
-	g_mutex_lock(&pscan.mutex);
-	print_progress();
-	g_mutex_unlock(&pscan.mutex);
-
-	if (continues)
+	if (continues) {
+		/*
+		 * A live dedupe phase will keep drawing this same block, so leave
+		 * it in place - workers and all - and just refresh it once so
+		 * hashing shows ticked. The refresh also settles the bar: the
+		 * printer stops the moment the producer says so, which can be
+		 * mid-tick. Nothing is wiped or stranded above the dedupe view,
+		 * and the worker list never blinks away. Threads, drawn_lines and
+		 * the hidden cursor are kept for the dedupe phase (it reuses the
+		 * now-idle slots and redraws over this block).
+		 */
+		g_mutex_lock(&pscan.mutex);
+		print_progress();
+		g_mutex_unlock(&pscan.mutex);
 		return;
+	}
 
 	/*
 	 * No live dedupe follows (print-only / non-tty / -v): wipe the live area
@@ -1217,8 +1230,7 @@ void pdedupe_begin(unsigned int batches)
 		 * When there was no scan block (drawn_lines already 0) it draws fresh.
 		 */
 	}
-	pdd.running = 1;
-	printer = g_thread_new("progress_printer", pscan_progress_thread, NULL);
+	printer_start(pscan_progress_thread);
 }
 
 void pdedupe_end(void)
@@ -1227,10 +1239,8 @@ void pdedupe_end(void)
 	stage_set(STAGE_DEDUPE, ST_DONE);
 	stage_set(STAGE_DONE, ST_DONE);
 
-	if (pdd.running) {
-		pdd.running = 0;
-		g_thread_join(printer);
-		printer = NULL;
+	if (printer) {
+		printer_stop();
 
 		/* Show the cursor again, wipe the live block, and leave the
 		 * fully-ticked stage line in place; the caller prints the final
@@ -1345,7 +1355,7 @@ static void *psearch_progress_thread(void * p)
 
 		/* Do not waste too much cpu */
 		usleep(100 * 1000);
-	} while (search_total != search_processed);
+	} while (printer_running);
 	printf("\n");
 	return NULL;
 }
@@ -1364,7 +1374,7 @@ void psearch_run(uint64_t num_filerecs)
 		pdedupe_set_activity("searching block-level matches");
 		return;
 	}
-	printer = g_thread_new("progress_printer", psearch_progress_thread, NULL);
+	printer_start(psearch_progress_thread);
 }
 
 void psearch_join(void)
@@ -1374,8 +1384,7 @@ void psearch_join(void)
 		search_processed = 0;
 		return;
 	}
-	g_thread_join(printer);
-	printer = NULL;
+	printer_stop();
 }
 
 void psearch_update_processed_count(unsigned int processed)

--- a/src/progress.c
+++ b/src/progress.c
@@ -917,10 +917,16 @@ static void *pscan_progress_thread(void * p)
 
 		/* Do not waste too much cpu */
 		usleep(1000 * (tty ? 100 : 1000));
-	} while (pdd.phase ? pdd.running
-			   : (!pscan.listing_completed
-			      || files_scanned != pscan.total_files_count
-			      || bytes_scanned != pscan.total_bytes_count));
+		/*
+		 * Both phases end when their producer says so, never when a counter
+		 * happens to match. The scan branch used to loop until
+		 * files_scanned/bytes_scanned reached the totals exactly; one file
+		 * counted into a total but not credited back (the invariant
+		 * test_skip_work_is_fully_credited pins) made that unreachable, so
+		 * this thread span in usleep forever and pscan_join() blocked in
+		 * g_thread_join() with all the actual work already finished.
+		 */
+	} while (pdd.phase ? pdd.running : pscan.scan_running);
 
 	return NULL;
 }
@@ -968,11 +974,14 @@ void pscan_run(void)
 	}
 
 	/* Will abort on failure */
+	pscan.scan_running = true;
 	printer = g_thread_new("progress_printer", pscan_progress_thread, NULL);
 }
 
 void pscan_join(bool continues)
 {
+	/* Tell the thread to stop before waiting for it, or we wait forever. */
+	pscan.scan_running = false;
 	g_thread_join(printer);
 	printer = NULL;
 
@@ -986,20 +995,26 @@ void pscan_join(bool continues)
 		return;
 	}
 
-	if (continues) {
-		/*
-		 * A live dedupe phase will keep drawing this same block, so leave
-		 * it in place - workers and all - and just refresh it once so
-		 * hashing shows ticked. Nothing is wiped or stranded above the
-		 * dedupe view, and the worker list never blinks away. Threads,
-		 * drawn_lines and the hidden cursor are kept for the dedupe phase
-		 * (it reuses the now-idle slots and redraws over this block).
-		 */
-		g_mutex_lock(&pscan.mutex);
-		print_progress();
-		g_mutex_unlock(&pscan.mutex);
+	/*
+	 * One final render, now that the counts are settled and hashing is
+	 * ticked. It is needed on every path, not just `continues`: the thread
+	 * now stops the moment the producer says so, which can be mid-tick, so
+	 * its last frame may show a bar short of 100%. The old counter-equality
+	 * exit gave that completeness as a side effect - at the cost of never
+	 * exiting at all when the counters could not meet.
+	 *
+	 * A live dedupe phase keeps drawing this same block, so leave it in
+	 * place - workers and all - rather than wiping it: nothing is stranded
+	 * above the dedupe view and the worker list never blinks away. Threads,
+	 * drawn_lines and the hidden cursor are kept for the dedupe phase, which
+	 * reuses the now-idle slots and redraws over this block.
+	 */
+	g_mutex_lock(&pscan.mutex);
+	print_progress();
+	g_mutex_unlock(&pscan.mutex);
+
+	if (continues)
 		return;
-	}
 
 	/*
 	 * No live dedupe follows (print-only / non-tty / -v): wipe the live area

--- a/src/progress.h
+++ b/src/progress.h
@@ -50,16 +50,6 @@ struct pscan_global {
 	_Atomic uint64_t	files_examined;	/* visited during listing */
 	_Atomic bool		listing_completed;
 
-	/* Whether the scan-phase progress thread should keep running. Set before
-	 * the thread starts, cleared by pscan_join() before it joins - the same
-	 * edge-triggered shutdown the dedupe phase already uses via pdd.running.
-	 * The thread must NOT decide to exit by comparing scanned counts against
-	 * totals: any file counted into the totals but never credited back leaves
-	 * them unequal forever, and the join then blocks for good (a real hang,
-	 * seen on slow/few-core machines). Only the producer knows when the work
-	 * is over, so only the producer ends the thread. */
-	_Atomic bool		scan_running;
-
 	/* Each thread tracks its own progress separately */
 	GMutex			mutex;
 	unsigned int		thread_count;

--- a/src/progress.h
+++ b/src/progress.h
@@ -50,6 +50,16 @@ struct pscan_global {
 	_Atomic uint64_t	files_examined;	/* visited during listing */
 	_Atomic bool		listing_completed;
 
+	/* Whether the scan-phase progress thread should keep running. Set before
+	 * the thread starts, cleared by pscan_join() before it joins - the same
+	 * edge-triggered shutdown the dedupe phase already uses via pdd.running.
+	 * The thread must NOT decide to exit by comparing scanned counts against
+	 * totals: any file counted into the totals but never credited back leaves
+	 * them unequal forever, and the join then blocks for good (a real hang,
+	 * seen on slow/few-core machines). Only the producer knows when the work
+	 * is over, so only the producer ends the thread. */
+	_Atomic bool		scan_running;
+
 	/* Each thread tracks its own progress separately */
 	GMutex			mutex;
 	unsigned int		thread_count;


### PR DESCRIPTION
## The bug

The scan-phase progress thread decided when to stop by comparing running sums against totals:

```c
} while (pdd.phase ? pdd.running
                   : (!pscan.listing_completed
                      || files_scanned != pscan.total_files_count
                      || bytes_scanned != pscan.total_bytes_count));
```

`total_files_count` is incremented when work is **queued** (`pscan_set_progress`); `files_scanned` is summed from per-thread counters credited on **completion** (`sum_scanned`). Any file counted into a total but never credited back leaves the two unable to ever meet — the thread spins in `usleep` forever, and `pscan_join()`'s `g_thread_join()` blocks for good, with the scan finished and every worker already exited.

That is a hang, not a slowdown, and it is not test-only: the same loop and the same join run in an ordinary `oans -rd --hashfile=...`.

## Evidence

CI hit it twice today — the TSAN leg on #134 and the ASAN leg on #137, both wedged in the progress tests (the ASAN one was killed by the `timeout-minutes` added in #135 rather than burning six hours). Reproduced locally, `eu-stack` on a wedged process:

```
TID main:  main -> scan_files -> pscan_join -> g_thread_join -> futex wait
TID other: pscan_progress_thread -> usleep
Threads: 2          <- all workers already exited
```

It needs a **small** machine. Twelve copies of the progress tests, each `taskset`-pinned to 2 cores, hang ~15% of the time; the same load unpinned on 32 cores never does. That is why it first read as CI flakiness — and why the machines most likely to hit it are exactly the small NAS/homelab boxes oans targets.

## The fix

The dedupe phase already had this right: `pdedupe_start()` sets `pdd.running`, `pdedupe_end()` clears it before joining. This gives the scan phase the same producer-driven shutdown via a new `pscan.scan_running`, so the condition becomes:

```c
} while (pdd.phase ? pdd.running : pscan.scan_running);
```

Only the producer knows when the work is over, so only the producer ends the thread. A progress thread should never be able to outlive the work it reports on, whatever the counters say.

**One consequence handled:** the old condition also guaranteed a final frame at 100%, since it could not exit before the counters said complete. Stopping on a flag can exit mid-tick, so `pscan_join()` now renders once after the join — on every non-JSON path rather than only when a dedupe phase follows, and placed after `stage_set(STAGE_HASH, ST_DONE)` so hashing still shows ticked. That also removes the duplicate render the `continues` branch used to do.

## Verification

Same reproducer, 72 runs per arm, run sequentially (never concurrently — they share scratch dirs and would contend for the CPU scarcity that is the variable under test):

| binary | runs | hangs | clean |
|---|---|---|---|
| pre-fix | 72 | **11** (15.3%) | 61 |
| fixed | 72 | **0** | 72 |

At a 15.3% baseline, zero hangs in 72 runs by chance is roughly 1 in 140,000.

`make check-all` passes all five legs locally: unit+integration, ASAN, UBSAN, TSAN, valgrind.

## Note on a regression test

I have not added one. The reproducer needs CPU pinning and ~12 concurrent processes to hit 15%, which is not something to put in the normal suite — it would be slow and still probabilistic. The `timeout-minutes` from #135 is the practical guard: this class of bug now surfaces as a bounded CI failure rather than an invisible stall. Happy to add a pinned stress target (`make stress-progress` or similar) if you want it available on demand.
