### PR TITLE
tsan: key the pool-lifetime edge on a token, not the pool pointer

### DIFF
--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -94,6 +94,12 @@ struct dedupe_work_item {
 };
 
 static GThreadPool	*dedupe_pool;
+/*
+ * Address only: the happens-before token workers publish on when they finish,
+ * collected in dedupe_phase_end(). Deliberately not dedupe_pool, which that
+ * teardown clears out from under a worker's tail. See tsan.h.
+ */
+static char		dedupe_pool_token;
 static GMutex		producer_mutex;	/* guards the in-flight list + counts */
 static GCond		producer_cond;	/* producer waits; workers/seal signal */
 static struct list_head	inflight_batches = LIST_HEAD_INIT(inflight_batches);
@@ -867,7 +873,7 @@ static void dedupe_worker(void *priv, void *unused [[maybe_unused]])
 {
 	oans_tsan_work_acquire(priv);
 	dedupe_worker_body(priv);
-	oans_tsan_work_done(dedupe_pool);
+	oans_tsan_work_done(&dedupe_pool_token);
 }
 
 /*
@@ -1161,6 +1167,7 @@ void dedupe_phase_end(void)
 	if (dedupe_pool) {
 		g_thread_pool_free(dedupe_pool, FALSE, TRUE);	/* waits for exit */
 		dedupe_pool = NULL;
+		oans_tsan_work_collect(&dedupe_pool_token);
 	}
 
 	pdedupe_end();

--- a/src/threads.c
+++ b/src/threads.c
@@ -43,7 +43,7 @@ static void pool_trampoline(gpointer item, gpointer user_data)
 
 	pool->worker(item, pool->worker_arg);
 
-	oans_tsan_work_done(pool->pool);
+	oans_tsan_work_done(&pool->tsan_token);
 	pool_work_done(pool);
 }
 
@@ -123,6 +123,7 @@ void register_cleanup(struct threads_pool *pool, void *function, void *ptr)
 void free_pool(struct threads_pool *pool)
 {
 	g_thread_pool_free(pool->pool, FALSE, TRUE);
+	oans_tsan_work_collect(&pool->tsan_token);
 
 	/* No worker can still be registering after that wait, but take the lock
 	 * register_cleanup() writes under anyway, so the ordering is stated in

--- a/src/threads.h
+++ b/src/threads.h
@@ -36,6 +36,12 @@ struct threads_cleanup_item {
 
 struct threads_pool {
 	GThreadPool *pool;
+	/*
+	 * Address only: the happens-before token workers publish on when they
+	 * finish, collected in free_pool(). Deliberately not `pool`, which that
+	 * teardown clears while a worker can still be in its tail. See tsan.h.
+	 */
+	char tsan_token;
 	struct threads_cleanup_item** items;
 	unsigned int item_count;
 	GMutex mutex; /* Protect the cleanup items operations */

--- a/src/tsan.h
+++ b/src/tsan.h
@@ -137,14 +137,27 @@ static inline void oans_tsan_work_acquire(void *item)
  * every task, so whatever the workers wrote is safely visible to the thread that
  * tears the pool down - but GLib recycles pool threads rather than joining them,
  * so TSAN sees no edge and calls the teardown's frees a race. Each worker
- * publishes on the pool once it is completely done (after any _cleanup_ handlers
- * have run, which is why this cannot simply be the worker's last statement), and
- * the free wrapper below collects it.
+ * publishes once it is completely done (after any _cleanup_ handlers have run,
+ * which is why this cannot simply be the worker's last statement), and the
+ * teardown collects it with oans_tsan_work_collect().
+ *
+ * Both sides name a *token* the caller owns, not the GThreadPool pointer.
+ * Teardown clears that pointer - dedupe_pool = NULL, pool->pool = NULL - and it
+ * does so while a worker can still be in its tail, so a worker reading it there
+ * is itself a data race. Worse, the read could land after the store and hand a
+ * NULL to a `if (pool)` guard, silently skipping the release: the edge would
+ * never be published and the teardown's frees would be reported as races
+ * *elsewhere*, which is exactly how this surfaced. A token is written once,
+ * never cleared, and lives as long as the pool's owner.
  */
-static inline void oans_tsan_work_done(void *pool)
+static inline void oans_tsan_work_done(void *token)
 {
-	if (pool)
-		__tsan_release(pool);
+	__tsan_release(token);
+}
+
+static inline void oans_tsan_work_collect(void *token)
+{
+	__tsan_acquire(token);
 }
 
 static inline void oans_tsan_pool_free(GThreadPool *pool, gboolean immediate,
@@ -169,7 +182,8 @@ static inline void oans_tsan_pool_free(GThreadPool *pool, gboolean immediate,
 #else	/* not a TSAN build: nothing to annotate */
 
 static inline void oans_tsan_work_acquire(void *item) { (void)item; }
-static inline void oans_tsan_work_done(void *pool) { (void)pool; }
+static inline void oans_tsan_work_done(void *token) { (void)token; }
+static inline void oans_tsan_work_collect(void *token) { (void)token; }
 
 #endif
 #endif	/* __OANS_TSAN_H__ */


### PR DESCRIPTION
GLib recycles pool threads rather than joining them, so TSAN sees no edge between a worker finishing and the teardown that frees what it wrote. The annotations bridge that gap: each worker releases when it is done, the teardown acquires. Both sides named the `GThreadPool` pointer.

That pointer is precisely what teardown clears:

```c
g_thread_pool_free(dedupe_pool, FALSE, TRUE);
dedupe_pool = NULL;              // run_dedupe.c:1163
```

and a worker can still be in its tail when that store lands, so reading it there to publish on is itself a data race:

```
Write of size 8 by main thread:   dedupe_phase_end run_dedupe.c:1163
Previous read of size 8 by T12:   dedupe_worker    run_dedupe.c:870
Location is global 'dedupe_pool'
```

The failure mode is worse than a spurious report. If the read lands after the store, the `if (pool)` guard sees NULL and skips the release entirely — the edge is never published, and the teardown's unrelated frees are reported as races *elsewhere*. That indirection is why this presented as a bug in the progress-slot teardown (`pscan_free_threads` freeing vs `pscan_finish_file` writing) rather than here.

Both sides now name a token the caller owns — a one-byte static in `run_dedupe.c`, a field in `struct threads_pool` — written once, never cleared, outliving every worker. `oans_tsan_work_collect()` is the acquire half, so the edge no longer rides on `g_thread_pool_free()`'s argument.

`threads.c` had the same latent flaw (`pool->pool = NULL` in `free_pool()`, read at `pool_trampoline()`) and is fixed alongside it. It simply had not been caught yet.

**Scope:** ThreadSanitizer builds only. Both helpers are empty inlines otherwise (`src/tsan.h`), so nothing changes for users.

### How it was found

Running the integration suite in parallel (#139) loads the box enough to lose this race reliably. It is invisible to a serial suite, which is why CI has been green.

| | result |
|---|---|
| before, 3 parallel runs | 3/3 failed, 14+ race reports |
| after, 4 parallel runs | 4/4 clean, 0 race reports |

Same binary at `-j 1` passed 3/3 both before and after, confirming it is load-exposed rather than a regression.

`scripts/verify.sh` passes, and the serial TSAN leg (`make integration SANITIZE=thread`) passes at 120 tests.

One dead end worth recording: capturing `dedupe_pool` into a local at worker *entry* does not work — the race just moves to the entry read (30 failures instead of 2), because a worker can be at its first instruction while the main thread clears the global. The handle cannot be read from shared mutable storage at any point, which is what motivated the token.

#139 should merge after this; it is what makes the TSAN leg run under this load.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4)_