### PR TITLE
ci: cache apt packages between runs

### DIFF
--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -1,0 +1,35 @@
+name: Install apt dependencies
+description: >-
+  Install a leg's build dependencies, reusing .debs cached from a previous run.
+  apt-get was 15-37s in every job, most of it `apt-get update`; a cache hit
+  skips it entirely.
+
+inputs:
+  leg:
+    description: Which .github/apt/<leg>.txt to install alongside base.txt.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # The cache must be keyed on the image, or a runner upgrade would reuse
+    # .debs built against the old one. ImageOS/ImageVersion are set in the
+    # runner's environment but are NOT visible to `${{ env.* }}` in a workflow
+    # expression - keying on those directly silently produced `apt---build-...`
+    # and pinned nothing. Read them in a shell, where they do exist, and fall
+    # back to /etc/os-release so the key is never image-blind.
+    - id: image
+      shell: bash
+      run: |
+        os="${ImageOS:-$(. /etc/os-release && echo "$ID$VERSION_ID")}"
+        echo "id=${os}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.apt-archives
+        key: apt-${{ steps.image.outputs.id }}-${{ hashFiles('.github/apt/base.txt', format('.github/apt/{0}.txt', inputs.leg)) }}
+
+    - shell: bash
+      run: |
+        .github/scripts/apt-install.sh \
+          .github/apt/base.txt ".github/apt/${{ inputs.leg }}.txt"

--- a/.github/apt/base.txt
+++ b/.github/apt/base.txt
@@ -1,0 +1,12 @@
+# Dependencies every CI leg needs. Per-leg extras live in build.txt,
+# valgrind.txt and sanitizers.txt; the installer takes both files, and the
+# cache key hashes both, so editing either invalidates the cached .debs.
+pkg-config
+libsqlite3-dev
+libglib2.0-dev
+libblkid-dev
+libmount-dev
+uuid-dev
+libbsd-dev
+libxxhash-dev
+btrfs-progs

--- a/.github/apt/build.txt
+++ b/.github/apt/build.txt
@@ -1,0 +1,15 @@
+# Packages for the build-and-test matrix. One per line; blank lines and
+# # comments ignored. The cache key hashes this file, so editing it
+# invalidates the cached .debs - which is the point.
+build-essential
+clang
+pkg-config
+libsqlite3-dev
+libglib2.0-dev
+libblkid-dev
+libmount-dev
+uuid-dev
+libbsd-dev
+libxxhash-dev
+btrfs-progs
+xfsprogs

--- a/.github/apt/build.txt
+++ b/.github/apt/build.txt
@@ -1,15 +1,5 @@
-# Packages for the build-and-test matrix. One per line; blank lines and
-# # comments ignored. The cache key hashes this file, so editing it
-# invalidates the cached .debs - which is the point.
+# Extras for the build-and-test matrix, on top of base.txt. Both compilers,
+# and xfs because that matrix covers both scratch filesystems.
 build-essential
 clang
-pkg-config
-libsqlite3-dev
-libglib2.0-dev
-libblkid-dev
-libmount-dev
-uuid-dev
-libbsd-dev
-libxxhash-dev
-btrfs-progs
 xfsprogs

--- a/.github/apt/sanitizers.txt
+++ b/.github/apt/sanitizers.txt
@@ -1,0 +1,13 @@
+# Packages for the sanitizer legs (clang only). See build.txt for the format.
+clang
+llvm
+libclang-rt-dev
+pkg-config
+libsqlite3-dev
+libglib2.0-dev
+libblkid-dev
+libmount-dev
+uuid-dev
+libbsd-dev
+libxxhash-dev
+btrfs-progs

--- a/.github/apt/sanitizers.txt
+++ b/.github/apt/sanitizers.txt
@@ -1,13 +1,5 @@
-# Packages for the sanitizer legs (clang only). See build.txt for the format.
+# Extras for the sanitizer legs, on top of base.txt. clang only: gcc has no
+# ThreadSanitizer support for this configuration.
 clang
 llvm
 libclang-rt-dev
-pkg-config
-libsqlite3-dev
-libglib2.0-dev
-libblkid-dev
-libmount-dev
-uuid-dev
-libbsd-dev
-libxxhash-dev
-btrfs-progs

--- a/.github/apt/valgrind.txt
+++ b/.github/apt/valgrind.txt
@@ -1,12 +1,3 @@
-# Packages for the valgrind leg. See build.txt for the format.
+# Extras for the valgrind leg, on top of base.txt.
 build-essential
-pkg-config
-libsqlite3-dev
-libglib2.0-dev
-libblkid-dev
-libmount-dev
-uuid-dev
-libbsd-dev
-libxxhash-dev
-btrfs-progs
 valgrind

--- a/.github/apt/valgrind.txt
+++ b/.github/apt/valgrind.txt
@@ -1,0 +1,12 @@
+# Packages for the valgrind leg. See build.txt for the format.
+build-essential
+pkg-config
+libsqlite3-dev
+libglib2.0-dev
+libblkid-dev
+libmount-dev
+uuid-dev
+libbsd-dev
+libxxhash-dev
+btrfs-progs
+valgrind

--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,73 +1,62 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
-# Install a package list from .github/apt/, reusing .debs cached by a previous
-# run where possible.
+# Install the packages named in one or more .github/apt/*.txt lists, reusing
+# .debs cached by a previous run where possible.
 #
-# The workflow restores $APT_CACHE_DIR with actions/cache before calling this,
-# keyed on the runner image *and* the hash of the list file - so a cache hit
-# means the exact same packages were resolved on the exact same image. That is
-# what makes the fast path safe: the cache holds every .deb apt downloaded last
-# time, including dependencies, so dpkg can install them straight from disk
-# with no `apt-get update` and no network at all.
-#
-# apt-get was taking 15-37s per job, which is most of the wall time of the
-# short legs (build (xfs, gcc) spent 28s of 33s here) and ~14% of the valgrind
-# leg that sets CI's critical path.
-#
-# Any doubt falls back to plain apt-get: a miss, a stale cache, or a dpkg that
-# will not take the set. The fallback is the old behaviour exactly, so the
-# worst case is the speed we had before, never a broken job.
+# .github/actions/apt-deps restores $APT_CACHE_DIR first, keyed on the runner
+# image and the hash of these same lists - so a cache hit means this exact set
+# was already resolved on this exact image, and dpkg can install it straight
+# from disk. That skips `apt-get update`, which is where most of the 15-37s
+# this replaces was going.
 set -euo pipefail
 
-list="${1:?usage: apt-install.sh <package-list-file>}"
+if [ $# -eq 0 ]; then
+    echo "apt-install: usage: apt-install.sh <package-list-file>..." >&2
+    exit 1
+fi
+
 cache="${APT_CACHE_DIR:-$HOME/.apt-archives}"
-
-# apt insists on a partial/ subdir inside any archives dir it writes to.
-mkdir -p "$cache/partial"
-
-mapfile -t pkgs < <(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$list")
+mapfile -t pkgs < <(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$@")
 if [ ${#pkgs[@]} -eq 0 ]; then
-    echo "no packages listed in $list" >&2
+    echo "apt-install: no packages listed in $*" >&2
     exit 1
 fi
 
 all_present() {
-    local pkg
-    for pkg in "${pkgs[@]}"; do
-        dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null \
-            | grep -q "^install ok installed$" || return 1
-    done
+    local installed
+    installed=$(dpkg-query -W -f='${Status}\n' "${pkgs[@]}" 2>/dev/null |
+                grep -c '^install ok installed$') || true
+    [ "$installed" -eq ${#pkgs[@]} ]
 }
 
 install_from_apt() {
     sudo apt-get update
-    # -f first: a failed fast path can leave packages unconfigured, and this is
-    # the only place with the package lists needed to repair that.
-    sudo apt-get install -y -f
     # apt drops privileges to _apt to download, so that user needs the archive
-    # dir; without this it warns and falls back to fetching as root.
-    sudo chown -R _apt:root "$cache"
+    # dir; without this it warns and refetches as root. It also insists on a
+    # partial/ subdir in any archive dir it writes to.
+    sudo mkdir -p "$cache/partial"
+    sudo chown _apt:root "$cache" "$cache/partial"
     sudo apt-get install -y --no-install-recommends \
         -o Dir::Cache::archives="$cache" "${pkgs[@]}"
     # ... and actions/cache saves as the runner user, which cannot read those.
     sudo chown -R "$(id -u):$(id -g)" "$cache"
 }
 
-if compgen -G "$cache/*.deb" >/dev/null; then
-    count=$(find "$cache" -maxdepth 1 -name '*.deb' | wc -l)
-    echo "apt cache hit: installing $count cached packages"
+shopt -s nullglob
+debs=("$cache"/*.deb)
+if [ ${#debs[@]} -gt 0 ]; then
+    echo "apt-install: cache hit, installing ${#debs[@]} cached packages"
     # dpkg succeeding is not the question - a partial cache can install cleanly
     # and still leave a package the build needs missing, which would surface far
     # away as a confusing compile error. Ask directly instead.
-    if sudo dpkg --install --skip-same-version "$cache"/*.deb && all_present; then
+    if sudo dpkg --install --skip-same-version "${debs[@]}" && all_present; then
         exit 0
     fi
-    echo "cached packages did not satisfy the set; falling back to apt-get" >&2
+    echo "apt-install: cached packages did not satisfy the set, using apt-get" >&2
+    # Only here can a half-applied dpkg run have left packages unconfigured,
+    # and only after `apt-get update` are the lists present to repair it.
+    sudo apt-get update
+    sudo apt-get install -y -f
 fi
 
 install_from_apt
-
-if ! all_present; then
-    echo "packages still missing after apt-get; see the list above" >&2
-    exit 1
-fi

--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Install a package list from .github/apt/, reusing .debs cached by a previous
+# run where possible.
+#
+# The workflow restores $APT_CACHE_DIR with actions/cache before calling this,
+# keyed on the runner image *and* the hash of the list file - so a cache hit
+# means the exact same packages were resolved on the exact same image. That is
+# what makes the fast path safe: the cache holds every .deb apt downloaded last
+# time, including dependencies, so dpkg can install them straight from disk
+# with no `apt-get update` and no network at all.
+#
+# apt-get was taking 15-37s per job, which is most of the wall time of the
+# short legs (build (xfs, gcc) spent 28s of 33s here) and ~14% of the valgrind
+# leg that sets CI's critical path.
+#
+# Any doubt falls back to plain apt-get: a miss, a stale cache, or a dpkg that
+# will not take the set. The fallback is the old behaviour exactly, so the
+# worst case is the speed we had before, never a broken job.
+set -euo pipefail
+
+list="${1:?usage: apt-install.sh <package-list-file>}"
+cache="${APT_CACHE_DIR:-$HOME/.apt-archives}"
+
+# apt insists on a partial/ subdir inside any archives dir it writes to.
+mkdir -p "$cache/partial"
+
+mapfile -t pkgs < <(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$list")
+if [ ${#pkgs[@]} -eq 0 ]; then
+    echo "no packages listed in $list" >&2
+    exit 1
+fi
+
+all_present() {
+    local pkg
+    for pkg in "${pkgs[@]}"; do
+        dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null \
+            | grep -q "^install ok installed$" || return 1
+    done
+}
+
+install_from_apt() {
+    sudo apt-get update
+    # -f first: a failed fast path can leave packages unconfigured, and this is
+    # the only place with the package lists needed to repair that.
+    sudo apt-get install -y -f
+    # apt drops privileges to _apt to download, so that user needs the archive
+    # dir; without this it warns and falls back to fetching as root.
+    sudo chown -R _apt:root "$cache"
+    sudo apt-get install -y --no-install-recommends \
+        -o Dir::Cache::archives="$cache" "${pkgs[@]}"
+    # ... and actions/cache saves as the runner user, which cannot read those.
+    sudo chown -R "$(id -u):$(id -g)" "$cache"
+}
+
+if compgen -G "$cache/*.deb" >/dev/null; then
+    count=$(find "$cache" -maxdepth 1 -name '*.deb' | wc -l)
+    echo "apt cache hit: installing $count cached packages"
+    # dpkg succeeding is not the question - a partial cache can install cleanly
+    # and still leave a package the build needs missing, which would surface far
+    # away as a confusing compile error. Ask directly instead.
+    if sudo dpkg --install --skip-same-version "$cache"/*.deb && all_present; then
+        exit 0
+    fi
+    echo "cached packages did not satisfy the set; falling back to apt-get" >&2
+fi
+
+install_from_apt
+
+if ! all_present; then
+    echo "packages still missing after apt-get; see the list above" >&2
+    exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # apt was 15-37s per job. The cache key pins the runner image and the
-      # package list, so a hit means the same packages on the same image; the
-      # installer then works straight from the cached .debs. See the script.
-      - name: Restore apt cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/apt-deps
         with:
-          path: ~/.apt-archives
-          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-build-${{ hashFiles('.github/apt/build.txt') }}
-
-      - name: Install build dependencies
-        run: .github/scripts/apt-install.sh .github/apt/build.txt
+          leg: build
 
       # Guards the long-path invariant (#117): a syscall taking a scanned
       # file's path silently ENAMETOOLONGs and drops the file, exit 0.
@@ -105,17 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # apt was 15-37s per job. The cache key pins the runner image and the
-      # package list, so a hit means the same packages on the same image; the
-      # installer then works straight from the cached .debs. See the script.
-      - name: Restore apt cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/apt-deps
         with:
-          path: ~/.apt-archives
-          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-valgrind-${{ hashFiles('.github/apt/valgrind.txt') }}
-
-      - name: Install build dependencies
-        run: .github/scripts/apt-install.sh .github/apt/valgrind.txt
+          leg: valgrind
 
       - name: Build
         run: make
@@ -164,17 +148,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # apt was 15-37s per job. The cache key pins the runner image and the
-      # package list, so a hit means the same packages on the same image; the
-      # installer then works straight from the cached .debs. See the script.
-      - name: Restore apt cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/apt-deps
         with:
-          path: ~/.apt-archives
-          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-sanitizers-${{ hashFiles('.github/apt/sanitizers.txt') }}
-
-      - name: Install build dependencies
-        run: .github/scripts/apt-install.sh .github/apt/sanitizers.txt
+          leg: sanitizers
 
       # Newer runners default vm.mmap_rnd_bits to 32, which clang's ASAN shadow
       # mapping can't accommodate ("Shadow memory range interleaves..."). 28 is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # apt was 15-37s per job. The cache key pins the runner image and the
+      # package list, so a hit means the same packages on the same image; the
+      # installer then works straight from the cached .debs. See the script.
+      - name: Restore apt cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.apt-archives
+          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-build-${{ hashFiles('.github/apt/build.txt') }}
+
       - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential clang pkg-config \
-            libsqlite3-dev libglib2.0-dev libblkid-dev libmount-dev \
-            uuid-dev libbsd-dev libxxhash-dev \
-            btrfs-progs xfsprogs
+        run: .github/scripts/apt-install.sh .github/apt/build.txt
 
       # Guards the long-path invariant (#117): a syscall taking a scanned
       # file's path silently ENAMETOOLONGs and drops the file, exit 0.
@@ -102,14 +105,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # apt was 15-37s per job. The cache key pins the runner image and the
+      # package list, so a hit means the same packages on the same image; the
+      # installer then works straight from the cached .debs. See the script.
+      - name: Restore apt cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.apt-archives
+          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-valgrind-${{ hashFiles('.github/apt/valgrind.txt') }}
+
       - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config \
-            libsqlite3-dev libglib2.0-dev libblkid-dev libmount-dev \
-            uuid-dev libbsd-dev libxxhash-dev \
-            btrfs-progs valgrind
+        run: .github/scripts/apt-install.sh .github/apt/valgrind.txt
 
       - name: Build
         run: make
@@ -158,14 +164,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # apt was 15-37s per job. The cache key pins the runner image and the
+      # package list, so a hit means the same packages on the same image; the
+      # installer then works straight from the cached .debs. See the script.
+      - name: Restore apt cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.apt-archives
+          key: apt-${{ env.ImageOS }}-${{ env.ImageVersion }}-sanitizers-${{ hashFiles('.github/apt/sanitizers.txt') }}
+
       - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            clang llvm libclang-rt-dev pkg-config \
-            libsqlite3-dev libglib2.0-dev libblkid-dev libmount-dev \
-            uuid-dev libbsd-dev libxxhash-dev \
-            btrfs-progs
+        run: .github/scripts/apt-install.sh .github/apt/sanitizers.txt
 
       # Newer runners default vm.mmap_rnd_bits to 32, which clang's ASAN shadow
       # mapping can't accommodate ("Shadow memory range interleaves..."). 28 is


### PR DESCRIPTION
Follow-up to #139. With the suite parallel, `apt-get` is now a visible share of every job: 15-37s, which on the short legs is most of the wall time — `build (xfs, gcc)` spent **28s installing packages and 5s testing** — and ~14% of the valgrind leg that sets CI's critical path.

Each job restores `~/.apt-archives` with `actions/cache` before installing. The key pins the runner image *and* the hash of the package list, so a hit means the same packages resolved against the same image. The installer then runs `dpkg` straight from the cached `.debs` — no `apt-get update`, no network. apt caches the dependencies it downloaded too, so the set is self-contained.

Package lists move to `.github/apt/*.txt`, one per leg. They have to be files rather than inline shell for the cache key to hash them. **The three sets are unchanged**, verified token by token against the previous workflow.

### Two things the fast path has to get right

- **`dpkg` succeeding does not mean the build has what it needs.** A partial cache can install cleanly and still leave a required package missing, surfacing later as a confusing compile error. The requested packages are checked explicitly with `dpkg-query`, and any shortfall falls back to `apt-get`.
- **apt drops privileges to `_apt` to download**, so the archive dir is chowned to it before the install and back to the runner user afterwards, since `actions/cache` saves as that user. Without this apt warns and refetches as root.

Every path falls back to plain `apt-get` on any doubt — cache miss, stale cache, or a `dpkg` that will not take the set — so the worst case is the speed we have today, never a broken job.

### Testing

Run against Ubuntu 24.04, the same family as the runners, exercising all three paths:

| scenario | result |
|---|---|
| cold cache | installs via apt, populates cache (incl. dependency) |
| warm cache | installs from disk in **0.2s**, no network |
| deliberately partial cache | detected, falls back to apt-get, recovers |

### Expected effect

**No change on the first run** — it populates the cache. After that, roughly 25s off each job. Since CI wall-clock is set by the valgrind leg, end-to-end gain is **~10%**; the rest shows up as runner-minutes rather than latency.

Worth being clear that this is the smaller of the two remaining levers. Valgrind's integration step is still 182s of its 226s, and that — not apt — is what CI wall-clock is now made of.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxN8SYwbj24nAyAAsPRdm4)_