### PR TITLE
scan: hash sparse files whose trailing hole ends at an unaligned EOF

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2109,8 +2109,18 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 			break;
 	}
 
+	/*
+	 * The size moved under us while we were reading, so the digest we just
+	 * computed describes a state that no longer exists. Drop it rather than
+	 * store a hash that matches nothing. Routinely hit on files that are
+	 * still being written (downloads, torrents, logs, VM images), so say so
+	 * and say that it resolves itself - "changed" alone reads like damage.
+	 */
 	if (ctxt.off != ctxt.filesize) {
-		eprintf("file %s changed\n", file->path);
+		eprintf("%s: size changed while hashing (read %"PRIu64" bytes, "
+			"expected %"PRIu64"). Skipped - it is probably still "
+			"being written; the next run will hash it.\n",
+			file->path, (uint64_t)ctxt.off, (uint64_t)ctxt.filesize);
 		return;
 	}
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1547,7 +1547,19 @@ static size_t hole_run_length(struct scan_ctxt *ctxt)
 	if (!block_is_hole(e, ctxt->off))
 		return 0;			/* block holds some data */
 
-	next_data = e ? e->fe_logical : ctxt->filesize;
+	/*
+	 * A trailing hole (no extent follows) runs to EOF, which need not be
+	 * block-aligned. Flooring here would leave the final partial block
+	 * unconsumed: nothing can read it (it maps no data, so fill_buffer caps
+	 * the read at zero bytes), the loop would exit with off < filesize, and
+	 * the caller would report the file as "changed while hashing" and skip
+	 * it - permanently, on every run. Only an *interior* hole floors, so
+	 * that the block holding the first data byte is read whole.
+	 */
+	if (!e)
+		return ctxt->filesize - ctxt->off;
+
+	next_data = e->fe_logical;
 	/* Stop at the block that first contains data (floor to block size). */
 	return (next_data / blocksize) * blocksize - ctxt->off;
 }

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1542,7 +1542,6 @@ static size_t hole_run_length(struct scan_ctxt *ctxt)
 {
 	struct fiemap_extent *e = get_extent(ctxt->fiemap, ctxt->off,
 					     &ctxt->extent_cursor);
-	size_t next_data;
 
 	if (!block_is_hole(e, ctxt->off))
 		return 0;			/* block holds some data */
@@ -1559,9 +1558,8 @@ static size_t hole_run_length(struct scan_ctxt *ctxt)
 	if (!e)
 		return ctxt->filesize - ctxt->off;
 
-	next_data = e->fe_logical;
 	/* Stop at the block that first contains data (floor to block size). */
-	return (next_data / blocksize) * blocksize - ctxt->off;
+	return (e->fe_logical / blocksize) * blocksize - ctxt->off;
 }
 
 /*
@@ -2124,9 +2122,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	/*
 	 * The size moved under us while we were reading, so the digest we just
 	 * computed describes a state that no longer exists. Drop it rather than
-	 * store a hash that matches nothing. Routinely hit on files that are
-	 * still being written (downloads, torrents, logs, VM images), so say so
-	 * and say that it resolves itself - "changed" alone reads like damage.
+	 * store a hash that matches nothing.
 	 */
 	if (ctxt.off != ctxt.filesize) {
 		eprintf("%s: size changed while hashing (read %"PRIu64" bytes, "

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -182,6 +182,15 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
  * floods the console, so the default view is one aggregate line in the final
  * summary and the per-file detail moved behind -v.
  */
+/*
+ * Two distinct conditions, deliberately counted apart: dest_changed is our own
+ * pre-flight size check (the file moved since the scan), dest_differs is the
+ * kernel's byte-compare verdict on a pair we believed identical. They used to
+ * share one counter reported as "changed since scan", which named the wrong
+ * cause for every kernel mismatch - and a mismatch is a property of the pair,
+ * not of the file we happen to name.
+ */
+static _Atomic uint64_t dedupe_dest_changed;
 static _Atomic uint64_t dedupe_dest_differs;
 static _Atomic uint64_t dedupe_dest_errors;
 /* Destinations skipped because they already shared all storage with the
@@ -216,7 +225,8 @@ static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 			continue;
 
 		if (target_status == FILE_DEDUPE_RANGE_DIFFERS) {
-			status_str = "data changed";
+			status_str = "content does not match the target "
+				     "(kernel byte-compare); left untouched";
 			atomic_fetch_add(&dedupe_dest_differs, 1);
 		} else {
 			if (target_status < 0)
@@ -560,9 +570,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			    (whole_file_dedup ?
 			     (uint64_t)st.st_size != len :
 			     (uint64_t)st.st_size + 4095 < extent->e_loff + len)) {
-				atomic_fetch_add(&dedupe_dest_differs, 1);
-				vprintf("%s: changed since scan (size %llu, "
-					"expected %llu). Skipping dedupe.\n",
+				atomic_fetch_add(&dedupe_dest_changed, 1);
+				vprintf("%s: size changed since the scan (now "
+					"%llu bytes, needs at least %llu). "
+					"Skipped - the next scan will re-hash "
+					"it.\n",
 					extent->e_file->filename,
 					(unsigned long long)st.st_size,
 					(unsigned long long)(extent->e_loff + len));
@@ -1186,12 +1198,32 @@ void dedupe_phase_end(void)
 			printf("  %sElapsed%s        %.1fs\n",
 			       col_dim, col_reset, elapsed_seconds());
 		}
-		if (dedupe_dest_differs || dedupe_dest_errors)
-			printf("  %sNot deduped%s    %lu changed since scan, "
-			       "%lu failed (rerun with -v for detail)\n",
-			       col_dim, col_reset,
-			       (uint64_t)dedupe_dest_differs,
-			       (uint64_t)dedupe_dest_errors);
+		if (dedupe_dest_changed || dedupe_dest_differs ||
+		    dedupe_dest_errors) {
+			/*
+			 * Name only the causes that actually occurred. Three
+			 * numbers where two are usually 0 reads as noise and
+			 * buries the one that matters.
+			 */
+			const char *sep = "";
+
+			printf("  %sNot deduped%s    ", col_dim, col_reset);
+			if (dedupe_dest_changed) {
+				printf("%s%lu changed since scan", sep,
+				       (uint64_t)dedupe_dest_changed);
+				sep = ", ";
+			}
+			if (dedupe_dest_differs) {
+				printf("%s%lu content mismatch", sep,
+				       (uint64_t)dedupe_dest_differs);
+				sep = ", ";
+			}
+			if (dedupe_dest_errors)
+				printf("%s%lu failed", sep,
+				       (uint64_t)dedupe_dest_errors);
+			printf(" %s(rerun with -v for detail)%s\n",
+			       col_dim, col_reset);
+		}
 		if (dedupe_dest_already_shared)
 			printf("  %sAlready shared%s %lu file%s skipped (no work "
 			       "needed)\n", col_dim, col_reset,

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -180,15 +180,11 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
  * Per-destination failures, tallied across the whole phase. A single bad
  * group can have a hundred failing destinations; printing one line each
  * floods the console, so the default view is one aggregate line in the final
- * summary and the per-file detail moved behind -v.
- */
-/*
- * Two distinct conditions, deliberately counted apart: dest_changed is our own
- * pre-flight size check (the file moved since the scan), dest_differs is the
- * kernel's byte-compare verdict on a pair we believed identical. They used to
- * share one counter reported as "changed since scan", which named the wrong
- * cause for every kernel mismatch - and a mismatch is a property of the pair,
- * not of the file we happen to name.
+ * summary and the per-file detail moved behind -v. dest_changed is our own
+ * pre-flight size check (this file moved since the scan); dest_differs is the
+ * kernel's byte-compare verdict on a pair we believed identical - a property
+ * of the pair, not of the file we happen to name. Different causes, counted
+ * apart so the summary can name the right one.
  */
 static _Atomic uint64_t dedupe_dest_changed;
 static _Atomic uint64_t dedupe_dest_differs;
@@ -1198,29 +1194,35 @@ void dedupe_phase_end(void)
 			printf("  %sElapsed%s        %.1fs\n",
 			       col_dim, col_reset, elapsed_seconds());
 		}
-		if (dedupe_dest_changed || dedupe_dest_differs ||
-		    dedupe_dest_errors) {
-			/*
-			 * Name only the causes that actually occurred. Three
-			 * numbers where two are usually 0 reads as noise and
-			 * buries the one that matters.
-			 */
+		/*
+		 * Name only the causes that actually occurred: three numbers
+		 * where two are usually 0 reads as noise and buries the one
+		 * that matters.
+		 */
+		const struct {
+			uint64_t n;
+			const char *what;
+		} causes[] = {
+			{ dedupe_dest_changed, "changed since scan" },
+			{ dedupe_dest_differs, "content mismatch" },
+			{ dedupe_dest_errors,  "failed" },
+		};
+		uint64_t not_deduped = 0;
+
+		for (unsigned int i = 0; i < ARRAY_SIZE(causes); i++)
+			not_deduped += causes[i].n;
+
+		if (not_deduped) {
 			const char *sep = "";
 
 			printf("  %sNot deduped%s    ", col_dim, col_reset);
-			if (dedupe_dest_changed) {
-				printf("%s%lu changed since scan", sep,
-				       (uint64_t)dedupe_dest_changed);
+			for (unsigned int i = 0; i < ARRAY_SIZE(causes); i++) {
+				if (!causes[i].n)
+					continue;
+				printf("%s%"PRIu64" %s", sep, causes[i].n,
+				       causes[i].what);
 				sep = ", ";
 			}
-			if (dedupe_dest_differs) {
-				printf("%s%lu content mismatch", sep,
-				       (uint64_t)dedupe_dest_differs);
-				sep = ", ";
-			}
-			if (dedupe_dest_errors)
-				printf("%s%lu failed", sep,
-				       (uint64_t)dedupe_dest_errors);
 			printf(" %s(rerun with -v for detail)%s\n",
 			       col_dim, col_reset);
 		}

--- a/tests/integration/test_sparse.py
+++ b/tests/integration/test_sparse.py
@@ -49,12 +49,10 @@ class SparseTest(DuperemoveTest):
             "trailing-hole file digested (not abandoned)")
 
     def test_trailing_hole_to_unaligned_eof_scans(self):
-        # Regression: a trailing hole whose EOF is NOT block-aligned. The hole
-        # run was floored to a block boundary, leaving a final partial block
-        # that maps no data - nothing could read it, so the loop exited with
-        # off < filesize and the file was reported "changed while hashing" and
-        # skipped, on every run, forever. The aligned case above never saw it.
-        # Shape taken from a real 2 GiB sparse torrent stub.
+        # Same as above but with an EOF that is NOT block-aligned, the shape of
+        # a real sparse torrent stub. hole_run_length() floored the hole run to
+        # a block, so the final partial block was never consumed and the file
+        # was reported "changed while hashing" and skipped, forever.
         self.make_trailing_hole("tree/th", os.urandom(200000),
                                 4 * 1024 * 1024 + 91943)
         self.scan(self.path("tree"))
@@ -69,8 +67,7 @@ class SparseTest(DuperemoveTest):
     def test_hole_only_file_unaligned_eof(self):
         # The same flooring bug with no data at all: a fully sparse file whose
         # size is not a multiple of the block size.
-        p = self.write("tree/hole", b"")
-        os.truncate(p, 8 * 1024 * 1024 + 1)
+        self.make_trailing_hole("tree/hole", b"", 8 * 1024 * 1024 + 1)
         self.scan(self.path("tree"))
         self.assertDmOk()
         self.assertNotIn("changed", self.out)

--- a/tests/integration/test_sparse.py
+++ b/tests/integration/test_sparse.py
@@ -48,6 +48,37 @@ class SparseTest(DuperemoveTest):
             0, self.hf_scalar("select count(*) from files where digest is null"),
             "trailing-hole file digested (not abandoned)")
 
+    def test_trailing_hole_to_unaligned_eof_scans(self):
+        # Regression: a trailing hole whose EOF is NOT block-aligned. The hole
+        # run was floored to a block boundary, leaving a final partial block
+        # that maps no data - nothing could read it, so the loop exited with
+        # off < filesize and the file was reported "changed while hashing" and
+        # skipped, on every run, forever. The aligned case above never saw it.
+        # Shape taken from a real 2 GiB sparse torrent stub.
+        self.make_trailing_hole("tree/th", os.urandom(200000),
+                                4 * 1024 * 1024 + 91943)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertNotIn("changed", self.out)
+        self.assertEqual(1, self.hf_count("files"),
+                         "unaligned trailing-hole file recorded")
+        self.assertEqual(
+            0, self.hf_scalar("select count(*) from files where digest is null"),
+            "unaligned trailing-hole file digested (not abandoned)")
+
+    def test_hole_only_file_unaligned_eof(self):
+        # The same flooring bug with no data at all: a fully sparse file whose
+        # size is not a multiple of the block size.
+        p = self.write("tree/hole", b"")
+        os.truncate(p, 8 * 1024 * 1024 + 1)
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertNotIn("changed", self.out)
+        self.assertEqual(1, self.hf_count("files"), "hole-only file recorded")
+        self.assertEqual(
+            0, self.hf_scalar("select count(*) from files where digest is null"),
+            "hole-only file still digested")
+
     @requires_reflink
     def test_trailing_hole_dedupes_and_preserves_data(self):
         data = os.urandom(240000)


### PR DESCRIPTION
## The bug

A file ending in a hole was **silently and permanently skipped** — on every run, forever — if its size was not a multiple of the hashing block size. It was reported as having changed while being read, which was not true:

```
Show.S01E04.mkv: size changed while hashing (read 2013921280 bytes, expected 2014013223)
```

Nothing had changed. The file was a 2 GiB sparse stub with 484 KiB actually allocated and a month-old mtime. The read stopped exactly on a 128 KiB block boundary, 91943 bytes short of EOF — one partial block.

`hole_run_length()` floors a hole run to a block boundary. That is right for an **interior** hole, where the block holding the first data byte must still be read whole, but wrong for a **trailing** hole, where no data follows. Flooring left a final partial block that maps no data, so `fill_buffer()` capped its read at zero bytes, the loop exited with `off < filesize`, and `csum_whole_file()` concluded the file had changed under it and threw the digest away. Nothing was stored, so the next run repeated it.

It hits exactly what sparseness is used for: preallocated torrent stubs, VM images, database files.

Only the `e == NULL` (trailing) branch changes. When EOF happens to be block-aligned the new expression is numerically identical to the old — which is why existing coverage passed: `test_trailing_hole_scans` truncates to 4 MiB, exactly 32 blocks.

### Why here and not at the EOF check

Relaxing `if (ctxt.off != ctxt.filesize)` would only silence the message. The fix makes `off` legitimately reach `filesize` **and** folds the true `{offset, length}` descriptor into the running checksum. Tolerating a short read instead would leave the final partial hole unaccounted, so two sparse files identical up to the last block boundary but differing in size would produce the same digest.

## Message clarity (how the bug became findable)

The old text was `file <path> changed` — no reason, no numbers, no consequence. It was the numbers in the reworded message that identified the block-boundary stop and led to the root cause.

Three different conditions used the word "changed" with three different meanings. They now each state what was observed and what follows from it.

**A counter was also reporting the wrong cause.** `dedupe_dest_differs` was incremented both by our own pre-flight size check and by the kernel's `FILE_DEDUPE_RANGE_DIFFERS` verdict, then printed as one number labelled `changed since scan` — so every kernel byte-compare mismatch was attributed to a file change that had not happened. A mismatch is also a property of the *pair*, not of the destination we happen to name. They are now counted apart, and the summary names only the causes that occurred:

```
  Not deduped    3 changed since scan, 2 content mismatch, 1 failed (rerun with -v for detail)
```

Counters are deliberately **not** exported to `--json`/`run_history` here — that is #145's job and doing it now would collide.

## Testing

Two regression tests in `test_sparse.py`: an unaligned trailing hole, and a fully-sparse unaligned file. I verified both **fail** without the fix and pass with it, and that every pre-existing test passes either way.

Also verified against the real file that triggered this (read-only `-r` scan): warning gone, file hashed and recorded.

`scripts/verify.sh` passes — build with warnings-as-failure, 122 tests, valgrind scan+dedupe+replay smoke.

A `/simplify` pass is included as the last commit: the summary line is table-driven rather than three copy-pasted branches, and some comments trimmed. No behaviour change.

## Note for release

Worth a release note — anyone with sparse files has been silently losing them from dedupe, with a message that pointed at the wrong cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)