### PR TITLE
--exclude: use .gitignore glob syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,31 @@ roots are known (`apply_storage_defaults()` in `oans.c`).
   timer, replaying the stored config. Guide: `docs/nas-quickstart.md`.
 - The `fdupes` mode was **removed** — don't reintroduce it.
 
+## --exclude matching (src/glob.{c,h})
+
+`.gitignore` syntax — the one git/ripgrep/fd use — not POSIX `fnmatch`. Bare
+name = basename at any depth, leading `/` = absolute anchor, interior `/` = any
+depth, trailing `/` = directories only, `*` stops at `/`, `**` does not.
+Negation (`!`) is deliberately unsupported.
+
+- **Breaking change in 1.6.0.** Patterns used to be `fnmatch`'d against the full
+  path with relative ones resolved against the cwd, so `--exclude node_modules`
+  matched at most one literal directory — usually nothing, silently (#147). Old
+  patterns stored in a hashfile are replayed under the *new* semantics; that was
+  a deliberate call (no syntax versioning) so there is only ever one meaning.
+- Patterns compile to PCRE2 fragments joined into **one** combined `GRegex`, so
+  match cost is independent of pattern count. `GRegex` is PCRE2 and GLib is
+  already linked — no new dependency. Exact absolute paths skip the regex via a
+  hash lookup.
+- **Compile once in `filescan_init()`**, on the main thread before any walker
+  exists; the set is read-only afterwards so walkers need no lock. Don't move
+  the compile later or make it lazy.
+- The hashfile and its `-wal`/`-shm` sidecars are added with
+  `add_exclude_path()` (literal), not as globs — a `*` or `[` in the hashfile's
+  own path must not become a wildcard.
+- Per-pattern match counts back the "matched nothing" warning; `glob_set_stat()`
+  enumerates **user** patterns only, skipping the internal ones.
+
 ## Measured dead-ends — don't re-attempt without new evidence
 
 - **Separating the walk from hashing into two sequential phases is not worth it.**

--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ commands and comparison binary are documented in the
   weekly, idle-priority dedupe, with a **[NAS quick-start guide](docs/nas-quickstart.md)**.
 - **Storage-aware thread defaults:** `--io-threads` is sized from the detected
   backing storage (SSD vs single spinning disk vs multi-device pool).
+- **`--exclude` takes `.gitignore`-style patterns** (as git, ripgrep and fd do):
+  a bare name like `@eaDir` or `node_modules` matches at any depth, `**` crosses
+  directories, a trailing `/` means directories only. Patterns that match
+  nothing are reported instead of failing silently.
 - **`--min-filesize`**, **`--cpu-threads`**, **`--no-color`** and **`-q`** added;
   the legacy `--fdupes` mode and other dead/testing options removed.
 - **Automatic housekeeping:** prune deleted files from the hashfile after a scan

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -168,12 +168,55 @@ deduplicating runs of zeroes.
 .TP
 \f[B]\-\-exclude\f[R]=\f[I]PATTERN\f[R]
 Exclude matching files and directories from the scan \[em] handy for
-skipping snapshot mounts or caches.
-A \f[I]PATTERN\f[R] without a leading \f[CR]/\f[R] is matched relative
-to the current directory.
-Because the shell also expands globs, quote the pattern,
-e.g.\ \f[CR]oans \-\-exclude \[dq]/srv/media/tmp/*\[dq] /srv/media\f[R].
+skipping snapshot mounts, caches and download staging areas.
 May be given multiple times.
+Because the shell also expands globs, \f[B]quote the pattern\f[R].
+.RS
+.PP
+\f[I]PATTERN\f[R] uses the same syntax as \f[CR].gitignore\f[R] (and
+\f[CR]ripgrep\f[R], \f[CR]fd\f[R]):
+.IP \[bu] 2
+A pattern with \f[B]no \f[CB]/\f[B]\f[R] matches the \f[B]file or
+directory name at any depth\f[R]:
+\f[CR]\-\-exclude \[aq]\[at]eaDir\[aq]\f[R] skips every
+\f[CR]\[at]eaDir\f[R] in the tree, and
+\f[CR]\-\-exclude \[aq]*.iso\[aq]\f[R] every \f[CR].iso\f[R] file.
+.IP \[bu] 2
+A pattern \f[B]starting with \f[CB]/\f[B]\f[R] is an absolute path,
+anchored at the filesystem root:
+\f[CR]\-\-exclude \[aq]/srv/media/cache*\[aq]\f[R].
+.IP \[bu] 2
+A pattern with a \f[B]\f[CB]/\f[B] elsewhere\f[R] matches at any depth,
+so \f[CR]\-\-exclude \[aq]Steam/temp\[aq]\f[R] skips
+\f[CR]/data/Steam/temp\f[R] and \f[CR]/home/u/Steam/temp\f[R] alike.
+Write a leading \f[CR]/\f[R] to anchor it instead.
+.IP \[bu] 2
+A \f[B]trailing \f[CB]/\f[B]\f[R] restricts the pattern to directories,
+so \f[CR]\-\-exclude \[aq]cache/\[aq]\f[R] skips directories named
+\f[CR]cache\f[R] but keeps files of that name.
+.IP \[bu] 2
+\f[CR]*\f[R] matches any run of characters \f[B]except
+\f[CB]/\f[B]\f[R], \f[CR]?\f[R] matches one non\-\f[CR]/\f[R] character,
+\f[CR][a\-z]\f[R] and \f[CR][!a\-z]\f[R] are character classes, and
+\f[CR]**\f[R] crosses directory boundaries.
+.PP
+Excluding a directory prunes the walk there, so naming a directory also
+skips everything inside it \[em] there is no need to add a wildcard for
+its contents.
+Negation (\f[CR]!\f[R]) is not supported.
+.PP
+A pattern that matches nothing during the scan is reported as a warning;
+a malformed one (an unterminated \f[CR][\f[R]) is an error and
+\f[CR]oans\f[R] refuses to run.
+.PP
+\f[B]Changed in 1.6.0.\f[R] Patterns used to be matched with
+\f[CR]fnmatch()\f[R] against the whole path, and a pattern without a
+leading \f[CR]/\f[R] was resolved against the current directory.
+\f[CR]\-\-exclude node_modules\f[R] therefore matched at most one
+literal directory, and usually nothing at all, silently.
+If you have stored patterns in a hashfile from an earlier release, check
+them with a scan before relying on the next scheduled run.
+.RE
 .TP
 \f[B]\-\-dedupe\-options\f[R]=\f[I]opt\f[R][,\f[I]opt\f[R]\&...]
 Comma\-separated switches that alter \f[I]what\f[R] gets deduplicated.
@@ -399,11 +442,12 @@ Preview what a run would dedupe, without changing anything (omit
 oans \-r foo/
 .EE
 .PP
-Skip tiny files and a snapshot directory on a media server:
+Skip tiny files, and every snapshot or NAS metadata directory anywhere
+in the tree (the bare names match at any depth):
 .IP
 .EX
 oans \-dr \-\-hashfile=media.hash \-\-min\-filesize=1M \[rs]
-     \-\-exclude \[dq]/srv/media/.snapshots/*\[dq] /srv/media
+     \-\-exclude \[aq].snapshots\[aq] \-\-exclude \[aq]\[at]eaDir\[aq] /srv/media
 .EE
 .PP
 Inspect a hashfile, watch savings over time, and export metrics:

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -139,10 +139,47 @@ directory scans the regular files directly inside it; add **-r** to recurse.
 
 **\--exclude**=*PATTERN*
   ~ Exclude matching files and directories from the scan — handy for skipping
-    snapshot mounts or caches. A *PATTERN* without a leading `/` is matched
-    relative to the current directory. Because the shell also expands globs,
-    quote the pattern, e.g. `oans --exclude "/srv/media/tmp/*" /srv/media`. May
-    be given multiple times.
+    snapshot mounts, caches and download staging areas. May be given multiple
+    times. Because the shell also expands globs, **quote the pattern**.
+
+    <!-- -->
+
+    *PATTERN* uses the same syntax as `.gitignore` (and `ripgrep`, `fd`):
+
+    - A pattern with **no `/`** matches the **file or directory name at any
+      depth**: `--exclude '@eaDir'` skips every `@eaDir` in the tree, and
+      `--exclude '*.iso'` every `.iso` file.
+    - A pattern **starting with `/`** is an absolute path, anchored at the
+      filesystem root: `--exclude '/srv/media/cache*'`.
+    - A pattern with a **`/` elsewhere** matches at any depth, so
+      `--exclude 'Steam/temp'` skips `/data/Steam/temp` and
+      `/home/u/Steam/temp` alike. Write a leading `/` to anchor it instead.
+    - A **trailing `/`** restricts the pattern to directories, so
+      `--exclude 'cache/'` skips directories named `cache` but keeps files of
+      that name.
+    - `*` matches any run of characters **except `/`**, `?` matches one
+      non-`/` character, `[a-z]` and `[!a-z]` are character classes, and `**`
+      crosses directory boundaries.
+
+    <!-- -->
+
+    Excluding a directory prunes the walk there, so naming a directory also
+    skips everything inside it — there is no need to add a wildcard for its
+    contents. Negation (`!`) is not supported.
+
+    <!-- -->
+
+    A pattern that matches nothing during the scan is reported as a warning; a
+    malformed one (an unterminated `[`) is an error and `oans` refuses to run.
+
+    <!-- -->
+
+    **Changed in 1.6.0.** Patterns used to be matched with `fnmatch()` against
+    the whole path, and a pattern without a leading `/` was resolved against
+    the current directory. `--exclude node_modules` therefore matched at most
+    one literal directory, and usually nothing at all, silently. If you have
+    stored patterns in a hashfile from an earlier release, check them with a
+    scan before relying on the next scheduled run.
 
 **\--dedupe-options**=*opt*\[,*opt*...]
   ~ Comma-separated switches that alter *what* gets deduplicated. Prefix an
@@ -338,11 +375,12 @@ Preview what a run would dedupe, without changing anything (omit **-d**):
 oans -r foo/
 ```
 
-Skip tiny files and a snapshot directory on a media server:
+Skip tiny files, and every snapshot or NAS metadata directory anywhere in the
+tree (the bare names match at any depth):
 
 ```
 oans -dr --hashfile=media.hash --min-filesize=1M \
-     --exclude "/srv/media/.snapshots/*" /srv/media
+     --exclude '.snapshots' --exclude '@eaDir' /srv/media
 ```
 
 Inspect a hashfile, watch savings over time, and export metrics:

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -123,6 +123,16 @@ stream to parse.
   `oans@backups`, …). Each is an independent timer you can schedule separately.
 - **Report-only mode:** set the job up with `-r` instead of `-dr` and the
   scheduled runs will only refresh hashes and report, never change data.
+- **Skipping snapshots and NAS metadata.** `--exclude` takes `.gitignore`-style
+  patterns, so a bare name matches at any depth — no path juggling:
+
+  ```sh
+  sudo oans -dr --hashfile=/var/cache/oans/media.hash \
+      --exclude '.snapshots' --exclude '@eaDir' /srv/media
+  ```
+
+  The patterns are stored with the rest of the run, so later scheduled runs
+  reuse them. A pattern that matches nothing is reported as a warning.
 - **The hashfile is just a cache** (under `/var/cache/oans`). Deleting it only
   forces the next run to re-hash from scratch; it can live on your system SSD,
   separate from the data pool.

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -133,6 +133,13 @@ stream to parse.
 
   The patterns are stored with the rest of the run, so later scheduled runs
   reuse them. A pattern that matches nothing is reported as a warning.
+
+  **Upgrading from before 1.6.0?** `--exclude` used to match with `fnmatch()`
+  against the whole path, and a pattern without a leading `/` was resolved
+  against the current directory. Patterns already stored in a hashfile are
+  replayed under the new rules, so a scheduled job could now exclude more (or
+  less) than it did. Run the job once by hand and check the output before
+  trusting the next timer firing.
 - **The hashfile is just a cache** (under `/var/cache/oans`). Deleting it only
   forces the next run to re-hash from scratch; it can live on your system SSD,
   separate from the data pool.

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1002,9 +1002,17 @@ static void process_dir(const char *path, struct dbhandle *db)
 	 * by NAME_MAX) instead of a fixed PATH_MAX. The absolute string is only
 	 * built for exclude matching, queueing and messages; children are
 	 * reached with dir-fd-relative syscalls below.
+	 *
+	 * calloc, not malloc: each entry writes only up to its own terminator,
+	 * so with malloc the tail past it stays uninitialised for the life of
+	 * the buffer. PCRE2's JIT matches a word at a time and reads those
+	 * bytes - harmlessly, they are inside the allocation, but memcheck
+	 * rightly flags the branch on them. Zeroing once per directory (not per
+	 * entry) makes every byte defined; the cost is nothing next to the
+	 * opendir/readdir/statx this loop is about to do.
 	 */
 	dirlen = strlen(path);
-	child = malloc(dirlen + 1 + NAME_MAX + 1);
+	child = calloc(1, dirlen + 1 + NAME_MAX + 1);
 	if (child == NULL) {
 		eprintf("Out of memory while scanning directory %s\n", path);
 		return;
@@ -1338,7 +1346,15 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 int scan_file(char *in_path, struct dbhandle *db)
 {
 	struct statx st;
-	char path[PATH_MAX];
+	/*
+	 * Zeroed, not just realpath'd into: realpath() writes up to the
+	 * terminator and leaves the rest of the buffer as whatever was on the
+	 * stack, and this path is then handed to the exclude matcher, whose
+	 * PCRE2 JIT reads a word at a time past the end of the string. The read
+	 * is harmless but the branch on undefined bytes is not something to
+	 * leave in place. Once per scan root, so the memset costs nothing.
+	 */
+	char path[PATH_MAX] = {0};
 	int ret;
 
 	/*

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -36,7 +36,6 @@
 #include <inttypes.h>
 #include <linux/magic.h>
 #include <sys/statfs.h>
-#include <fnmatch.h>
 #include <blkid/blkid.h>
 #include <libmount/libmount.h>
 #include <sys/sysmacros.h>
@@ -60,19 +59,20 @@
 #include "fiemap.h"
 #include "progress.h"
 #include "longpath.h"
+#include "glob.h"
 
 /* This is not in linux/magic.h */
 #ifndef	XFS_SB_MAGIC
 #define	XFS_SB_MAGIC		0x58465342	/* 'XFSB' */
 #endif
 
-struct exclude_file {
-	char *pattern;
-	bool is_glob;	/* pattern has fnmatch metacharacters */
-	SLIST_ENTRY(exclude_file) list;
-};
-
-SLIST_HEAD(exclude_list, exclude_file) exclude_head = SLIST_HEAD_INITIALIZER(exclude_head);
+/*
+ * --exclude patterns, gitignore-style (see glob.h). Built up by
+ * add_exclude_pattern() during option parsing and hashfile replay, compiled
+ * once in filescan_init() before any walker thread exists, then read-only for
+ * the rest of the run.
+ */
+static struct glob_set *excludes;
 
 static int __scan_file(char *path, struct dbhandle *db, struct statx *st);
 static bool seen_inode(uint64_t ino, uint64_t subvol);
@@ -479,27 +479,15 @@ static void free_scan_ctxt(struct scan_ctxt *ctxt)
 		finish_running_checksum(ctxt->extent_csum, NULL);
 }
 
-static int is_excluded(const char *name)
+static int is_excluded(const char *name, bool is_dir)
 {
-	struct exclude_file *exclude;
+	const char *which = NULL;
 
-	SLIST_FOREACH(exclude, &exclude_head, list) {
-		/*
-		 * Patterns without metacharacters (e.g. the hashfile paths we
-		 * always exclude) match exactly, so skip fnmatch's much more
-		 * expensive char-by-char loop - this runs for every file.
-		 */
-		bool match = exclude->is_glob ?
-			(fnmatch(exclude->pattern, name, 0) == 0) :
-			(strcmp(exclude->pattern, name) == 0);
-		if (match) {
-			vprintf("Excluding: %s (matches %s)\n", name,
-				exclude->pattern);
-			return 1;
-		}
-	}
+	if (!excludes || !glob_set_match(excludes, name, is_dir, &which))
+		return 0;
 
-	return 0;
+	vprintf("Excluding: %s (matches %s)\n", name, which ? which : "?");
+	return 1;
 }
 
 static inline void mnt_unref_table_cleanup(struct libmnt_table **tb)
@@ -753,7 +741,7 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	struct fs_probe probe = {0,};
 	dev_t dev;
 
-	if (is_excluded(path))
+	if (is_excluded(path, S_ISDIR(st->stx_mode)))
 		return false;
 
 	if (!S_ISREG(st->stx_mode) && !S_ISDIR(st->stx_mode)) {
@@ -2214,47 +2202,59 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	atomic_fetch_add(&scan_hashed_bytes, ctxt.off);
 }
 
+static struct glob_set *excludes_get(void)
+{
+	if (!excludes)
+		excludes = glob_set_new();
+	return excludes;
+}
+
 /*
- * An exclude pattern is only ever matched with fnmatch()/strcmp() against a
- * path -- it is never handed to a syscall -- so nothing here needs to fit
- * PATH_MAX. It used to, which meant a relative --exclude naming a deep subtree
- * was rejected with "cannot prepend cwd to ...": you could not exclude the very
- * trees #117 made scannable. Build the expansion on the heap instead.
+ * A pattern is only ever matched against a path string -- never handed to a
+ * syscall -- so nothing here is bounded by PATH_MAX; a pattern may name a
+ * subtree deeper than that (#117).
+ *
+ * Patterns are NOT resolved against the cwd. A relative pattern matches at any
+ * depth, which is the whole point of the gitignore syntax: `--exclude @eaDir`
+ * means "any directory called @eaDir", not "$PWD/@eaDir".
  */
 int add_exclude_pattern(const char *pattern)
 {
-	struct exclude_file *exclude = malloc(sizeof(*exclude));
+	char *err = NULL;
 
-	if (!exclude)
-		return 1;
-
-	if (pattern[0] == '/') {
-		exclude->pattern = strdup(pattern);
-	} else {
-		_cleanup_(freep) char *cwd = get_current_dir_name();
-
-		if (!cwd) {
-			eprintf("Error: cannot read cwd for pattern %s\n", pattern);
-			free(exclude);
-			return 1;
-		}
-		if (asprintf(&exclude->pattern, "%s/%s", cwd, pattern) < 0)
-			exclude->pattern = NULL;
-	}
-
-	if (!exclude->pattern) {
-		eprintf("Error: out of memory adding exclude pattern %s\n",
-			pattern);
-		free(exclude);
+	if (glob_set_add(excludes_get(), pattern, &err)) {
+		eprintf("Error: %s\n", err ? err : "bad --exclude pattern");
+		g_free(err);
 		return 1;
 	}
 
-	exclude->is_glob = strpbrk(exclude->pattern, "*?[\\") != NULL;
-
-	vprintf("Adding exclude pattern: %s\n", exclude->pattern);
-
-	SLIST_INSERT_HEAD(&exclude_head, exclude, list);
+	vprintf("Adding exclude pattern: %s\n", pattern);
 	return 0;
+}
+
+/*
+ * A path oans excludes on the user's behalf (the hashfile and its WAL
+ * sidecars). Matched literally, so a '*' or '[' in the hashfile's own path
+ * cannot turn into a wildcard and silently drop unrelated files.
+ */
+int add_exclude_path(const char *path)
+{
+	return glob_set_add_literal(excludes_get(), path);
+}
+
+/* Warn about patterns that matched nothing -- almost always a typo or the
+ * wrong syntax, and silent until now (#147). */
+static void excludes_report_unmatched(void)
+{
+	const char *pattern;
+	unsigned long matches;
+
+	for (unsigned int i = 0; glob_set_stat(excludes, i, &pattern, &matches); i++) {
+		if (matches)
+			continue;
+		eprintf("WARNING: --exclude pattern \"%s\" matched nothing.\n",
+			pattern);
+	}
 }
 
 /*
@@ -2473,6 +2473,23 @@ void filescan_init(void)
 	abort_on(scan_workq.workers);
 	abort_on(scan_writer_open());
 	seen_inodes_init();
+
+	/*
+	 * Compile the exclude set here: this runs once, on the main thread,
+	 * before any walker exists, and every add_exclude_pattern() caller
+	 * (option parsing, then hashfile replay) has already run. After this
+	 * the set is read-only, so the walkers need no lock.
+	 */
+	if (excludes) {
+		char *err = NULL;
+
+		if (glob_set_compile(excludes, &err)) {
+			eprintf("Error: %s\n", err ? err : "bad --exclude set");
+			g_free(err);
+			abort_on(1);
+		}
+	}
+
 	scan_workq_start(options.io_threads);
 }
 
@@ -2485,4 +2502,10 @@ void filescan_free(void)
 	subvol_cache_free();
 	verified_dev_free();
 	seen_inodes_free();
+
+	if (excludes) {
+		excludes_report_unmatched();
+		glob_set_free(excludes);
+		excludes = NULL;
+	}
 }

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -41,7 +41,6 @@
 #include <sys/sysmacros.h>
 #include <uuid/uuid.h>
 #include <stdatomic.h>
-#include <bsd/sys/queue.h>
 
 #include <glib.h>
 
@@ -486,7 +485,7 @@ static int is_excluded(const char *name, bool is_dir)
 	if (!excludes || !glob_set_match(excludes, name, is_dir, &which))
 		return 0;
 
-	vprintf("Excluding: %s (matches %s)\n", name, which ? which : "?");
+	vprintf("Excluding: %s (matches %s)\n", name, which);
 	return 1;
 }
 
@@ -2223,7 +2222,7 @@ int add_exclude_pattern(const char *pattern)
 	char *err = NULL;
 
 	if (glob_set_add(excludes_get(), pattern, &err)) {
-		eprintf("Error: %s\n", err ? err : "bad --exclude pattern");
+		eprintf("Error: %s\n", err);
 		g_free(err);
 		return 1;
 	}
@@ -2237,20 +2236,28 @@ int add_exclude_pattern(const char *pattern)
  * sidecars). Matched literally, so a '*' or '[' in the hashfile's own path
  * cannot turn into a wildcard and silently drop unrelated files.
  */
-int add_exclude_path(const char *path)
+void add_exclude_path(const char *path)
 {
-	return glob_set_add_literal(excludes_get(), path);
+	glob_set_add_literal(excludes_get(), path);
 }
 
-/* Warn about patterns that matched nothing -- almost always a typo or the
- * wrong syntax, and silent until now (#147). */
-static void excludes_report_unmatched(void)
+/*
+ * Warn about patterns that matched nothing -- almost always a typo or the wrong
+ * syntax, and silent until now (#147). Called by the caller once the walk has
+ * finished, not from filescan_free(): after a walk that failed outright every
+ * pattern would trivially have matched nothing, and saying so would bury the
+ * real error.
+ */
+void filescan_report_excludes(void)
 {
 	const char *pattern;
-	unsigned long matches;
+	bool matched;
 
-	for (unsigned int i = 0; glob_set_stat(excludes, i, &pattern, &matches); i++) {
-		if (matches)
+	if (!excludes)
+		return;
+
+	for (unsigned int i = 0; glob_set_stat(excludes, i, &pattern, &matched); i++) {
+		if (matched)
 			continue;
 		eprintf("WARNING: --exclude pattern \"%s\" matched nothing.\n",
 			pattern);
@@ -2484,7 +2491,7 @@ void filescan_init(void)
 		char *err = NULL;
 
 		if (glob_set_compile(excludes, &err)) {
-			eprintf("Error: %s\n", err ? err : "bad --exclude set");
+			eprintf("Error: %s\n", err);
 			g_free(err);
 			abort_on(1);
 		}
@@ -2503,9 +2510,5 @@ void filescan_free(void)
 	verified_dev_free();
 	seen_inodes_free();
 
-	if (excludes) {
-		excludes_report_unmatched();
-		glob_set_free(excludes);
-		excludes = NULL;
-	}
+	g_clear_pointer(&excludes, glob_set_free);
 }

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -76,7 +76,9 @@ struct file_to_scan {
 
 int add_exclude_pattern(const char *pattern);
 /* An exact path to skip, matched literally (the hashfile and its sidecars). */
-int add_exclude_path(const char *path);
+void add_exclude_path(const char *path);
+/* Warn about --exclude patterns that matched nothing; call after the walk. */
+void filescan_report_excludes(void);
 
 void filescan_init(void);
 void filescan_free(void);

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -75,6 +75,8 @@ struct file_to_scan {
 };
 
 int add_exclude_pattern(const char *pattern);
+/* An exact path to skip, matched literally (the hashfile and its sidecars). */
+int add_exclude_path(const char *path);
 
 void filescan_init(void);
 void filescan_free(void);

--- a/src/glob.c
+++ b/src/glob.c
@@ -8,10 +8,10 @@
  * patterns there are. Exact paths (the hashfile and its sidecars, which oans
  * excludes on the user's behalf) skip the regex entirely via a hash lookup.
  *
- * The per-pattern regexes are kept as well, but only to attribute a hit to the
- * pattern that caused it for the -v message. That runs only when the combined
- * regex already matched, i.e. on a path we are about to skip anyway - never on
- * the hot negative path.
+ * The per-pattern regexes are kept as well, but only to work out *which*
+ * pattern caused a hit - for the -v message, and to apply the directory-only
+ * rule. That scan runs only when the combined regex already matched, i.e. on a
+ * path we are about to skip anyway, never on the hot negative path.
  *
  * GRegex is PCRE2 underneath and GLib is already linked, so this adds no
  * dependency.
@@ -26,6 +26,7 @@
  * General Public License for more details.
  */
 
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -34,30 +35,32 @@
 #include "glob.h"
 
 struct glob_pat {
-	char		*pattern;	/* as written, for diagnostics */
-	char		*literal;	/* exact-match entries only */
-	GRegex		*re;		/* glob entries only */
+	char		*pattern;	/* as written; also the literal hash key */
+	GRegex		*re;		/* NULL for exact-match entries */
 	bool		dir_only;
 	bool		internal;	/* added by oans, not by the user */
-	unsigned long	matches;
+	/*
+	 * Set from the walker threads, which run concurrently. Only ever
+	 * flipped false->true, and only its final value is read (after the
+	 * walk, to report patterns that matched nothing), so a relaxed atomic
+	 * is enough - and writing it only on the first hit keeps the shared
+	 * cache line off the hot path.
+	 */
+	_Atomic bool	matched;
 };
 
 struct glob_set {
 	GPtrArray	*pats;		/* struct glob_pat *, in add order */
-	GHashTable	*literals;	/* literal -> struct glob_pat * */
-	GRegex		*any;		/* combined, patterns matching any path */
-	GRegex		*dir;		/* combined, directory-only patterns */
-	bool		compiled;
+	GHashTable	*literals;	/* pattern -> struct glob_pat * */
+	GRegex		*re;		/* every glob fragment, one alternation */
 };
 
 static void glob_pat_free(gpointer p)
 {
 	struct glob_pat *gp = p;
 
-	if (gp->re)
-		g_regex_unref(gp->re);
+	g_clear_pointer(&gp->re, g_regex_unref);
 	g_free(gp->pattern);
-	g_free(gp->literal);
 	g_free(gp);
 }
 
@@ -74,72 +77,50 @@ void glob_set_free(struct glob_set *gs)
 {
 	if (!gs)
 		return;
-	if (gs->any)
-		g_regex_unref(gs->any);
-	if (gs->dir)
-		g_regex_unref(gs->dir);
+	g_clear_pointer(&gs->re, g_regex_unref);
 	g_hash_table_destroy(gs->literals);
 	g_ptr_array_free(gs->pats, TRUE);
 	g_free(gs);
 }
 
-bool glob_set_empty(const struct glob_set *gs)
-{
-	return gs->pats->len == 0;
-}
-
-/* Characters PCRE2 treats specially, which a literal glob byte must escape. */
-static void append_literal_char(GString *out, char c)
-{
-	if (strchr("\\^$.[]|()*+?{}", c))
-		g_string_append_c(out, '\\');
-	g_string_append_c(out, c);
-}
-
 /*
  * Translate a glob character class starting at pat[*i] == '['. On success
  * advances *i to the closing ']' (the caller's loop steps past it) and returns
- * true; returns false if the class is unterminated.
+ * true; on an unterminated class rolls `out` back and returns false.
  */
 static bool append_class(GString *out, const char *pat, size_t len, size_t *i)
 {
-	GString *cls = g_string_new("[");
+	size_t mark = out->len;
 	size_t j = *i + 1;
-	bool closed = false;
+
+	g_string_append_c(out, '[');
 
 	/* Both spellings of negation; PCRE2 only knows '^'. */
 	if (j < len && (pat[j] == '!' || pat[j] == '^')) {
-		g_string_append_c(cls, '^');
+		g_string_append_c(out, '^');
 		j++;
 	}
 	/* A ']' immediately after the (possibly negated) open bracket is data. */
 	if (j < len && pat[j] == ']') {
-		g_string_append(cls, "\\]");
+		g_string_append(out, "\\]");
 		j++;
 	}
 
 	for (; j < len; j++) {
 		if (pat[j] == ']') {
-			closed = true;
-			break;
+			g_string_append_c(out, ']');
+			*i = j;
+			return true;
 		}
 		/* '-' and ranges pass through; only these two would change
 		 * meaning inside a PCRE2 class. */
 		if (pat[j] == '\\' || pat[j] == '[')
-			g_string_append_c(cls, '\\');
-		g_string_append_c(cls, pat[j]);
+			g_string_append_c(out, '\\');
+		g_string_append_c(out, pat[j]);
 	}
 
-	if (!closed) {
-		g_string_free(cls, TRUE);
-		return false;
-	}
-
-	g_string_append_c(cls, ']');
-	g_string_append(out, cls->str);
-	g_string_free(cls, TRUE);
-	*i = j;
-	return true;
+	g_string_truncate(out, mark);
+	return false;
 }
 
 /*
@@ -149,7 +130,6 @@ static bool append_class(GString *out, const char *pat, size_t len, size_t *i)
 static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
 {
 	size_t len = strlen(pat);
-	bool has_slash = false;
 	GString *re;
 
 	*dir_only = false;
@@ -162,17 +142,10 @@ static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
 		return NULL;
 	}
 
-	for (size_t i = 0; i < len; i++) {
-		if (pat[i] == '/') {
-			has_slash = true;
-			break;
-		}
-	}
-
 	re = g_string_new(NULL);
 	if (pat[0] == '/')
 		g_string_append_c(re, '^');		/* absolute */
-	else if (has_slash)
+	else if (memchr(pat, '/', len))
 		g_string_append(re, "^(?:.*/)?");	/* any depth */
 	else
 		g_string_append(re, "(?:^|/)");		/* basename */
@@ -181,17 +154,19 @@ static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
 		char c = pat[i];
 
 		if (c == '*') {
-			if (i + 1 < len && pat[i + 1] == '*') {
-				i++;
-				if (i + 1 < len && pat[i + 1] == '/') {
-					/* '**' then '/': zero or more dirs */
-					g_string_append(re, "(?:.*/)?");
-					i++;
-				} else {
-					g_string_append(re, ".*");
-				}
-			} else {
+			size_t stars = 0;
+
+			while (i + stars < len && pat[i + stars] == '*')
+				stars++;
+			if (stars == 1) {
 				g_string_append(re, "[^/]*");
+			} else if (i + stars < len && pat[i + stars] == '/') {
+				/* '**' then a separator: zero or more dirs */
+				g_string_append(re, "(?:.*/)?");
+				i += stars;
+			} else {
+				g_string_append(re, ".*");
+				i += stars - 1;
 			}
 		} else if (c == '?') {
 			g_string_append(re, "[^/]");
@@ -203,10 +178,14 @@ static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
 				g_string_free(re, TRUE);
 				return NULL;
 			}
-		} else if (c == '\\' && i + 1 < len) {
-			append_literal_char(re, pat[++i]);
 		} else {
-			append_literal_char(re, c);
+			/* Escape via GLib rather than a hand-kept metacharacter
+			 * list, which could drift from PCRE2's. */
+			char one[2] = { (c == '\\' && i + 1 < len) ? pat[++i] : c, 0 };
+			char *esc = g_regex_escape_string(one, 1);
+
+			g_string_append(re, esc);
+			g_free(esc);
 		}
 	}
 	g_string_append_c(re, '$');
@@ -214,10 +193,15 @@ static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
 	return g_string_free(re, FALSE);
 }
 
-/* True if the pattern has no metacharacter, so it can go in the literal set. */
+/*
+ * An absolute path with no metacharacter needs no regex at all, so it can go
+ * in the literal set: a hash lookup, and no chance of a stray '*' in someone's
+ * hashfile path behaving as a wildcard.
+ */
 static bool is_plain_path(const char *pat)
 {
-	return pat[0] == '/' && !strpbrk(pat, "*?[\\");
+	return pat[0] == '/' && !strpbrk(pat, "*?[\\") &&
+	       !g_str_has_suffix(pat, "/");
 }
 
 static struct glob_pat *pat_new(struct glob_set *gs, const char *pattern)
@@ -229,20 +213,17 @@ static struct glob_pat *pat_new(struct glob_set *gs, const char *pattern)
 	return gp;
 }
 
-static int add_literal(struct glob_set *gs, const char *path, bool internal)
+static void add_literal(struct glob_set *gs, const char *path, bool internal)
 {
 	struct glob_pat *gp = pat_new(gs, path);
 
-	gp->literal = g_strdup(path);
 	gp->internal = internal;
-	g_hash_table_insert(gs->literals, gp->literal, gp);
-	gs->compiled = false;
-	return 0;
+	g_hash_table_insert(gs->literals, gp->pattern, gp);
 }
 
-int glob_set_add_literal(struct glob_set *gs, const char *path)
+void glob_set_add_literal(struct glob_set *gs, const char *path)
 {
-	return add_literal(gs, path, true);
+	add_literal(gs, path, true);
 }
 
 int glob_set_add(struct glob_set *gs, const char *pattern, char **err)
@@ -252,15 +233,10 @@ int glob_set_add(struct glob_set *gs, const char *pattern, char **err)
 	char *frag;
 	GError *gerr = NULL;
 
-	*err = NULL;
-
-	/*
-	 * An absolute path with no metacharacters is the common case for the
-	 * excludes oans adds itself and for a user naming one directory; a hash
-	 * lookup beats the regex.
-	 */
-	if (is_plain_path(pattern) && pattern[strlen(pattern) - 1] != '/')
-		return add_literal(gs, pattern, false);
+	if (is_plain_path(pattern)) {
+		add_literal(gs, pattern, false);
+		return 0;
+	}
 
 	frag = glob_to_regex(pattern, &dir_only, err);
 	if (!frag)
@@ -268,7 +244,12 @@ int glob_set_add(struct glob_set *gs, const char *pattern, char **err)
 
 	gp = pat_new(gs, pattern);
 	gp->dir_only = dir_only;
-	gp->re = g_regex_new(frag, 0, 0, &gerr);
+	/*
+	 * G_REGEX_OPTIMIZE turns on PCRE2's JIT. It is not optional here: this
+	 * runs once per directory entry on every walker thread, and matching
+	 * measured ~12x slower without it.
+	 */
+	gp->re = g_regex_new(frag, G_REGEX_OPTIMIZE, 0, &gerr);
 	g_free(frag);
 	if (!gp->re) {
 		*err = g_strdup_printf("bad exclude pattern \"%s\": %s",
@@ -276,69 +257,47 @@ int glob_set_add(struct glob_set *gs, const char *pattern, char **err)
 		g_error_free(gerr);
 		return 1;
 	}
-	gs->compiled = false;
 	return 0;
-}
-
-/* Join every fragment of one flavour into a single alternation. */
-static GRegex *compile_combined(struct glob_set *gs, bool dir_only, char **err)
-{
-	GString *all = g_string_new(NULL);
-	GRegex *re = NULL;
-	GError *gerr = NULL;
-	unsigned int n = 0;
-
-	for (unsigned int i = 0; i < gs->pats->len; i++) {
-		struct glob_pat *gp = g_ptr_array_index(gs->pats, i);
-		const gchar *frag;
-
-		if (!gp->re || gp->dir_only != dir_only)
-			continue;
-		frag = g_regex_get_pattern(gp->re);
-		if (n++)
-			g_string_append_c(all, '|');
-		g_string_append_printf(all, "(?:%s)", frag);
-	}
-
-	if (n) {
-		re = g_regex_new(all->str, 0, 0, &gerr);
-		if (!re) {
-			*err = g_strdup_printf("combining exclude patterns: %s",
-					       gerr->message);
-			g_error_free(gerr);
-		}
-	}
-	g_string_free(all, TRUE);
-	return re;
 }
 
 int glob_set_compile(struct glob_set *gs, char **err)
 {
-	*err = NULL;
+	GString *all = g_string_new(NULL);
+	GError *gerr = NULL;
+	unsigned int n = 0;
+	int ret = 0;
 
-	if (gs->any) {
-		g_regex_unref(gs->any);
-		gs->any = NULL;
+	g_clear_pointer(&gs->re, g_regex_unref);
+
+	for (unsigned int i = 0; i < gs->pats->len; i++) {
+		struct glob_pat *gp = g_ptr_array_index(gs->pats, i);
+
+		if (!gp->re)
+			continue;
+		if (n++)
+			g_string_append_c(all, '|');
+		g_string_append_printf(all, "(?:%s)",
+				       g_regex_get_pattern(gp->re));
 	}
-	if (gs->dir) {
-		g_regex_unref(gs->dir);
-		gs->dir = NULL;
+
+	if (n) {
+		gs->re = g_regex_new(all->str, G_REGEX_OPTIMIZE, 0, &gerr);
+		if (!gs->re) {
+			*err = g_strdup_printf("combining exclude patterns: %s",
+					       gerr->message);
+			g_error_free(gerr);
+			ret = 1;
+		}
 	}
-
-	gs->any = compile_combined(gs, false, err);
-	if (*err)
-		return 1;
-	gs->dir = compile_combined(gs, true, err);
-	if (*err)
-		return 1;
-
-	gs->compiled = true;
-	return 0;
+	g_string_free(all, TRUE);
+	return ret;
 }
 
 /*
- * Which pattern matched? Only called once the combined regex has already said
- * yes, so the linear scan runs at most once per excluded path.
+ * Which pattern matched? Only reached once the combined regex has already said
+ * yes, so this linear scan runs at most once per excluded path - and it is
+ * also where the directory-only rule is applied, since the combined regex does
+ * not distinguish.
  */
 static struct glob_pat *attribute(struct glob_set *gs, const char *path,
 				  bool is_dir)
@@ -357,32 +316,27 @@ static struct glob_pat *attribute(struct glob_set *gs, const char *path,
 bool glob_set_match(struct glob_set *gs, const char *path, bool is_dir,
 		    const char **which)
 {
-	struct glob_pat *gp;
+	struct glob_pat *gp = g_hash_table_lookup(gs->literals, path);
 
-	if (gs->pats->len == 0)
-		return false;
-
-	gp = g_hash_table_lookup(gs->literals, path);
 	if (!gp) {
-		bool hit = (gs->any && g_regex_match(gs->any, path, 0, NULL)) ||
-			   (is_dir && gs->dir &&
-			    g_regex_match(gs->dir, path, 0, NULL));
-
-		if (!hit)
+		if (!gs->re || !g_regex_match(gs->re, path, 0, NULL))
 			return false;
+		/* A directory-only pattern can match the combined regex on a
+		 * plain file; attribute() is what rejects it. */
 		gp = attribute(gs, path, is_dir);
+		if (!gp)
+			return false;
 	}
 
-	if (gp) {
-		gp->matches++;
-		if (which)
-			*which = gp->pattern;
-	}
+	if (!atomic_load_explicit(&gp->matched, memory_order_relaxed))
+		atomic_store_explicit(&gp->matched, true, memory_order_relaxed);
+	if (which)
+		*which = gp->pattern;
 	return true;
 }
 
 bool glob_set_stat(const struct glob_set *gs, unsigned int i,
-		   const char **pattern, unsigned long *matches)
+		   const char **pattern, bool *matched)
 {
 	unsigned int seen = 0;
 
@@ -394,7 +348,8 @@ bool glob_set_stat(const struct glob_set *gs, unsigned int i,
 		if (seen++ != i)
 			continue;
 		*pattern = gp->pattern;
-		*matches = gp->matches;
+		*matched = atomic_load_explicit(&gp->matched,
+						memory_order_relaxed);
 		return true;
 	}
 	return false;

--- a/src/glob.c
+++ b/src/glob.c
@@ -1,0 +1,401 @@
+/*
+ * glob.c
+ *
+ * gitignore-style path matching for --exclude. See glob.h for the syntax.
+ *
+ * Patterns are translated to PCRE2 fragments and joined into a single combined
+ * regex, so matching costs one regex run per path regardless of how many
+ * patterns there are. Exact paths (the hashfile and its sidecars, which oans
+ * excludes on the user's behalf) skip the regex entirely via a hash lookup.
+ *
+ * The per-pattern regexes are kept as well, but only to attribute a hit to the
+ * pattern that caused it for the -v message. That runs only when the combined
+ * regex already matched, i.e. on a path we are about to skip anyway - never on
+ * the hot negative path.
+ *
+ * GRegex is PCRE2 underneath and GLib is already linked, so this adds no
+ * dependency.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "glob.h"
+
+struct glob_pat {
+	char		*pattern;	/* as written, for diagnostics */
+	char		*literal;	/* exact-match entries only */
+	GRegex		*re;		/* glob entries only */
+	bool		dir_only;
+	bool		internal;	/* added by oans, not by the user */
+	unsigned long	matches;
+};
+
+struct glob_set {
+	GPtrArray	*pats;		/* struct glob_pat *, in add order */
+	GHashTable	*literals;	/* literal -> struct glob_pat * */
+	GRegex		*any;		/* combined, patterns matching any path */
+	GRegex		*dir;		/* combined, directory-only patterns */
+	bool		compiled;
+};
+
+static void glob_pat_free(gpointer p)
+{
+	struct glob_pat *gp = p;
+
+	if (gp->re)
+		g_regex_unref(gp->re);
+	g_free(gp->pattern);
+	g_free(gp->literal);
+	g_free(gp);
+}
+
+struct glob_set *glob_set_new(void)
+{
+	struct glob_set *gs = g_malloc0(sizeof(*gs));
+
+	gs->pats = g_ptr_array_new_with_free_func(glob_pat_free);
+	gs->literals = g_hash_table_new(g_str_hash, g_str_equal);
+	return gs;
+}
+
+void glob_set_free(struct glob_set *gs)
+{
+	if (!gs)
+		return;
+	if (gs->any)
+		g_regex_unref(gs->any);
+	if (gs->dir)
+		g_regex_unref(gs->dir);
+	g_hash_table_destroy(gs->literals);
+	g_ptr_array_free(gs->pats, TRUE);
+	g_free(gs);
+}
+
+bool glob_set_empty(const struct glob_set *gs)
+{
+	return gs->pats->len == 0;
+}
+
+/* Characters PCRE2 treats specially, which a literal glob byte must escape. */
+static void append_literal_char(GString *out, char c)
+{
+	if (strchr("\\^$.[]|()*+?{}", c))
+		g_string_append_c(out, '\\');
+	g_string_append_c(out, c);
+}
+
+/*
+ * Translate a glob character class starting at pat[*i] == '['. On success
+ * advances *i to the closing ']' (the caller's loop steps past it) and returns
+ * true; returns false if the class is unterminated.
+ */
+static bool append_class(GString *out, const char *pat, size_t len, size_t *i)
+{
+	GString *cls = g_string_new("[");
+	size_t j = *i + 1;
+	bool closed = false;
+
+	/* Both spellings of negation; PCRE2 only knows '^'. */
+	if (j < len && (pat[j] == '!' || pat[j] == '^')) {
+		g_string_append_c(cls, '^');
+		j++;
+	}
+	/* A ']' immediately after the (possibly negated) open bracket is data. */
+	if (j < len && pat[j] == ']') {
+		g_string_append(cls, "\\]");
+		j++;
+	}
+
+	for (; j < len; j++) {
+		if (pat[j] == ']') {
+			closed = true;
+			break;
+		}
+		/* '-' and ranges pass through; only these two would change
+		 * meaning inside a PCRE2 class. */
+		if (pat[j] == '\\' || pat[j] == '[')
+			g_string_append_c(cls, '\\');
+		g_string_append_c(cls, pat[j]);
+	}
+
+	if (!closed) {
+		g_string_free(cls, TRUE);
+		return false;
+	}
+
+	g_string_append_c(cls, ']');
+	g_string_append(out, cls->str);
+	g_string_free(cls, TRUE);
+	*i = j;
+	return true;
+}
+
+/*
+ * Compile one gitignore-style pattern into an anchored PCRE2 fragment.
+ * Returns a newly allocated string, or NULL with *err set.
+ */
+static char *glob_to_regex(const char *pat, bool *dir_only, char **err)
+{
+	size_t len = strlen(pat);
+	bool has_slash = false;
+	GString *re;
+
+	*dir_only = false;
+	while (len > 0 && pat[len - 1] == '/') {
+		*dir_only = true;
+		len--;
+	}
+	if (len == 0) {
+		*err = g_strdup_printf("empty exclude pattern \"%s\"", pat);
+		return NULL;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		if (pat[i] == '/') {
+			has_slash = true;
+			break;
+		}
+	}
+
+	re = g_string_new(NULL);
+	if (pat[0] == '/')
+		g_string_append_c(re, '^');		/* absolute */
+	else if (has_slash)
+		g_string_append(re, "^(?:.*/)?");	/* any depth */
+	else
+		g_string_append(re, "(?:^|/)");		/* basename */
+
+	for (size_t i = 0; i < len; i++) {
+		char c = pat[i];
+
+		if (c == '*') {
+			if (i + 1 < len && pat[i + 1] == '*') {
+				i++;
+				if (i + 1 < len && pat[i + 1] == '/') {
+					/* '**' then '/': zero or more dirs */
+					g_string_append(re, "(?:.*/)?");
+					i++;
+				} else {
+					g_string_append(re, ".*");
+				}
+			} else {
+				g_string_append(re, "[^/]*");
+			}
+		} else if (c == '?') {
+			g_string_append(re, "[^/]");
+		} else if (c == '[') {
+			if (!append_class(re, pat, len, &i)) {
+				*err = g_strdup_printf(
+					"unterminated '[' in exclude pattern \"%s\"",
+					pat);
+				g_string_free(re, TRUE);
+				return NULL;
+			}
+		} else if (c == '\\' && i + 1 < len) {
+			append_literal_char(re, pat[++i]);
+		} else {
+			append_literal_char(re, c);
+		}
+	}
+	g_string_append_c(re, '$');
+
+	return g_string_free(re, FALSE);
+}
+
+/* True if the pattern has no metacharacter, so it can go in the literal set. */
+static bool is_plain_path(const char *pat)
+{
+	return pat[0] == '/' && !strpbrk(pat, "*?[\\");
+}
+
+static struct glob_pat *pat_new(struct glob_set *gs, const char *pattern)
+{
+	struct glob_pat *gp = g_malloc0(sizeof(*gp));
+
+	gp->pattern = g_strdup(pattern);
+	g_ptr_array_add(gs->pats, gp);
+	return gp;
+}
+
+static int add_literal(struct glob_set *gs, const char *path, bool internal)
+{
+	struct glob_pat *gp = pat_new(gs, path);
+
+	gp->literal = g_strdup(path);
+	gp->internal = internal;
+	g_hash_table_insert(gs->literals, gp->literal, gp);
+	gs->compiled = false;
+	return 0;
+}
+
+int glob_set_add_literal(struct glob_set *gs, const char *path)
+{
+	return add_literal(gs, path, true);
+}
+
+int glob_set_add(struct glob_set *gs, const char *pattern, char **err)
+{
+	struct glob_pat *gp;
+	bool dir_only = false;
+	char *frag;
+	GError *gerr = NULL;
+
+	*err = NULL;
+
+	/*
+	 * An absolute path with no metacharacters is the common case for the
+	 * excludes oans adds itself and for a user naming one directory; a hash
+	 * lookup beats the regex.
+	 */
+	if (is_plain_path(pattern) && pattern[strlen(pattern) - 1] != '/')
+		return add_literal(gs, pattern, false);
+
+	frag = glob_to_regex(pattern, &dir_only, err);
+	if (!frag)
+		return 1;
+
+	gp = pat_new(gs, pattern);
+	gp->dir_only = dir_only;
+	gp->re = g_regex_new(frag, 0, 0, &gerr);
+	g_free(frag);
+	if (!gp->re) {
+		*err = g_strdup_printf("bad exclude pattern \"%s\": %s",
+				       pattern, gerr->message);
+		g_error_free(gerr);
+		return 1;
+	}
+	gs->compiled = false;
+	return 0;
+}
+
+/* Join every fragment of one flavour into a single alternation. */
+static GRegex *compile_combined(struct glob_set *gs, bool dir_only, char **err)
+{
+	GString *all = g_string_new(NULL);
+	GRegex *re = NULL;
+	GError *gerr = NULL;
+	unsigned int n = 0;
+
+	for (unsigned int i = 0; i < gs->pats->len; i++) {
+		struct glob_pat *gp = g_ptr_array_index(gs->pats, i);
+		const gchar *frag;
+
+		if (!gp->re || gp->dir_only != dir_only)
+			continue;
+		frag = g_regex_get_pattern(gp->re);
+		if (n++)
+			g_string_append_c(all, '|');
+		g_string_append_printf(all, "(?:%s)", frag);
+	}
+
+	if (n) {
+		re = g_regex_new(all->str, 0, 0, &gerr);
+		if (!re) {
+			*err = g_strdup_printf("combining exclude patterns: %s",
+					       gerr->message);
+			g_error_free(gerr);
+		}
+	}
+	g_string_free(all, TRUE);
+	return re;
+}
+
+int glob_set_compile(struct glob_set *gs, char **err)
+{
+	*err = NULL;
+
+	if (gs->any) {
+		g_regex_unref(gs->any);
+		gs->any = NULL;
+	}
+	if (gs->dir) {
+		g_regex_unref(gs->dir);
+		gs->dir = NULL;
+	}
+
+	gs->any = compile_combined(gs, false, err);
+	if (*err)
+		return 1;
+	gs->dir = compile_combined(gs, true, err);
+	if (*err)
+		return 1;
+
+	gs->compiled = true;
+	return 0;
+}
+
+/*
+ * Which pattern matched? Only called once the combined regex has already said
+ * yes, so the linear scan runs at most once per excluded path.
+ */
+static struct glob_pat *attribute(struct glob_set *gs, const char *path,
+				  bool is_dir)
+{
+	for (unsigned int i = 0; i < gs->pats->len; i++) {
+		struct glob_pat *gp = g_ptr_array_index(gs->pats, i);
+
+		if (!gp->re || (gp->dir_only && !is_dir))
+			continue;
+		if (g_regex_match(gp->re, path, 0, NULL))
+			return gp;
+	}
+	return NULL;
+}
+
+bool glob_set_match(struct glob_set *gs, const char *path, bool is_dir,
+		    const char **which)
+{
+	struct glob_pat *gp;
+
+	if (gs->pats->len == 0)
+		return false;
+
+	gp = g_hash_table_lookup(gs->literals, path);
+	if (!gp) {
+		bool hit = (gs->any && g_regex_match(gs->any, path, 0, NULL)) ||
+			   (is_dir && gs->dir &&
+			    g_regex_match(gs->dir, path, 0, NULL));
+
+		if (!hit)
+			return false;
+		gp = attribute(gs, path, is_dir);
+	}
+
+	if (gp) {
+		gp->matches++;
+		if (which)
+			*which = gp->pattern;
+	}
+	return true;
+}
+
+bool glob_set_stat(const struct glob_set *gs, unsigned int i,
+		   const char **pattern, unsigned long *matches)
+{
+	unsigned int seen = 0;
+
+	for (unsigned int j = 0; j < gs->pats->len; j++) {
+		struct glob_pat *gp = g_ptr_array_index(gs->pats, j);
+
+		if (gp->internal)
+			continue;	/* the hashfile and its sidecars */
+		if (seen++ != i)
+			continue;
+		*pattern = gp->pattern;
+		*matches = gp->matches;
+		return true;
+	}
+	return false;
+}

--- a/src/glob.h
+++ b/src/glob.h
@@ -1,0 +1,92 @@
+/*
+ * glob.h
+ *
+ * gitignore-style path matching for --exclude.
+ *
+ * The syntax is the one git, ripgrep and fd use, because that is what users
+ * reach for. The rules, in full:
+ *
+ *   - A pattern with no '/' matches the **basename** at any depth, so
+ *     `@eaDir`, `node_modules` and `*.iso` do the obvious thing. (The old
+ *     fnmatch-against-the-full-path behaviour made these match nothing.)
+ *   - A pattern starting with '/' is an absolute path, anchored at the
+ *     filesystem root, e.g. `/srv/media/cache*`.
+ *   - A pattern with a '/' anywhere else matches at any depth, i.e. it is
+ *     implicitly prefixed with `**` + '/': `Steam/temp` matches
+ *     `/data/Steam/temp` and `/home/u/Steam/temp`. (gitignore anchors these to
+ *     the ignore file's directory; there is no ignore file here, so any-depth
+ *     is the closest useful analogue - write a leading '/' to anchor.)
+ *   - A trailing '/' restricts the pattern to directories.
+ *   - `*` matches any run of characters except '/', `?` matches one non-'/'
+ *     character, `[abc]` / `[a-z]` / `[!a-z]` are character classes, and `**`
+ *     crosses directory boundaries.
+ *
+ * Excluding a directory prunes the walk there, so a pattern naming a directory
+ * also drops everything under it; you need not add a wildcard for its
+ * contents.
+ *
+ * Negation (`!`) is deliberately not supported.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#ifndef	__GLOB_H__
+#define	__GLOB_H__
+
+#include <stdbool.h>
+
+struct glob_set;
+
+struct glob_set *glob_set_new(void);
+
+/*
+ * Add a gitignore-style pattern. Returns 0 on success, non-zero if the pattern
+ * is malformed (an unterminated character class) or on allocation failure; on
+ * failure *err is set to a message the caller owns and must free.
+ */
+int glob_set_add(struct glob_set *gs, const char *pattern, char **err);
+
+/*
+ * Add a path that must match exactly, with no metacharacter interpretation.
+ * For paths oans excludes on the user's behalf (the hashfile and its WAL
+ * sidecars), which may legitimately contain '*' or '['.
+ */
+int glob_set_add_literal(struct glob_set *gs, const char *path);
+
+/*
+ * Compile the added patterns into the matching automaton. Must be called after
+ * the last add and before the first match. Returns 0 on success; on failure
+ * *err is set to a message the caller owns and must free.
+ */
+int glob_set_compile(struct glob_set *gs, char **err);
+
+/* True when no pattern has been added (match always returns false). */
+bool glob_set_empty(const struct glob_set *gs);
+
+/*
+ * True if `path` (absolute) is matched. `is_dir` selects whether trailing-'/'
+ * directory-only patterns apply. When it matches and `which` is non-NULL,
+ * *which is set to the matching pattern, owned by the set, for diagnostics.
+ */
+bool glob_set_match(struct glob_set *gs, const char *path, bool is_dir,
+		    const char **which);
+
+/*
+ * Number of paths a pattern has matched so far, indexed over the *user's*
+ * patterns in add order, so callers can report a pattern that never matched
+ * anything. Entries added via glob_set_add_literal() are oans's own and are
+ * skipped. Returns false once `i` runs past the end.
+ */
+bool glob_set_stat(const struct glob_set *gs, unsigned int i,
+		   const char **pattern, unsigned long *matches);
+
+void glob_set_free(struct glob_set *gs);
+
+#endif	/* __GLOB_H__ */

--- a/src/glob.h
+++ b/src/glob.h
@@ -48,27 +48,27 @@ struct glob_set *glob_set_new(void);
 
 /*
  * Add a gitignore-style pattern. Returns 0 on success, non-zero if the pattern
- * is malformed (an unterminated character class) or on allocation failure; on
- * failure *err is set to a message the caller owns and must free.
+ * is malformed (an unterminated character class); on failure *err is set to a
+ * message the caller owns and must release with g_free().
  */
 int glob_set_add(struct glob_set *gs, const char *pattern, char **err);
 
 /*
  * Add a path that must match exactly, with no metacharacter interpretation.
  * For paths oans excludes on the user's behalf (the hashfile and its WAL
- * sidecars), which may legitimately contain '*' or '['.
+ * sidecars), which may legitimately contain '*' or '['. Such entries are left
+ * out of glob_set_stat(), since they are not the user's to be warned about.
  */
-int glob_set_add_literal(struct glob_set *gs, const char *path);
+void glob_set_add_literal(struct glob_set *gs, const char *path);
 
 /*
  * Compile the added patterns into the matching automaton. Must be called after
- * the last add and before the first match. Returns 0 on success; on failure
- * *err is set to a message the caller owns and must free.
+ * the last add and before the first match. After it returns the set is
+ * read-only apart from the internal match flags, which are atomic, so the
+ * concurrent walker threads need no lock. Returns 0 on success; on failure
+ * *err is set to a message the caller owns and must release with g_free().
  */
 int glob_set_compile(struct glob_set *gs, char **err);
-
-/* True when no pattern has been added (match always returns false). */
-bool glob_set_empty(const struct glob_set *gs);
 
 /*
  * True if `path` (absolute) is matched. `is_dir` selects whether trailing-'/'
@@ -79,13 +79,13 @@ bool glob_set_match(struct glob_set *gs, const char *path, bool is_dir,
 		    const char **which);
 
 /*
- * Number of paths a pattern has matched so far, indexed over the *user's*
- * patterns in add order, so callers can report a pattern that never matched
- * anything. Entries added via glob_set_add_literal() are oans's own and are
- * skipped. Returns false once `i` runs past the end.
+ * Whether a pattern has matched anything, indexed over the *user's* patterns in
+ * add order, so callers can report one that never matched. Entries added via
+ * glob_set_add_literal() are oans's own and are skipped. Returns false once `i`
+ * runs past the end.
  */
 bool glob_set_stat(const struct glob_set *gs, unsigned int i,
-		   const char **pattern, unsigned long *matches);
+		   const char **pattern, bool *matched);
 
 void glob_set_free(struct glob_set *gs);
 

--- a/src/oans.c
+++ b/src/oans.c
@@ -846,14 +846,18 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 			}
 			break;
 		case EXCLUDE_OPTION:
-			if (add_exclude_pattern(optarg)) {
-				eprintf("Error: cannot exclude %s\n", optarg);
-			} else {
-				user_excludes = realloc(user_excludes,
-					(n_user_excludes + 1) * sizeof(*user_excludes));
-				abort_on(!user_excludes);
-				user_excludes[n_user_excludes++] = strdup(optarg);
-			}
+			/*
+			 * A rejected pattern is a typo in the command line, and
+			 * carrying on would scan a wider tree than asked for -
+			 * silently, since the run would still exit 0.
+			 * add_exclude_pattern() has already said what is wrong.
+			 */
+			if (add_exclude_pattern(optarg))
+				return EINVAL;
+			user_excludes = realloc(user_excludes,
+				(n_user_excludes + 1) * sizeof(*user_excludes));
+			abort_on(!user_excludes);
+			user_excludes[n_user_excludes++] = strdup(optarg);
 			break;
 		case BATCH_SIZE_OPTION:
 		case 'B':
@@ -883,11 +887,11 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 	 */
 	if (options.hashfile != NULL) {
 		char tmp[PATH_MAX + 10 ] = {0,};
-		add_exclude_pattern(options.hashfile);
+		add_exclude_path(options.hashfile);
 		snprintf(tmp, PATH_MAX + 9, "%s-wal", options.hashfile);
-		add_exclude_pattern(tmp);
+		add_exclude_path(tmp);
 		snprintf(tmp, PATH_MAX + 9, "%s-shm", options.hashfile);
-		add_exclude_pattern(tmp);
+		add_exclude_path(tmp);
 	}
 
 	*filelist_idx = optind;

--- a/src/oans.c
+++ b/src/oans.c
@@ -1318,6 +1318,11 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 		ret = 1;
 	}
 
+	/* Only once the walk actually ran: after a failure every pattern would
+	 * trivially have "matched nothing" and would bury the real error. */
+	if (!ret)
+		filescan_report_excludes();
+
 	pscan_finish_listing();
 	filescan_free();
 	if (want_progress) {
@@ -1362,7 +1367,7 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 }
 
 /* Apply a replayed scan config to the global options (see scan_config). */
-static void apply_scan_config(const struct scan_config *sc)
+static int apply_scan_config(const struct scan_config *sc)
 {
 	int i;
 
@@ -1374,8 +1379,22 @@ static void apply_scan_config(const struct scan_config *sc)
 	options.dedupe_same_file = sc->dedupe_same_file;
 	options.min_filesize = sc->min_filesize;
 
-	for (i = 0; i < sc->nexcludes; i++)
-		add_exclude_pattern(sc->excludes[i]);
+	/*
+	 * A stored pattern that no longer parses must stop the run, for the
+	 * same reason a bad one on the command line does: carrying on scans a
+	 * wider tree than the job was set up for, and this is the *unattended*
+	 * path, so nobody would see it. Reachable since 1.6.0 - fnmatch
+	 * tolerated syntax the glob parser rejects.
+	 */
+	for (i = 0; i < sc->nexcludes; i++) {
+		if (add_exclude_pattern(sc->excludes[i])) {
+			eprintf("Error: stored --exclude pattern from a "
+				"previous run is no longer valid; re-run with "
+				"the paths and options to update it.\n");
+			return 1;
+		}
+	}
+	return 0;
 }
 
 /*
@@ -1594,7 +1613,10 @@ int main(int argc, char **argv)
 			goto out;
 		}
 
-		apply_scan_config(&replay);
+		if (apply_scan_config(&replay)) {
+			ret = 1;
+			goto out;
+		}
 		numfiles = drop_missing_roots(&replay);
 		if (numfiles == 0) {
 			eprintf("Error: none of the stored paths exist; refusing "

--- a/src/tests.c
+++ b/src/tests.c
@@ -671,29 +671,21 @@ MU_TEST(test_longpath) {
 
 /* --- gitignore-style --exclude matching (glob.c) --- */
 
-/* Build a set from one pattern; aborts the test if the pattern is rejected. */
-static struct glob_set *gs_one(const char *pattern)
+/*
+ * Match one path against one pattern. A pattern that fails to compile aborts
+ * rather than returning false: laundering it into "no match" would let every
+ * negative assertion below pass vacuously.
+ */
+static bool gs_hit(const char *pattern, const char *path, bool is_dir)
 {
 	char *err = NULL;
 	struct glob_set *gs = glob_set_new();
-
-	if (glob_set_add(gs, pattern, &err) || glob_set_compile(gs, &err)) {
-		fprintf(stderr, "glob_set_add(\"%s\"): %s\n", pattern,
-			err ? err : "?");
-		g_free(err);
-		glob_set_free(gs);
-		return NULL;
-	}
-	return gs;
-}
-
-static bool gs_hit(const char *pattern, const char *path, bool is_dir)
-{
-	struct glob_set *gs = gs_one(pattern);
 	bool r;
 
-	if (!gs)
-		return false;
+	if (glob_set_add(gs, pattern, &err) || glob_set_compile(gs, &err)) {
+		fprintf(stderr, "glob pattern \"%s\" rejected: %s\n", pattern, err);
+		abort();
+	}
 	r = glob_set_match(gs, path, is_dir, NULL);
 	glob_set_free(gs);
 	return r;
@@ -767,7 +759,7 @@ MU_TEST(test_glob_literal_paths_are_not_globs) {
 	char *err = NULL;
 	struct glob_set *gs = glob_set_new();
 
-	mu_check(glob_set_add_literal(gs, "/tmp/h[1].db") == 0);
+	glob_set_add_literal(gs, "/tmp/h[1].db");
 	mu_check(glob_set_compile(gs, &err) == 0);
 	mu_check(glob_set_match(gs, "/tmp/h[1].db", false, NULL));
 	mu_check(!glob_set_match(gs, "/tmp/h1.db", false, NULL));
@@ -778,7 +770,7 @@ MU_TEST(test_glob_reports_matching_pattern_and_counts) {
 	char *err = NULL;
 	struct glob_set *gs = glob_set_new();
 	const char *which = NULL, *pat = NULL;
-	unsigned long n = 0;
+	bool matched = false;
 
 	mu_check(glob_set_add(gs, "*.log", &err) == 0);
 	mu_check(glob_set_add(gs, "@eaDir", &err) == 0);
@@ -790,10 +782,10 @@ MU_TEST(test_glob_reports_matching_pattern_and_counts) {
 	mu_check(glob_set_match(gs, "/a/@eaDir", true, &which));
 	mu_check(which && strcmp(which, "@eaDir") == 0);
 
-	/* Per-pattern counts back the "matched nothing" warning (#147). */
-	mu_check(glob_set_stat(gs, 0, &pat, &n) && n == 1);
-	mu_check(glob_set_stat(gs, 1, &pat, &n) && n == 1);
-	mu_check(!glob_set_stat(gs, 2, &pat, &n));
+	/* Per-pattern flags back the "matched nothing" warning (#147). */
+	mu_check(glob_set_stat(gs, 0, &pat, &matched) && matched);
+	mu_check(glob_set_stat(gs, 1, &pat, &matched) && matched);
+	mu_check(!glob_set_stat(gs, 2, &pat, &matched));
 	glob_set_free(gs);
 }
 
@@ -812,7 +804,6 @@ MU_TEST(test_glob_empty_set_matches_nothing) {
 	struct glob_set *gs = glob_set_new();
 
 	mu_check(glob_set_compile(gs, &err) == 0);
-	mu_check(glob_set_empty(gs));
 	mu_check(!glob_set_match(gs, "/anything", false, NULL));
 	glob_set_free(gs);
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -22,6 +22,7 @@
 #include "progress.c"
 #include "storage.c"
 #include "longpath.c"
+#include "glob.c"
 
 
 unsigned int blocksize = DEFAULT_BLOCKSIZE;
@@ -667,6 +668,155 @@ MU_TEST(test_longpath) {
 	mu_check(rc == 0);
 }
 
+
+/* --- gitignore-style --exclude matching (glob.c) --- */
+
+/* Build a set from one pattern; aborts the test if the pattern is rejected. */
+static struct glob_set *gs_one(const char *pattern)
+{
+	char *err = NULL;
+	struct glob_set *gs = glob_set_new();
+
+	if (glob_set_add(gs, pattern, &err) || glob_set_compile(gs, &err)) {
+		fprintf(stderr, "glob_set_add(\"%s\"): %s\n", pattern,
+			err ? err : "?");
+		g_free(err);
+		glob_set_free(gs);
+		return NULL;
+	}
+	return gs;
+}
+
+static bool gs_hit(const char *pattern, const char *path, bool is_dir)
+{
+	struct glob_set *gs = gs_one(pattern);
+	bool r;
+
+	if (!gs)
+		return false;
+	r = glob_set_match(gs, path, is_dir, NULL);
+	glob_set_free(gs);
+	return r;
+}
+
+MU_TEST(test_glob_basename) {
+	/* The #147 case: a bare name matches at any depth. Under the old
+	 * full-path fnmatch these all silently matched nothing. */
+	mu_check(gs_hit("@eaDir", "/srv/media/@eaDir", true));
+	mu_check(gs_hit("@eaDir", "/srv/a/b/c/@eaDir", true));
+	mu_check(gs_hit("node_modules", "/home/u/p/node_modules", true));
+	/* ...but only whole components. */
+	mu_check(!gs_hit("@eaDir", "/srv/media/@eaDirectory", true));
+	mu_check(!gs_hit("@eaDir", "/srv/media/x@eaDir", true));
+	mu_check(!gs_hit("node_modules", "/home/u/node_modules_old", true));
+
+	mu_check(gs_hit("*.iso", "/data/img/x.iso", false));
+	mu_check(!gs_hit("*.iso", "/data/img/x.iso.part", false));
+}
+
+MU_TEST(test_glob_anchored_vs_any_depth) {
+	/* Leading '/' anchors at the filesystem root. */
+	mu_check(gs_hit("/srv/media/cache*", "/srv/media/cache1", false));
+	mu_check(!gs_hit("/srv/media/cache*", "/other/srv/media/cache1", false));
+
+	/* An interior '/' matches at any depth. */
+	mu_check(gs_hit("Steam/temp", "/data/Steam/temp", true));
+	mu_check(gs_hit("Steam/temp", "/home/u/games/Steam/temp", true));
+	mu_check(!gs_hit("Steam/temp", "/data/Steamx/temp", true));
+}
+
+MU_TEST(test_glob_wildcards_respect_separators) {
+	/* '*' must not cross a '/'. */
+	mu_check(gs_hit("/a/*", "/a/b", false));
+	mu_check(!gs_hit("/a/*", "/a/b/c", false));
+
+	/* '**' does cross. */
+	mu_check(gs_hit("/a/**/t", "/a/t", false));
+	mu_check(gs_hit("/a/**/t", "/a/b/t", false));
+	mu_check(gs_hit("/a/**/t", "/a/b/c/d/t", false));
+
+	/* '?' is exactly one non-separator. */
+	mu_check(gs_hit("a?.txt", "/x/ab.txt", false));
+	mu_check(!gs_hit("a?.txt", "/x/abc.txt", false));
+	mu_check(!gs_hit("a?.txt", "/x/a/.txt", false));
+}
+
+MU_TEST(test_glob_character_classes) {
+	mu_check(gs_hit("f[0-9].log", "/x/f3.log", false));
+	mu_check(!gs_hit("f[0-9].log", "/x/fx.log", false));
+	mu_check(gs_hit("f[!0-9].log", "/x/fx.log", false));
+	mu_check(!gs_hit("f[!0-9].log", "/x/f3.log", false));
+	mu_check(gs_hit("f[abc].log", "/x/fb.log", false));
+
+	/* A '.' in the pattern is a literal, not "any character". */
+	mu_check(!gs_hit("a.txt", "/x/axtxt", false));
+}
+
+MU_TEST(test_glob_directory_only) {
+	/* A trailing '/' restricts the pattern to directories. */
+	mu_check(gs_hit("cache/", "/a/cache", true));
+	mu_check(!gs_hit("cache/", "/a/cache", false));
+	/* Without it, either kind matches. */
+	mu_check(gs_hit("cache", "/a/cache", true));
+	mu_check(gs_hit("cache", "/a/cache", false));
+}
+
+MU_TEST(test_glob_literal_paths_are_not_globs) {
+	/* An exact path oans excludes on the user's behalf must match itself
+	 * even when it contains regex/glob metacharacters. */
+	char *err = NULL;
+	struct glob_set *gs = glob_set_new();
+
+	mu_check(glob_set_add_literal(gs, "/tmp/h[1].db") == 0);
+	mu_check(glob_set_compile(gs, &err) == 0);
+	mu_check(glob_set_match(gs, "/tmp/h[1].db", false, NULL));
+	mu_check(!glob_set_match(gs, "/tmp/h1.db", false, NULL));
+	glob_set_free(gs);
+}
+
+MU_TEST(test_glob_reports_matching_pattern_and_counts) {
+	char *err = NULL;
+	struct glob_set *gs = glob_set_new();
+	const char *which = NULL, *pat = NULL;
+	unsigned long n = 0;
+
+	mu_check(glob_set_add(gs, "*.log", &err) == 0);
+	mu_check(glob_set_add(gs, "@eaDir", &err) == 0);
+	mu_check(glob_set_compile(gs, &err) == 0);
+
+	mu_check(glob_set_match(gs, "/a/b/x.log", false, &which));
+	mu_check(which && strcmp(which, "*.log") == 0);
+
+	mu_check(glob_set_match(gs, "/a/@eaDir", true, &which));
+	mu_check(which && strcmp(which, "@eaDir") == 0);
+
+	/* Per-pattern counts back the "matched nothing" warning (#147). */
+	mu_check(glob_set_stat(gs, 0, &pat, &n) && n == 1);
+	mu_check(glob_set_stat(gs, 1, &pat, &n) && n == 1);
+	mu_check(!glob_set_stat(gs, 2, &pat, &n));
+	glob_set_free(gs);
+}
+
+MU_TEST(test_glob_rejects_malformed) {
+	char *err = NULL;
+	struct glob_set *gs = glob_set_new();
+
+	mu_check(glob_set_add(gs, "f[abc", &err) != 0);
+	mu_check(err != NULL);
+	g_free(err);
+	glob_set_free(gs);
+}
+
+MU_TEST(test_glob_empty_set_matches_nothing) {
+	char *err = NULL;
+	struct glob_set *gs = glob_set_new();
+
+	mu_check(glob_set_compile(gs, &err) == 0);
+	mu_check(glob_set_empty(gs));
+	mu_check(!glob_set_match(gs, "/anything", false, NULL));
+	glob_set_free(gs);
+}
+
 MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_block_zeroed);
 	MU_RUN_TEST(test_block_len);
@@ -683,6 +833,15 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_scan_eta);
 	MU_RUN_TEST(test_group_u64);
 	MU_RUN_TEST(test_longpath);
+	MU_RUN_TEST(test_glob_basename);
+	MU_RUN_TEST(test_glob_anchored_vs_any_depth);
+	MU_RUN_TEST(test_glob_wildcards_respect_separators);
+	MU_RUN_TEST(test_glob_character_classes);
+	MU_RUN_TEST(test_glob_directory_only);
+	MU_RUN_TEST(test_glob_literal_paths_are_not_globs);
+	MU_RUN_TEST(test_glob_reports_matching_pattern_and_counts);
+	MU_RUN_TEST(test_glob_rejects_malformed);
+	MU_RUN_TEST(test_glob_empty_set_matches_nothing);
 }
 
 int main(int argc [[maybe_unused]], char *argv[]) {

--- a/tests/integration/test_exclude.py
+++ b/tests/integration/test_exclude.py
@@ -1,4 +1,4 @@
-"""Exclude patterns: literal paths and globs are skipped during listing."""
+"""--exclude: gitignore-style glob matching (see src/glob.h)."""
 
 import os
 
@@ -39,15 +39,14 @@ class ExcludeTest(DuperemoveTest):
         self.assertEqual(1, self.hf_count("files"), "subtree contents excluded")
 
     def test_relative_exclude_longer_than_path_max(self):
-        """A relative --exclude whose cwd-expansion exceeds PATH_MAX works.
+        """A pattern longer than PATH_MAX is accepted, not rejected.
 
-        An exclude pattern is only ever matched with fnmatch()/strcmp(); it is
-        never passed to a syscall, so PATH_MAX has no business bounding it. It
-        used to: add_exclude_pattern() built the expansion in a fixed buffer and
-        bailed with "cannot prepend cwd to ...", which meant you could not
-        exclude the deep subtrees #117 had just made scannable -- and excluding
-        one is the natural workaround for the remaining over-PATH_MAX root
-        limit.
+        A pattern is only ever matched against a path string, never passed to a
+        syscall, so PATH_MAX has no business bounding it. It used to: the old
+        add_exclude_pattern() resolved relative patterns against the cwd in a
+        fixed buffer and bailed with "cannot prepend cwd to ...", so you could
+        not exclude the deep subtrees #117 had just made scannable. Patterns are
+        no longer cwd-resolved at all, but the length must still be fine.
         """
         deep = self.path("tree")
         comp = "c" * 200
@@ -74,3 +73,96 @@ class ExcludeTest(DuperemoveTest):
         # The pattern does not match anything, so both files are still scanned;
         # the point is that oans accepted it instead of refusing to start.
         self.assertEqual(2, self.hf_count("files"))
+
+    # --- gitignore semantics ---
+
+    def test_bare_name_matches_at_any_depth(self):
+        """The #147 case: `--exclude node_modules` used to match nothing.
+
+        Patterns were fnmatch'd against the full path and relative ones were
+        resolved against the cwd, so a bare name could only ever match one
+        literal directory. Every NAS user's first instinct -- @eaDir,
+        .snapshots, node_modules -- was a silent no-op.
+        """
+        self.mkrand("tree/keep.bin", 4000)
+        self.mkrand("tree/node_modules/a.bin", 4000)
+        self.mkrand("tree/deep/nested/node_modules/b.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=node_modules")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"),
+                         "every node_modules at any depth is pruned")
+        self.assertNotIn("matched nothing", self.out)
+
+    def test_bare_name_matches_whole_components_only(self):
+        self.mkrand("tree/node_modules/a.bin", 4000)
+        self.mkrand("tree/node_modules_old/b.bin", 4000)
+        self.mkrand("tree/xnode_modules/c.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=node_modules")
+        self.assertDmOk()
+        self.assertEqual(2, self.hf_count("files"),
+                         "a substring of a component is not a match")
+
+    def test_leading_slash_anchors_absolute(self):
+        self.mkrand("tree/cache/a.bin", 4000)
+        self.mkrand("tree/sub/cache/b.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=" + self.path("tree/cache"))
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"),
+                         "an absolute pattern anchors, so the nested cache stays")
+
+    def test_interior_slash_matches_any_depth(self):
+        self.mkrand("tree/keep.bin", 4000)
+        self.mkrand("tree/Steam/temp/a.bin", 4000)
+        self.mkrand("tree/deep/Steam/temp/b.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=Steam/temp")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"))
+
+    def test_double_star_crosses_directories(self):
+        self.mkrand("tree/a/t.bin", 4000)
+        self.mkrand("tree/a/b/c/t.bin", 4000)
+        self.mkrand("tree/a/keep.txt", 4000)
+        self.scan(self.path("tree"), "--exclude=a/**/t.bin")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"), "only keep.txt survives")
+
+    def test_single_star_does_not_cross_directories(self):
+        self.mkrand("tree/a/x.bin", 4000)
+        self.mkrand("tree/a/b/y.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=" + self.path("tree/a/*.bin"))
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"),
+                         "'*' stops at '/', so the nested file is kept")
+
+    def test_character_class(self):
+        for n in ("f1.log", "f2.log", "fx.log"):
+            self.mkrand("tree/" + n, 4000)
+        self.scan(self.path("tree"), "--exclude=f[0-9].log")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"), "only fx.log survives")
+
+    def test_trailing_slash_matches_directories_only(self):
+        self.mkrand("tree/cache/a.bin", 4000)      # a directory named cache
+        self.write("tree/plain/cache", b"x" * 4000)  # a *file* named cache
+        self.scan(self.path("tree"), "--exclude=cache/")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"),
+                         "only the directory is pruned")
+        self.assertEqual(
+            1, self.hf_scalar(
+                "select count(*) from files where filename like '%/plain/cache'"),
+            "the file named cache is kept")
+
+    def test_unmatched_pattern_warns(self):
+        self.mkrand("tree/a.bin", 4000)
+        self.scan(self.path("tree"), "--exclude=definitely-not-here")
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"))
+        self.assertIn('matched nothing', self.out,
+                      "a pattern that matches nothing must say so (#147)")
+
+    def test_malformed_pattern_is_rejected(self):
+        self.mkrand("tree/a.bin", 4000)
+        self.dm("-r", "--exclude=f[abc", self.path("tree"))
+        self.assertNotEqual(0, self.rc, "an unterminated class is an error")
+        self.assertIn("unterminated", self.out)

--- a/tests/integration/test_exclude.py
+++ b/tests/integration/test_exclude.py
@@ -76,6 +76,20 @@ class ExcludeTest(DuperemoveTest):
 
     # --- gitignore semantics ---
 
+    def assert_kept(self, files, pattern, kept, msg=None):
+        """Create `files`, scan with one --exclude, assert how many survive.
+
+        Seven of the cases below differ only in those three values; the pattern
+        semantics themselves are pinned in src/tests.c, so what these add is
+        that the walk really prunes on them.
+        """
+        for f in files:
+            self.mkrand(f, 4000)
+        self.scan(self.path("tree"), "--exclude=" + pattern)
+        self.assertDmOk()
+        self.assertEqual(kept, self.hf_count("files"), msg)
+
+
     def test_bare_name_matches_at_any_depth(self):
         """The #147 case: `--exclude node_modules` used to match nothing.
 
@@ -84,62 +98,45 @@ class ExcludeTest(DuperemoveTest):
         literal directory. Every NAS user's first instinct -- @eaDir,
         .snapshots, node_modules -- was a silent no-op.
         """
-        self.mkrand("tree/keep.bin", 4000)
-        self.mkrand("tree/node_modules/a.bin", 4000)
-        self.mkrand("tree/deep/nested/node_modules/b.bin", 4000)
-        self.scan(self.path("tree"), "--exclude=node_modules")
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"),
-                         "every node_modules at any depth is pruned")
+        self.assert_kept(
+            ["tree/keep.bin", "tree/node_modules/a.bin",
+             "tree/deep/nested/node_modules/b.bin"],
+            "node_modules", 1, "every node_modules at any depth is pruned")
         self.assertNotIn("matched nothing", self.out)
 
     def test_bare_name_matches_whole_components_only(self):
-        self.mkrand("tree/node_modules/a.bin", 4000)
-        self.mkrand("tree/node_modules_old/b.bin", 4000)
-        self.mkrand("tree/xnode_modules/c.bin", 4000)
-        self.scan(self.path("tree"), "--exclude=node_modules")
-        self.assertDmOk()
-        self.assertEqual(2, self.hf_count("files"),
-                         "a substring of a component is not a match")
+        self.assert_kept(
+            ["tree/node_modules/a.bin", "tree/node_modules_old/b.bin",
+             "tree/xnode_modules/c.bin"],
+            "node_modules", 2, "a substring of a component is not a match")
 
     def test_leading_slash_anchors_absolute(self):
-        self.mkrand("tree/cache/a.bin", 4000)
-        self.mkrand("tree/sub/cache/b.bin", 4000)
-        self.scan(self.path("tree"), "--exclude=" + self.path("tree/cache"))
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"),
-                         "an absolute pattern anchors, so the nested cache stays")
+        self.assert_kept(
+            ["tree/cache/a.bin", "tree/sub/cache/b.bin"],
+            self.path("tree/cache"), 1,
+            "an absolute pattern anchors, so the nested cache stays")
 
     def test_interior_slash_matches_any_depth(self):
-        self.mkrand("tree/keep.bin", 4000)
-        self.mkrand("tree/Steam/temp/a.bin", 4000)
-        self.mkrand("tree/deep/Steam/temp/b.bin", 4000)
-        self.scan(self.path("tree"), "--exclude=Steam/temp")
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"))
+        self.assert_kept(
+            ["tree/keep.bin", "tree/Steam/temp/a.bin",
+             "tree/deep/Steam/temp/b.bin"],
+            "Steam/temp", 1)
 
     def test_double_star_crosses_directories(self):
-        self.mkrand("tree/a/t.bin", 4000)
-        self.mkrand("tree/a/b/c/t.bin", 4000)
-        self.mkrand("tree/a/keep.txt", 4000)
-        self.scan(self.path("tree"), "--exclude=a/**/t.bin")
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"), "only keep.txt survives")
+        self.assert_kept(
+            ["tree/a/t.bin", "tree/a/b/c/t.bin", "tree/a/keep.txt"],
+            "a/**/t.bin", 1, "only keep.txt survives")
 
     def test_single_star_does_not_cross_directories(self):
-        self.mkrand("tree/a/x.bin", 4000)
-        self.mkrand("tree/a/b/y.bin", 4000)
-        self.scan(self.path("tree"), "--exclude=" + self.path("tree/a/*.bin"))
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"),
-                         "'*' stops at '/', so the nested file is kept")
+        self.assert_kept(
+            ["tree/a/x.bin", "tree/a/b/y.bin"],
+            self.path("tree/a/*.bin"), 1,
+            "'*' stops at '/', so the nested file is kept")
 
     def test_character_class(self):
-        for n in ("f1.log", "f2.log", "fx.log"):
-            self.mkrand("tree/" + n, 4000)
-        self.scan(self.path("tree"), "--exclude=f[0-9].log")
-        self.assertDmOk()
-        self.assertEqual(1, self.hf_count("files"), "only fx.log survives")
+        self.assert_kept(
+            ["tree/f1.log", "tree/f2.log", "tree/fx.log"],
+            "f[0-9].log", 1, "only fx.log survives")
 
     def test_trailing_slash_matches_directories_only(self):
         self.mkrand("tree/cache/a.bin", 4000)      # a directory named cache


### PR DESCRIPTION
Closes #147.

`--exclude node_modules` matched nothing, silently. Patterns were `fnmatch`'d against the whole path and relative ones were resolved against the cwd, so a bare name could only ever match one literal directory — and usually not even that. Every NAS user's first instinct (`@eaDir`, `.snapshots`, `node_modules`) was a no-op, and the tool said nothing.

## The syntax

The one git, ripgrep and fd already use:

| Pattern | Meaning |
|---|---|
| `@eaDir`, `*.iso` | no `/` → matches the **name at any depth** |
| `/srv/media/cache*` | leading `/` → **absolute**, anchored |
| `Steam/temp` | interior `/` → matches **at any depth** |
| `cache/` | trailing `/` → **directories only** |
| `*` `?` `[a-z]` `**` | `*` stops at `/`, `**` crosses |

Negation (`!`) is deliberately unsupported — last-match-wins ordering is where the complexity and the bugs are, and nobody has asked for it.

Excluding a directory prunes the walk there, so naming a directory also drops everything inside it.

## This is a breaking change

Taken deliberately, **without syntax versioning**, so a pattern only ever has one meaning. Patterns stored in an existing hashfile replay under the new rules — which matters most for scheduled systemd jobs.

Two things blunt the edge:

- **A pattern that matches nothing is now reported**, instead of being silent. That is what catches a stored pattern whose meaning narrowed.
- **A malformed pattern is an error** before the scan starts, on both the command line *and* the replay path, rather than a warning the run ignores while scanning a wider tree and exiting 0.

The widening direction (a stored relative pattern that now matches more) can't be caught by a count, but `-v` already prints `Excluding: <path> (matches <pattern>)` per file, which shows it directly. Documented as *Changed in 1.6.0* in the man page, with an upgrade note in the NAS quick-start where affected users actually look, and in `CLAUDE.md` for contributors.

## Implementation

New `src/glob.{c,h}`. Patterns compile to PCRE2 fragments joined into **one** combined `GRegex`, so matching costs one regex run per path however many patterns there are. Exact absolute paths skip it via a hash lookup. `GRegex` is PCRE2 and GLib was already linked, so **no new dependency**.

The set is compiled once in `filescan_init()` — main thread, before any walker exists — and is read-only afterwards apart from one relaxed `_Atomic bool` per pattern, so the walkers need no lock. The per-pattern regexes survive only to name the matching pattern and apply the directory-only rule, which runs on paths already being excluded, never on the hot negative path.

The hashfile and its `-wal`/`-shm` sidecars register via `add_exclude_path()` and match literally, so a `*` or `[` in the hashfile's own path cannot become a wildcard.

## Performance

`is_excluded()` runs once per directory entry on every walker, so this was measured rather than assumed. With PCRE2's JIT enabled (`G_REGEX_OPTIMIZE`), 4096 realistic paths against 3 patterns:

| | ns/path |
|---|---|
| old: 3× `strcmp` + 3× `fnmatch` | 138 |
| new, without JIT | 3694 |
| **new, as shipped** | **304** |

~2.2× the absolute cost of the old code, but **O(1) in pattern count** rather than O(n) — which is the trade the design is for. The JIT flag is not optional here; without it this would have been a 12× regression on a hot path. (It is also well under the `statx`/btrfs-btree cost that dominates the walk.)

## Testing

9 unit tests over the matching rules, 10 integration tests over observable behaviour — pruning, the `S_ISDIR` plumbing that the unit tests can't reach, the warning, and the malformed-pattern exit code.

`scripts/verify.sh` passes: build with warnings-as-failure, 126 tests, valgrind scan+dedupe+replay smoke.

A `/simplify` pass is the second commit: it found the missing JIT flag, a plain (non-atomic) shared counter written from the walker threads, and the replay path ignoring pattern errors. See that commit message for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)