### PR TITLE
scan: skip read-only subvolumes (snapshots) when deduplicating

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -317,6 +317,30 @@ Requires \f[B]\-\-hashfile\f[R].
 \f[B]\-R\f[R] is for removing paths that still exist.)
 .SS Output and information
 .TP
+\f[B]\-\-skip\-readonly\-subvols\f[R], \f[B]\-\-no\-skip\-readonly\-subvols\f[R]
+Skip (or include) read\-only btrfs subvolumes \(em snapshots taken with
+\f[CR]btrfs subvolume snapshot \-r\f[R], i.e.\ what snapper, Timeshift
+and Synology create.
+\f[B]On by default when deduplicating\f[R] (\f[B]\-d\f[R]), off
+otherwise.
+.RS
+.PP
+A read\-only subvolume can never be a dedupe \f[I]destination\f[R] \(em
+the kernel refuses \(em so under \f[B]\-d\f[R] every file read and
+hashed in one is provably wasted work.
+The saving scales with snapshot count: 20 snapshots of a 1 TiB tree
+means reading \(ti20 TiB to reclaim nothing from 19 of them.
+Without \f[B]\-d\f[R] they are scanned normally, since \(lqwhat
+duplicates exist inside my snapshots?\(rq is a fair question to ask a
+reporting tool.
+.PP
+Detection is by property (the subvolume\(cqs read\-only flag), not by
+directory name, so it never fires on a writable directory that merely
+happens to be called \f[CR].snapshots\f[R].
+The number skipped is reported in the run summary and in
+\f[B]\-\-json\f[R]; the choice is stored in the hashfile and replayed.
+.RE
+.TP
 \f[B]\-q\f[R], \f[B]\-\-quiet\f[R]
 Quiet: print only errors and a one\-line dedupe summary.
 Suppresses the live progress display, the multi\-line summary block, and

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -263,6 +263,26 @@ directory scans the regular files directly inside it; add **-r** to recurse.
 
 ## Output and information
 
+**\--skip-readonly-subvols**, **\--no-skip-readonly-subvols**
+
+  ~ Skip (or include) read-only btrfs subvolumes — snapshots taken with
+    `btrfs subvolume snapshot -r`, i.e. what snapper, Timeshift and Synology
+    create. **On by default when deduplicating** (**-d**), off otherwise.
+
+    A read-only subvolume can never be a dedupe *destination* — the kernel
+    refuses — so under **-d** every file read and hashed in one is provably
+    wasted work. The saving scales with snapshot count: 20 snapshots of a 1 TiB
+    tree means reading ~20 TiB to reclaim nothing from 19 of them. Without
+    **-d** they are scanned normally, since "what duplicates exist inside my
+    snapshots?" is a fair question to ask a reporting tool.
+
+    Detection is by property (the subvolume's read-only flag), not by directory
+    name, so it never fires on a writable directory that merely happens to be
+    called `.snapshots`. The number skipped is reported in the run summary and
+    in **\--json**; the choice is stored in the hashfile and replayed.
+
+<!-- -->
+
 **-q**, **\--quiet**
 
   ~ Quiet: print only errors and a one-line dedupe summary. Suppresses the live

--- a/src/btrfs-util.c
+++ b/src/btrfs-util.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <linux/magic.h>
 #include <linux/btrfs.h>
+#include <linux/btrfs_tree.h>
+#include <stdbool.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -74,5 +76,22 @@ int btrfs_get_fsuuid(int fd, uuid_t *uuid)
 		return errno;
 
 	uuid_copy(*uuid, args.metadata_uuid);
+	return 0;
+}
+
+int btrfs_subvol_is_readonly(int fd, bool *rdonly)
+{
+	struct btrfs_ioctl_get_subvol_info_args args;
+	int ret;
+
+	memset(&args, 0, sizeof(args));
+	/*
+	 * < 0, not != 0: this ioctl returns a positive value on success.
+	 */
+	ret = ioctl(fd, BTRFS_IOC_GET_SUBVOL_INFO, &args);
+	if (ret < 0)
+		return -1;
+
+	*rdonly = !!(args.flags & BTRFS_ROOT_SUBVOL_RDONLY);
 	return 0;
 }

--- a/src/btrfs-util.h
+++ b/src/btrfs-util.h
@@ -17,8 +17,21 @@
 #define	__BTRFS_UTIL__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <uuid/uuid.h>
 
 int lookup_btrfs_subvol(int fd, uint64_t *rootid);
 int btrfs_get_fsuuid(int fd, uuid_t *uuid);
+
+/*
+ * Set *rdonly when fd's containing subvolume is read-only (a snapshot taken
+ * with -r). Returns 0 on success, -1 on failure with *rdonly untouched.
+ *
+ * Uses BTRFS_IOC_GET_SUBVOL_INFO, which resolves the subvolume containing the
+ * inode, rather than BTRFS_IOC_SUBVOL_GETFLAGS, which the kernel rejects with
+ * EINVAL unless fd is the subvolume *root*. The walk meets ordinary
+ * directories, so the latter would only ever answer for a path that happened
+ * to be a subvolume root.
+ */
+int btrfs_subvol_is_readonly(int fd, bool *rdonly);
 #endif	/* __BTRFS_UTIL__ */

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -362,7 +362,8 @@ static int create_tables(sqlite3 *db)
 "skip_permission INTEGER NOT NULL DEFAULT 0, "				\
 "skip_unreadable INTEGER NOT NULL DEFAULT 0, "				\
 "skip_path_too_long INTEGER NOT NULL DEFAULT 0, "			\
-"skip_unsupported_fs INTEGER NOT NULL DEFAULT 0);"
+"skip_unsupported_fs INTEGER NOT NULL DEFAULT 0, "			\
+"readonly_subvols INTEGER NOT NULL DEFAULT 0);"
 	ret = sqlite3_exec(db, CREATE_TABLE_RUN_HISTORY, NULL, NULL, NULL);
 	if (ret)
 		goto out;
@@ -383,6 +384,7 @@ static int create_tables(sqlite3 *db)
 		"ALTER TABLE run_history ADD COLUMN skip_unreadable INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE run_history ADD COLUMN skip_path_too_long INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE run_history ADD COLUMN skip_unsupported_fs INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE run_history ADD COLUMN readonly_subvols INTEGER NOT NULL DEFAULT 0",
 	};
 	for (unsigned int i = 0; i < ARRAY_SIZE(run_history_adds); i++)
 		sqlite3_exec(db, run_history_adds[i], NULL, NULL, NULL);
@@ -1188,6 +1190,8 @@ int dbfile_store_scan_config(struct dbhandle *dbh, const struct scan_config *sc)
 	    (ret = sync_config_int(stmt, "opt_run_dedupe", sc->run_dedupe)) ||
 	    (ret = sync_config_int(stmt, "opt_recurse", sc->recurse)) ||
 	    (ret = sync_config_int(stmt, "opt_skip_zeroes", sc->skip_zeroes)) ||
+	    (ret = sync_config_int(stmt, "opt_skip_readonly_subvols",
+				   sc->skip_readonly_subvols)) ||
 	    (ret = sync_config_int(stmt, "opt_only_whole_files", sc->only_whole_files)) ||
 	    (ret = sync_config_int(stmt, "opt_do_block_hash", sc->do_block_hash)) ||
 	    (ret = sync_config_int(stmt, "opt_dedupe_same_file", sc->dedupe_same_file)) ||
@@ -1276,6 +1280,15 @@ int dbfile_load_scan_config(struct dbhandle *dbh, struct scan_config *sc)
 	get_config_int(stmt, "opt_run_dedupe", &sc->run_dedupe);
 	get_config_int(stmt, "opt_recurse", &sc->recurse);
 	get_config_int(stmt, "opt_skip_zeroes", &sc->skip_zeroes);
+	/*
+	 * Absent in a hashfile written before #156; get_config_int leaves the
+	 * caller's value alone, and scan_config is memset to 0 -- which would
+	 * read as an explicit "no". Pre-seed the auto sentinel so an old
+	 * hashfile replays with the current default rather than opting out.
+	 */
+	sc->skip_readonly_subvols = -1;
+	get_config_int(stmt, "opt_skip_readonly_subvols",
+		       &sc->skip_readonly_subvols);
 	get_config_int(stmt, "opt_only_whole_files", &sc->only_whole_files);
 	get_config_int(stmt, "opt_do_block_hash", &sc->do_block_hash);
 	get_config_int(stmt, "opt_dedupe_same_file", &sc->dedupe_same_file);
@@ -1322,8 +1335,9 @@ int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
 	ret = sqlite3_prepare_v2(dbh->db,
 		"insert into run_history(ts, duration_ms, files_scanned, "
 		"reclaimed, groups, kernel_bytes, deduped, skip_permission, "
-		"skip_unreadable, skip_path_too_long, skip_unsupported_fs) "
-		"values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+		"skip_unreadable, skip_path_too_long, skip_unsupported_fs, "
+		"readonly_subvols) "
+		"values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
 		-1, &stmt, NULL);
 	if (ret)
 		goto out;
@@ -1340,6 +1354,7 @@ int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
 	sqlite3_bind_int64(stmt, 9, r->skip_unreadable);
 	sqlite3_bind_int64(stmt, 10, r->skip_path_too_long);
 	sqlite3_bind_int64(stmt, 11, r->skip_unsupported_fs);
+	sqlite3_bind_int64(stmt, 12, r->readonly_subvols);
 
 	if (sqlite3_step(stmt) != SQLITE_DONE)
 		ret = -1;
@@ -1383,7 +1398,8 @@ int dbfile_get_run_summary(struct dbhandle *dbh, struct run_summary *s)
 	stmt = NULL;
 	ret = sqlite3_prepare_v2(dbh->db,
 		"select skip_permission, skip_unreadable, skip_path_too_long, "
-		"skip_unsupported_fs from run_history order by ts desc limit 1",
+		"skip_unsupported_fs, readonly_subvols "
+		"from run_history order by ts desc limit 1",
 		-1, &stmt, NULL);
 	if (ret) {
 		perror_sqlite(ret, "reading last run skips");
@@ -1394,6 +1410,7 @@ int dbfile_get_run_summary(struct dbhandle *dbh, struct run_summary *s)
 		s->last_skip_unreadable = sqlite3_column_int64(stmt, 1);
 		s->last_skip_path_too_long = sqlite3_column_int64(stmt, 2);
 		s->last_skip_unsupported_fs = sqlite3_column_int64(stmt, 3);
+		s->last_readonly_subvols = sqlite3_column_int64(stmt, 4);
 	}
 	return 0;
 }

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -149,6 +149,7 @@ struct scan_config {
 	int		run_dedupe;
 	int		recurse;
 	int		skip_zeroes;
+	int		skip_readonly_subvols;	/* -1 auto, 0 no, 1 yes (#156) */
 	int		only_whole_files;
 	int		do_block_hash;
 	int		dedupe_same_file;
@@ -192,6 +193,12 @@ struct run_record {
 	uint64_t	skip_unreadable;
 	uint64_t	skip_path_too_long;
 	uint64_t	skip_unsupported_fs;
+	/*
+	 * Read-only subvolumes skipped (#156). Not an error bucket -- it is a
+	 * saving -- but it does mean the run covered less than the given tree,
+	 * so it is recorded and reported rather than left silent.
+	 */
+	uint64_t	readonly_subvols;
 };
 int dbfile_record_run(struct dbhandle *db, const struct run_record *r);
 
@@ -209,6 +216,7 @@ struct run_summary {
 	uint64_t	last_skip_unsupported_fs;
 	/* Lifetime sum of all four, so a total stays honest. */
 	uint64_t	total_skip_errors;
+	uint64_t	last_readonly_subvols;
 };
 int dbfile_get_run_summary(struct dbhandle *db, struct run_summary *s);
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -192,6 +192,8 @@ static const struct {
 	[SCAN_SKIP_EXCLUDED]	  = { "excluded",	"excluded",		false },
 	[SCAN_SKIP_TOO_SMALL]	  = { "too_small",	"below --min-filesize",	false },
 	[SCAN_SKIP_NOT_REGULAR]	  = { "not_regular",	"not a regular file",	false },
+	[SCAN_SKIP_READONLY_SUBVOL] = { "readonly_subvol",
+					"read-only subvolume",		false },
 };
 
 bool scan_skip_is_error(enum scan_skip_bucket b)
@@ -633,6 +635,96 @@ static void verified_dev_free(void)
 	g_clear_pointer(&verified_devs, g_hash_table_destroy);
 }
 
+/*
+ * Read-only-subvolume cache (#156).
+ *
+ * btrfs gives every subvolume its own anonymous st_dev, so read-only-ness is a
+ * per-device fact and one ioctl answers it for every file below. Like
+ * verified_devs (and unlike subvol_cache, which is consumer-thread only) this
+ * is read from check_file() on the walker threads, so it is mutex-guarded.
+ *
+ * Detected by property rather than by directory name: a name list would be
+ * silent, would fire on a real directory that merely happens to be called
+ * .snapshots, and -- being an implicit default -- would never reach
+ * scan_excludes, so a replay's scope would depend on the binary version.
+ */
+struct ro_subvol_ent {
+	bool known;
+	bool rdonly;
+};
+static GHashTable *ro_subvols;		/* dev_t -> struct ro_subvol_ent * */
+static GMutex ro_subvol_lock;
+
+static void ro_subvol_free(void)
+{
+	g_clear_pointer(&ro_subvols, g_hash_table_destroy);
+}
+
+/*
+ * True when `path` (on device `dev`) lives in a read-only btrfs subvolume.
+ * One ioctl per device; the answer is cached for every later path on it.
+ */
+static bool dev_is_readonly_subvol(dev_t dev, const char *path)
+{
+	struct ro_subvol_ent *ent;
+	bool rdonly = false;
+	int fd;
+
+	g_mutex_lock(&ro_subvol_lock);
+	if (!ro_subvols)
+		ro_subvols = g_hash_table_new_full(g_direct_hash, g_direct_equal,
+						   NULL, g_free);
+	ent = g_hash_table_lookup(ro_subvols, GSIZE_TO_POINTER((gsize)dev));
+	if (ent && ent->known) {
+		rdonly = ent->rdonly;
+		g_mutex_unlock(&ro_subvol_lock);
+		return rdonly;
+	}
+	g_mutex_unlock(&ro_subvol_lock);
+
+	/*
+	 * Probe outside the lock: the ioctl is the slow part, and a duplicate
+	 * probe from a second walker is harmless (same answer, idempotent
+	 * insert) where holding the lock across it would serialise the walk.
+	 */
+	fd = longpath_open(path, O_RDONLY);
+	if (fd == -1)
+		return false;	/* unreadable is someone else's error to report */
+	if (btrfs_subvol_is_readonly(fd, &rdonly))
+		rdonly = false;	/* not a subvolume, or an old kernel: scan it */
+	close(fd);
+
+	g_mutex_lock(&ro_subvol_lock);
+	ent = g_hash_table_lookup(ro_subvols, GSIZE_TO_POINTER((gsize)dev));
+	if (!ent) {
+		ent = g_malloc0(sizeof(*ent));
+		g_hash_table_insert(ro_subvols, GSIZE_TO_POINTER((gsize)dev), ent);
+	}
+	if (!ent->known) {
+		ent->known = true;
+		ent->rdonly = rdonly;
+		/*
+		 * Count subvolumes, not files: the skip happens at the
+		 * subvolume's root directory and never descends, so this fires
+		 * once per snapshot -- the number the summary should report.
+		 */
+		if (rdonly)
+			filescan_count_skip(SCAN_SKIP_READONLY_SUBVOL);
+	}
+	rdonly = ent->rdonly;
+	g_mutex_unlock(&ro_subvol_lock);
+
+	return rdonly;
+}
+
+/* Whether this run should skip read-only subvolumes (-1 = auto: iff -d). */
+static bool skipping_readonly_subvols(void)
+{
+	if (options.skip_readonly_subvols < 0)
+		return options.run_dedupe;
+	return options.skip_readonly_subvols != 0;
+}
+
 static char *extract_first_device(const char *fs_source)
 {
 	const char *colon;
@@ -816,6 +908,31 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		vprintf("Skipping file below --min-filesize: %s (%llu < %"PRIu64")\n",
 			path, st->stx_size, options.min_filesize);
 		filescan_count_skip(SCAN_SKIP_TOO_SMALL);
+		return false;
+	}
+
+	/*
+	 * Read-only subvolumes (snapshots) are dead weight under -d (#156).
+	 *
+	 * Pointed at the normal shape of a NAS or a snapper/Timeshift desktop,
+	 * the walk descends into every read-only snapshot and reads and hashes
+	 * every file in it. The result is *safe* - the already-shared check
+	 * catches them before any ioctl - but by then all the read and hash I/O
+	 * has been spent, and it scales with snapshot count: 20 snapshots of a
+	 * 1 TiB tree means reading ~20 TiB to reclaim nothing from 19 of them.
+	 *
+	 * The kernel refuses a read-only destination, so under -d this work is
+	 * provably wasted, not merely usually wasted. In report mode it is not:
+	 * asking "what duplicates exist inside my snapshots?" is a reasonable
+	 * thing to ask a reporting tool, so the default keys off -d.
+	 *
+	 * Checked after the config skips so an explicit --exclude still wins,
+	 * and before the locked-fs probe so a snapshot costs one ioctl rather
+	 * than a full probe. Non-btrfs filesystems have no subvolumes at all.
+	 */
+	if (locked_fs.is_btrfs && skipping_readonly_subvols() &&
+	    dev_is_readonly_subvol(stx_to_dev(st), path)) {
+		vprintf("Skipping read-only subvolume: %s\n", path);
 		return false;
 	}
 
@@ -2617,6 +2734,7 @@ void filescan_free(void)
 	scan_writer_close();
 	subvol_cache_free();
 	verified_dev_free();
+	ro_subvol_free();
 	seen_inodes_free();
 
 	g_clear_pointer(&excludes, glob_set_free);

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -67,6 +67,7 @@ enum scan_skip_bucket {
 	SCAN_SKIP_EXCLUDED,		/* --exclude matched */
 	SCAN_SKIP_TOO_SMALL,		/* below --min-filesize */
 	SCAN_SKIP_NOT_REGULAR,		/* neither a regular file nor a directory */
+	SCAN_SKIP_READONLY_SUBVOL,	/* read-only btrfs subvolume, see #156 */
 	SCAN_SKIP__COUNT
 };
 

--- a/src/oans.c
+++ b/src/oans.c
@@ -114,6 +114,10 @@ static char *scan_config_options_str(const struct scan_config *sc)
 		g_string_append(s, "-d ");
 	if (sc->skip_zeroes)
 		g_string_append(s, "--skip-zeroes ");
+	if (sc->skip_readonly_subvols == 0)
+		g_string_append(s, "--no-skip-readonly-subvols ");
+	else if (sc->skip_readonly_subvols == 1)
+		g_string_append(s, "--skip-readonly-subvols ");
 	if (sc->min_filesize > 1)
 		g_string_append_printf(s, "--min-filesize=%"PRIu64" ", sc->min_filesize);
 
@@ -496,6 +500,12 @@ static int print_metrics_json(char *filename)
 	printf("    \"unsupported_fs\": %"PRIu64"\n", sum.last_skip_unsupported_fs);
 	printf("  },\n");
 	printf("  \"scan_skipped_errors_total\": %"PRIu64",\n", sum.total_skip_errors);
+	/*
+	 * Deliberately outside the error object: a skipped snapshot is a saving,
+	 * not a fault, but it does mean the run covered less than the tree (#156).
+	 */
+	printf("  \"readonly_subvols_skipped_last_run\": %"PRIu64",\n",
+	       sum.last_readonly_subvols);
 	printf("  \"last_run_ts\": %"PRId64"\n", sum.last_ts);
 	printf("}\n");
 	return 0;
@@ -639,6 +649,8 @@ enum {
 	IO_THREADS_OPTION,
 	CPU_THREADS_OPTION,
 	SKIP_ZEROES_OPTION,
+	SKIP_RO_SUBVOLS_OPTION,
+	NO_SKIP_RO_SUBVOLS_OPTION,
 	DEDUPE_OPTS_OPTION,
 	QUIET_OPTION,
 	EXCLUDE_OPTION,
@@ -732,6 +744,9 @@ static void help(void)
 "  -q, --quiet                 print only errors and a one-line summary\n"
 "  -v                          verbose output\n"
 "      --progress=json         stream machine-readable progress (JSONL) to stderr\n"
+"      --[no-]skip-readonly-subvols\n"
+"                              skip read-only subvolumes (snapshots) when\n"
+"                              deduplicating; on by default with -d\n"
 "      --no-color              disable colored output\n"
 "      --debug                 print debug messages (implies -v)\n"
 "      --version               print version and exit\n"
@@ -756,6 +771,8 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "io-threads", 1, NULL, IO_THREADS_OPTION },
 		{ "cpu-threads", 1, NULL, CPU_THREADS_OPTION },
 		{ "skip-zeroes", 0, NULL, SKIP_ZEROES_OPTION },
+		{ "skip-readonly-subvols", 0, NULL, SKIP_RO_SUBVOLS_OPTION },
+		{ "no-skip-readonly-subvols", 0, NULL, NO_SKIP_RO_SUBVOLS_OPTION },
 		{ "dedupe-options", 1, NULL, DEDUPE_OPTS_OPTION },
 		{ "quiet", 0, NULL, QUIET_OPTION },
 		{ "exclude", 1, NULL, EXCLUDE_OPTION },
@@ -826,6 +843,12 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 			break;
 		case SKIP_ZEROES_OPTION:
 			options.skip_zeroes = true;
+			break;
+		case SKIP_RO_SUBVOLS_OPTION:
+			options.skip_readonly_subvols = 1;
+			break;
+		case NO_SKIP_RO_SUBVOLS_OPTION:
+			options.skip_readonly_subvols = 0;
 			break;
 		case DEDUPE_OPTS_OPTION:
 			if (parse_dedupe_opts(optarg))
@@ -1336,12 +1359,26 @@ static void report_scan_skips(const uint64_t *skips)
 		printf(" %s(rerun with -v for detail)%s\n", col_dim, col_reset);
 	}
 
+	/*
+	 * Read-only subvolumes are reported by default, not just under -v: this
+	 * is the one config-ish bucket that *shrinks the scan the user asked
+	 * for*, and a default that quietly covers less is the same class of
+	 * surprise as the silent --exclude no-op #147 removed (#156).
+	 */
+	if (skips[SCAN_SKIP_READONLY_SUBVOL])
+		printf("  %sSnapshots%s      %"PRIu64" read-only subvolume%s skipped "
+		       "%s(--no-skip-readonly-subvols to include them)%s\n",
+		       col_dim, col_reset, skips[SCAN_SKIP_READONLY_SUBVOL],
+		       skips[SCAN_SKIP_READONLY_SUBVOL] == 1 ? "" : "s",
+		       col_dim, col_reset);
+
 	if (!verbose)
 		return;
 
 	sep = "";
 	for (i = 0; i < SCAN_SKIP__COUNT; i++) {
-		if (!skips[i] || scan_skip_is_error(i))
+		if (!skips[i] || scan_skip_is_error(i) ||
+		    i == SCAN_SKIP_READONLY_SUBVOL)
 			continue;
 		if (!*sep)
 			printf("  %sNot scanned%s    ", col_dim, col_reset);
@@ -1452,6 +1489,7 @@ static int apply_scan_config(const struct scan_config *sc)
 	options.run_dedupe = sc->run_dedupe;
 	options.recurse_dirs = sc->recurse;
 	options.skip_zeroes = sc->skip_zeroes;
+	options.skip_readonly_subvols = sc->skip_readonly_subvols;
 	options.only_whole_files = sc->only_whole_files;
 	options.do_block_hash = sc->do_block_hash;
 	options.dedupe_same_file = sc->dedupe_same_file;
@@ -1541,6 +1579,7 @@ static void persist_scan_config(struct dbhandle *db, char **roots, int nroots)
 	sc.run_dedupe = options.run_dedupe;
 	sc.recurse = options.recurse_dirs;
 	sc.skip_zeroes = options.skip_zeroes;
+	sc.skip_readonly_subvols = options.skip_readonly_subvols;
 	sc.only_whole_files = options.only_whole_files;
 	sc.do_block_hash = options.do_block_hash;
 	sc.dedupe_same_file = options.dedupe_same_file;
@@ -1759,6 +1798,7 @@ int main(int argc, char **argv)
 				.skip_unreadable = scan_skips[SCAN_SKIP_UNREADABLE],
 				.skip_path_too_long = scan_skips[SCAN_SKIP_PATH_TOO_LONG],
 				.skip_unsupported_fs = scan_skips[SCAN_SKIP_UNSUPPORTED_FS],
+				.readonly_subvols = scan_skips[SCAN_SKIP_READONLY_SUBVOL],
 			};
 			dbfile_record_run(db, &rec);
 		}

--- a/src/opt.c
+++ b/src/opt.c
@@ -19,6 +19,7 @@ struct options options = {
 	.io_threads = 0,
 	.cpu_threads = 0,
 	.skip_zeroes = false,
+	.skip_readonly_subvols = -1,	/* auto: on when deduplicating */
 	.only_whole_files = false,
 	.do_block_hash = false,
 	.dedupe_same_file = true,

--- a/src/opt.h
+++ b/src/opt.h
@@ -29,6 +29,14 @@ struct options {
 	unsigned int io_threads;
 	unsigned int cpu_threads;
 	bool skip_zeroes : 1;
+	/*
+	 * Skip read-only btrfs subvolumes (snapshots) when deduplicating. A
+	 * read-only subvolume can never be a dedupe *destination* -- the kernel
+	 * refuses -- so under -d the read and hash of every file in it is
+	 * provably wasted, not merely usually wasted. Tri-state so an explicit
+	 * --[no-]skip-readonly-subvols beats the -d-derived default (#156).
+	 */
+	int skip_readonly_subvols;	/* -1 = auto (on iff -d), 0 = no, 1 = yes */
 	bool only_whole_files : 1;
 	bool do_block_hash : 1;
 	bool dedupe_same_file : 1;

--- a/tests/integration/test_readonly_subvols.py
+++ b/tests/integration/test_readonly_subvols.py
@@ -1,0 +1,144 @@
+"""Read-only btrfs subvolumes are dead weight under -d (#156).
+
+Pointed at the normal shape of a NAS or a snapper/Timeshift desktop, oans used
+to walk into every read-only snapshot and read and hash every file in it. The
+behaviour was *safe* -- the already-shared check catches them before any ioctl
+-- but by then all the read and hash I/O had been spent, and the waste scales
+with snapshot count: 20 snapshots of a 1 TiB tree means reading ~20 TiB to
+reclaim nothing from 19 of them.
+
+Detected by property (BTRFS_IOC_GET_SUBVOL_INFO -> BTRFS_ROOT_SUBVOL_RDONLY),
+not by directory name, so it catches snapper, Timeshift and Synology alike and
+never fires on a writable directory that merely happens to be called
+".snapshots".
+"""
+
+import json
+import os
+import subprocess
+import unittest
+
+from harness import DuperemoveTest, requires_btrfs
+
+
+def _btrfs(*args):
+    return subprocess.run(["btrfs", *args], stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL).returncode == 0
+
+
+@requires_btrfs
+class ReadonlySubvolTest(DuperemoveTest):
+    def setUp(self):
+        super().setUp()
+        self.live = os.path.join(self.work, "live")
+        if not _btrfs("subvolume", "create", self.live):
+            self.skipTest("cannot create a btrfs subvolume here")
+
+    def tearDown(self):
+        # Subvolumes must be deleted with the ioctl, not rmtree.
+        for name in ("snap1", "snap2", "live"):
+            _btrfs("subvolume", "delete", os.path.join(self.work, name))
+        super().tearDown()
+
+    def _snapshot(self, name, readonly=True):
+        args = ["subvolume", "snapshot"]
+        if readonly:
+            args.append("-r")
+        dst = os.path.join(self.work, name)
+        self.assertTrue(_btrfs(*args, self.live, dst),
+                        f"could not snapshot into {name}")
+        return dst
+
+    def _live_dups(self):
+        """Two duplicate files inside the live subvolume."""
+        data = os.urandom(200000)
+        for name in ("a.bin", "b.bin"):
+            with open(os.path.join(self.live, name), "wb") as f:
+                f.write(data)
+        self.sync()
+
+    def _scanned(self):
+        return {os.path.basename(os.path.dirname(row[0]))
+                for row in self.hf_query("select filename from files")}
+
+    def test_dedupe_does_not_hash_a_readonly_snapshot(self):
+        """The whole point: no read, no hash, no hashfile rows."""
+        self._live_dups()
+        self._snapshot("snap1")
+        self.dedupe(self.work)
+        self.assertDmOk()
+        self.assertNotIn("snap1", self._scanned(),
+                         "the read-only snapshot was hashed anyway")
+        self.assertIn("live", self._scanned())
+
+    def test_report_mode_still_covers_snapshots(self):
+        """Without -d, "what duplicates exist in my snapshots?" is fair to ask."""
+        self._live_dups()
+        self._snapshot("snap1")
+        self.scan(self.work)
+        self.assertDmOk()
+        self.assertIn("snap1", self._scanned(),
+                      "report mode should not skip snapshots")
+
+    def test_skip_is_reported_not_silent(self):
+        """A default that quietly shrinks the scan is the #147 failure mode."""
+        self._live_dups()
+        self._snapshot("snap1")
+        self.dedupe(self.work)
+        self.assertIn("read-only subvolume", self.out,
+                      "the skip was silent")
+
+    def test_skip_is_counted_per_subvolume_not_per_file(self):
+        self._live_dups()
+        self._snapshot("snap1")
+        self._snapshot("snap2")
+        self.dedupe(self.work)
+        self.assertIn("2 read-only subvolumes skipped", self.out)
+
+    def test_opt_out_scans_them_again(self):
+        self._live_dups()
+        self._snapshot("snap1")
+        self.dm("-rd", "--no-skip-readonly-subvols", self.work)
+        self.assertDmOk()
+        self.assertIn("snap1", self._scanned(),
+                      "--no-skip-readonly-subvols was ignored")
+
+    def test_opt_out_survives_a_replay(self):
+        """The choice is scan-shaping, so the hashfile must remember it.
+
+        Otherwise a scheduled job's scope would silently change the first time
+        it replayed, which is exactly what the stored-config design prevents.
+        """
+        self._live_dups()
+        self._snapshot("snap1")
+        self.dm("-rd", "--no-skip-readonly-subvols", self.work)
+        rows_before = len(self.hf_query("select filename from files"))
+
+        # Bare replay: no paths, no options.
+        self.dm(hashfile=True)
+        self.assertDmOk()
+        self.assertEqual(rows_before,
+                         len(self.hf_query("select filename from files")),
+                         "the replay dropped the snapshot the opt-out included")
+
+    def test_writable_snapshot_is_still_scanned(self):
+        """Read-only-ness is the criterion, not "is a snapshot"."""
+        self._live_dups()
+        self._snapshot("snap1", readonly=False)
+        self.dedupe(self.work)
+        self.assertDmOk()
+        self.assertIn("snap1", self._scanned(),
+                      "a writable snapshot must still be deduplicated")
+
+    def test_skip_reaches_json(self):
+        self._live_dups()
+        self._snapshot("snap1")
+        self.dedupe(self.work)
+        metrics = json.loads(self.dm("--json"))
+        self.assertEqual(1, metrics["readonly_subvols_skipped_last_run"])
+        # A saving, not a fault: it must not raise the error total.
+        self.assertEqual(0, metrics["scan_skipped_errors_total"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #156. **PR 3 of 3 in a stack** — based on #163 (scan skip counters), which is based on #162 (`-q` fix). Review last.

Pointed at a tree containing snapshots — the normal shape of a NAS or a snapper/Timeshift desktop — oans read and hashed every file in every read-only snapshot for no possible gain. The behaviour was safe (the already-shared check catches them before any ioctl), but by then all the I/O had been spent. 20 snapshots of a 1 TiB tree means reading ~20 TiB to reclaim nothing from 19 of them.

## Before / after

```console
$ oans -rd --hashfile=/tmp/h.db $T          # live subvol + one -r snapshot
  Snapshots      1 read-only subvolume skipped (--no-skip-readonly-subvols to include them)
Summary
  Reclaimed      195.3 KiB across 1 group

$ sqlite3 /tmp/h.db "select filename from files"
.../live/a.bin
.../live/big.bin
.../live/big2.bin      # the snapshot's copies are absent, not hashed-then-discarded
```

## One deviation worth flagging

The issue proposed `BTRFS_IOC_SUBVOL_GETFLAGS`. That doesn't work here: the kernel rejects it with `EINVAL` unless the fd is the subvolume **root**, and the walk meets ordinary directories. I used `BTRFS_IOC_GET_SUBVOL_INFO`, which resolves the containing subvolume from any inode — verified on a real snapshot:

```
.../live         treeid=276 flags=0x0 rdonly=0
.../snap1        treeid=277 flags=0x1 rdonly=1
.../live/a.bin   treeid=276 flags=0x0 rdonly=0
.../snap1/a.bin  treeid=277 flags=0x1 rdonly=1   <- a plain file, not the subvol root
```

It also returns a **positive** value on success, so the check is `< 0`, not `!= 0` (this cost me a confusing "failed: Success" while probing).

## Design points, all from the issue

- **By property, not by name.** No `.snapshots` list: it's silent, fires on a writable directory that merely has that name, and being an implicit default would never reach `scan_excludes`, so a replay's scope would depend on the binary version.
- **Cache keyed by `st_dev`**, since btrfs gives every subvolume a distinct anonymous one. It rides alongside `verified_devs` rather than `subvol_cache` — `check_file()` runs on the **walker** threads, so it needs the mutex; `subvol_cache` is consumer-thread only and can't be reused here. The ioctl is done outside the lock (a duplicate probe from a second walker is harmless and idempotent; holding the lock across it would serialise the walk).
- **Only under `-d`.** Report mode still covers snapshots — "what duplicates exist inside my snapshots?" is a fair question for a reporting tool. `--[no-]skip-readonly-subvols` forces either way.
- **Reported, not silent**, in the summary and `--json`. Uses #145's accounting rather than a parallel counter, as the issue asked. The bucket is *not* an error bucket (a skipped snapshot is a saving) but does print by default rather than under `-v`, because it's the one config-ish bucket that shrinks the scan the user asked for.
- **Stored in the hashfile and replayed**, since it's scan-shaping. An old hashfile pre-seeds the auto sentinel, so a missing key doesn't read as an explicit "no". Additive config key — no `DB_FILE_MINOR` bump.

On the issue's open question (should a read-only subvolume still be hashed to serve as a dedupe *source*): I went with your inclination — no. Hashing them is the entire cost this removes, and if the content matched, the extents are usually already shared.

## Testing

- New `tests/integration/test_readonly_subvols.py` — 8 cases against real `btrfs subvolume snapshot -r` (unprivileged): snapshots aren't hashed under `-d`, report mode still covers them, the skip is reported, counted per-subvolume not per-file, the opt-out works and survives a bare replay, a **writable** snapshot is still deduplicated, and the count reaches `--json` without inflating the error total.
- `scripts/verify.sh` passes: build clean, 146 tests, valgrind smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)