### PR TITLE
scan: stage block digests in a bounded batch

### DIFF
--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -388,6 +388,34 @@ struct buffer {
  * extents_count and blocks_count are the size of the allocated arrays
  * extents_index and blocks_index are the index of the next free entries
  */
+/*
+ * Cap on the block digests held in memory for one file (#161).
+ *
+ * Block hashes are write-only while a file is being scanned: each is filled
+ * once, in file order, and then only serialized to the database. Holding all of
+ * them meant one 8 TiB file at -b 4K needed ~48 GiB of anonymous memory
+ * (2^31 blocks x 24 bytes) purely as a staging buffer, which is an OOM rather
+ * than a slowdown.
+ *
+ * So the array is a bounded ring: once it fills, the batch is flushed to the
+ * hashfile and reused. 64Ki entries is 1.5 MiB of struct block_csum, and even
+ * at the 4K minimum blocksize that is 256 MiB of file data per flush - rare
+ * enough that the extra lock acquisitions do not matter, while the memory is
+ * now flat in file size instead of linear.
+ *
+ * Only reached with --dedupe-options=partial; block hashing is off by default.
+ */
+#define BLOCK_BATCH_MAX		(64U * 1024)
+
+/*
+ * Test hook only: DUPEREMOVE_BLOCK_BATCH lowers the cap so the flush path is
+ * reachable without writing a multi-hundred-GB file. Read once, on the main
+ * thread in filescan_init(), before any worker exists - so the workers see a
+ * constant and need no synchronisation. Unset (the default) is unchanged
+ * behaviour.
+ */
+static unsigned int block_batch_max = BLOCK_BATCH_MAX;
+
 struct hashes {
 	unsigned int extents_count;
 	unsigned int extents_index;
@@ -396,6 +424,16 @@ struct hashes {
 	unsigned int blocks_count;
 	unsigned int blocks_index;
 	struct block_csum *blocks;
+	/*
+	 * Batches already written to the hashfile. Only ever non-zero for a
+	 * file large enough to overflow BLOCK_BATCH_MAX, and used solely to
+	 * assert that an early flush and the inlined-file check cannot both
+	 * apply to the same file.
+	 */
+	uint64_t blocks_flushed;
+	/* Where an early flush writes to; NULL until csum_whole_file sets it. */
+	struct dbhandle *db;
+	int64_t fileid;
 };
 
 struct scan_ctxt {
@@ -476,6 +514,14 @@ static bool allocate_hashes(struct hashes *hashes, struct scan_ctxt *ctxt)
 	size_t max_blocks = ctxt->filesize / blocksize + 1;
 	if (mapped_blocks > max_blocks)
 		mapped_blocks = max_blocks;
+
+	/*
+	 * Never allocate beyond one batch: past that the array is recycled, so
+	 * a huge file no longer sizes its staging buffer from its own length
+	 * (#161).
+	 */
+	if (mapped_blocks > block_batch_max)
+		mapped_blocks = block_batch_max;
 
 	hashes->blocks_count = mapped_blocks + 1;
 	hashes->blocks = calloc(hashes->blocks_count, sizeof(struct block_csum));
@@ -1658,13 +1704,63 @@ static int ensure_hash_capacity(void **arr, unsigned int *count,
 	return 0;
 }
 
+/*
+ * Write the block digests gathered so far to the hashfile and reset the batch.
+ *
+ * Takes the write lock itself: unlike the end-of-file store this runs in the
+ * middle of the read+hash loop, with no lock held. Uses the same batched-writer
+ * bracket as everything else on the scan path, so the rows join the current
+ * transaction rather than forcing a commit of their own.
+ */
+static int flush_block_hashes(struct hashes *hashes)
+{
+	int ret;
+
+	if (!hashes->blocks_index)
+		return 0;
+
+	dbfile_lock();
+	ret = scan_write_begin();
+	if (ret) {
+		dbfile_unlock();
+		return ret;
+	}
+
+	ret = dbfile_store_block_hashes(hashes->db, hashes->fileid,
+					hashes->blocks_index, hashes->blocks);
+	if (ret)
+		scan_write_abort();
+	else
+		ret = scan_write_end();
+	dbfile_unlock();
+
+	if (ret)
+		return ret;
+
+	hashes->blocks_flushed += hashes->blocks_index;
+	hashes->blocks_index = 0;
+	return 0;
+}
+
 static int add_block_hash(struct hashes *hashes,
 			  uint64_t loff, unsigned char *digest)
 {
-	int ret = ensure_hash_capacity((void **)&hashes->blocks,
-				       &hashes->blocks_count,
-				       hashes->blocks_index,
-				       sizeof(struct block_csum));
+	int ret;
+
+	/*
+	 * Full batch: drain it before adding, so the array never grows past
+	 * BLOCK_BATCH_MAX no matter how large the file is (#161).
+	 */
+	if (hashes->blocks_index >= block_batch_max) {
+		ret = flush_block_hashes(hashes);
+		if (ret)
+			return ret;
+	}
+
+	ret = ensure_hash_capacity((void **)&hashes->blocks,
+				   &hashes->blocks_count,
+				   hashes->blocks_index,
+				   sizeof(struct block_csum));
 	if (ret)
 		return ret;
 
@@ -2194,6 +2290,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	/* Prevent close on fd 0 if, somehow, an error occurs before we open */
 	ctxt.fd = -1;
 
+	/* Where an over-full block batch drains to, mid-file (#161). */
+	hashes.db = db;
+	hashes.fileid = file->fileid;
+
 	uint64_t t_start = mono_ns(), t_hash = 0, t_done = 0;	/* calibration */
 
 	if (!(buffer->buf)) {
@@ -2377,7 +2477,16 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		return;
 	}
 
-	/* Do not store the blocks if the file is inlined */
+	/*
+	 * Do not store the blocks if the file is inlined.
+	 *
+	 * An inlined extent is at most a page, so such a file can never have
+	 * reached block_batch_max and flushed early - if it had, this check
+	 * would be skipping only the tail while earlier batches were already
+	 * committed. Assert the invariant rather than trust the arithmetic.
+	 */
+	abort_on(inlined && hashes.blocks_flushed != 0);
+
 	if (hashes.blocks_index != 0 && !inlined) {
 		ret = dbfile_store_block_hashes(db, file->fileid,
 						hashes.blocks_index, hashes.blocks);
@@ -2703,6 +2812,15 @@ void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits)
 
 void filescan_init(void)
 {
+	const char *batch_env = getenv("DUPEREMOVE_BLOCK_BATCH");
+
+	if (batch_env) {
+		unsigned long v = strtoul(batch_env, NULL, 10);
+
+		if (v > 0 && v <= BLOCK_BATCH_MAX)
+			block_batch_max = (unsigned int)v;
+	}
+
 	abort_on(scan_workq.workers);
 	abort_on(scan_writer_open());
 	seen_inodes_init();

--- a/tests/integration/test_block_batching.py
+++ b/tests/integration/test_block_batching.py
@@ -1,0 +1,120 @@
+"""Block digests are staged in a bounded batch, not one array per file (#161).
+
+Block hashes are write-only during a scan: each is filled once, in file order,
+then only serialized to the hashfile. Holding all of them meant an 8 TiB file at
+-b 4K needed ~48 GiB of anonymous memory (2^31 blocks x 24 bytes) purely as a
+staging buffer -- an OOM, not a slowdown.
+
+The array is now recycled every BLOCK_BATCH_MAX entries. These tests use the
+DUPEREMOVE_BLOCK_BATCH hook to force many flushes on small files; what has to
+hold is that flushing changes nothing observable -- same digests, same row
+count, same dedupe outcome.
+
+Block hashing only happens under --dedupe-options=partial, which is off by
+default, so every test here passes it explicitly.
+"""
+
+import os
+import unittest
+
+from harness import DuperemoveTest, requires_reflink
+
+PARTIAL = "--dedupe-options=partial"
+# 4K blocks over 1 MiB files gives 256 block digests per file, so a batch of
+# 16 forces 16 flushes per file -- plenty of boundary crossings.
+SMALL_BATCH = {"DUPEREMOVE_BLOCK_BATCH": "16"}
+BLOCK_ARGS = ("-b", "4K", PARTIAL)
+
+
+class BlockBatchingTest(DuperemoveTest):
+    def _block_rows(self):
+        return self.hf_query(
+            "select f.filename, b.loff, quote(b.digest) from blocks b "
+            "join files f on f.id = b.fileid order by f.filename, b.loff")
+
+    def _file_digests(self):
+        return self.hf_query(
+            "select filename, quote(digest) from files order by filename")
+
+    def test_flushing_does_not_change_the_stored_digests(self):
+        """The batch boundary must be invisible in the hashfile."""
+        self.mkdup("tree/a.bin", "tree/b.bin", 1 << 20)
+        self.scan(self.path("tree"), *BLOCK_ARGS)
+        self.assertDmOk()
+        unbatched_blocks = self._block_rows()
+        unbatched_files = self._file_digests()
+        self.assertEqual(512, len(unbatched_blocks),
+                         "expected 256 block digests per 1 MiB file at -b 4K")
+
+        # Same tree, same options, but flushing every 16 blocks.
+        os.unlink(self.hf)
+        self.dm("-r", self.path("tree"), *BLOCK_ARGS, env=SMALL_BATCH)
+        self.assertDmOk()
+
+        self.assertEqual(unbatched_blocks, self._block_rows(),
+                         "batched flushing changed the block digests")
+        self.assertEqual(unbatched_files, self._file_digests(),
+                         "batched flushing changed the file digests")
+
+    def test_no_duplicate_or_missing_rows_across_flushes(self):
+        """Each block is written exactly once, however the batches fall."""
+        self.mkrand("tree/a.bin", 1 << 20)
+        self.dm("-r", self.path("tree"), *BLOCK_ARGS, env=SMALL_BATCH)
+        self.assertDmOk()
+
+        total = self.hf_scalar("select count(*) from blocks")
+        distinct = self.hf_scalar("select count(*) from "
+                                  "(select distinct fileid, loff from blocks)")
+        self.assertEqual(total, distinct, "a block was stored twice")
+        self.assertEqual(256, total, "a block went missing across a flush")
+
+    def test_batch_size_does_not_change_the_row_count(self):
+        """Sweep the boundary: a size that divides evenly, and one that doesn't."""
+        self.mkrand("tree/a.bin", 1 << 20)
+        counts = {}
+        for batch in ("7", "16", "64", "255", "256", "257"):
+            os.unlink(self.hf) if os.path.exists(self.hf) else None
+            self.dm("-r", self.path("tree"), *BLOCK_ARGS,
+                    env={"DUPEREMOVE_BLOCK_BATCH": batch})
+            self.assertDmOk(f"scan failed at batch={batch}")
+            counts[batch] = self.hf_scalar("select count(*) from blocks")
+        self.assertEqual({256}, set(counts.values()),
+                         f"row count varied with batch size: {counts}")
+
+    @requires_reflink
+    def test_partial_dedupe_still_works_after_flushing(self):
+        """The rows are not just present, they are still usable."""
+        a, b = self.mkdup("tree/a.bin", "tree/b.bin", 1 << 20)
+        self.sync()
+        self.dm("-rd", *BLOCK_ARGS, self.path("tree"), env=SMALL_BATCH)
+        self.assertDmOk()
+        self.assertShared(a, b, "partial dedupe failed after batched flushes")
+
+    @requires_reflink
+    def test_data_is_unchanged(self):
+        self.mkdup("tree/a.bin", "tree/b.bin", 1 << 20)
+        self.sync()
+        before = self.tree_digest(self.path("tree"))
+        self.dm("-rd", *BLOCK_ARGS, self.path("tree"), env=SMALL_BATCH)
+        self.assertDmOk()
+        self.assertEqual(before, self.tree_digest(self.path("tree")),
+                         "file contents changed")
+
+    def test_tiny_file_never_trips_the_inlined_assert(self):
+        """An inlined file must not have flushed early.
+
+        csum_whole_file() skips storing blocks for an inlined file entirely; if
+        such a file had already flushed a batch, that check would be dropping
+        only the tail while earlier batches sat committed. The batch cap is far
+        above the inline limit so it cannot happen -- this pins that a
+        one-block-batch run over tiny files still exits cleanly.
+        """
+        for i in range(4):
+            self.write(f"tree/tiny{i}.bin", b"x" * 100)
+        self.dm("-r", self.path("tree"), *BLOCK_ARGS,
+                env={"DUPEREMOVE_BLOCK_BATCH": "1"})
+        self.assertDmOk()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #161 (reported by @crass). **Independent of the #162 → #163 → #164 stack** — it touches the hashing path, not the reporting plumbing, so it can be reviewed and merged on its own.

Block digests were accumulated for a whole file and written once at the end, so the array was a staging buffer that scaled with the file. @crass's arithmetic checks out exactly: `sizeof(struct block_csum)` is 24 bytes (8-byte `loff` + 16-byte `DIGEST_LEN`), so 8 TiB at `-b 4K` is 2³¹ × 24 ≈ **48 GiB** of anonymous memory to hold data that is written once and read once, in order.

Now the array is recycled every `BLOCK_BATCH_MAX` (64Ki) entries — 1.5 MiB, and 256 MiB of file data per flush even at the 4K minimum blocksize.

## Measured

16 GiB file, `-b 4K --dedupe-options=partial`, interleaved A/B against a separately-built `master` binary (confirmed distinct):

| | peak RSS | wall |
|---|---|---|
| master | 203500 kB / 201804 kB | 34.9 s / 38.6 s |
| this branch | **147036 kB / 146272 kB** | 38.9 s / 38.4 s |

~56 MB saved, wall unchanged, and the saving grows linearly with file size. Block digests and file digests are byte-identical either way.

Worth noting for anyone repeating this: at 1 and 4 GiB the difference is **invisible** — peak RSS there is set later, when the dup search loads the block hashes back out of the hashfile, not by the scan-phase staging buffer. You need a file big enough for the staging array to dominate before the effect shows.

## Two things found while implementing

- **Block hashing is off by default.** `opt.c` has `do_block_hash = false`; only `--dedupe-options=partial` turns it on, so the default scan path never filled this array. It *did* still allocate it (`allocate_hashes()` callocs unconditionally), but a large `calloc` is lazily-faulted anonymous memory and `process_blocks()` returns early without touching it — so that was address space, not resident memory. I capped the allocation anyway since it's free to do.
- **The inlined-file interaction needed an invariant.** `csum_whole_file()` deliberately stores no blocks for an inlined file, and that check runs at end of file — which would be wrong if such a file had already flushed a batch (it would drop only the tail while earlier batches sat committed). An inlined extent is at most a page so it can't approach the bound; there's an `abort_on()` asserting it rather than trusting the arithmetic.

## Testing

- New `tests/integration/test_block_batching.py` — 6 cases via a `DUPEREMOVE_BLOCK_BATCH` test hook that forces many flushes on small files: digests identical with and without flushing, no duplicate or missing rows, row count invariant across batch sizes that do and don't divide evenly (7/16/64/255/256/257), partial dedupe still works afterwards, file contents unchanged, and a one-block batch over tiny files doesn't trip the inlined assert.
- `scripts/verify.sh` passes: build clean, 132 tests, valgrind smoke.

## On the rest of @crass's issues

Happy to write these up on the issues themselves if useful — short version:

- **#160** (don't write block records) is already the default, and its rationale doesn't hold: `blocksize` never affects the extent digest, which `process_extents()` computes over the fiemap extent's own bytes.
- **#157** (periodic commit) is already done — `COMMIT_INTERVAL_SEC = 10.0` in `file_scan.c`. What's actually missing is a commit *mid-file*, which needs #159.
- **#158** (hash of hashes) has a correct observation — two running checksums cover every byte by default — but making the file digest a hash of *extent* digests would make fragmentation part of file identity, so byte-identical files with different extent layouts would stop matching. That's a silent regression in whole-file dedupe, and it's most likely on exactly the long-lived deduped trees oans targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)