### PR TITLE
scan: count, report and export the skips the walk hits

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -290,6 +290,19 @@ a node_exporter textfile).
 \f[CR]reclaimable_logical_bytes\f[R] is a logical upper bound; real disk
 freed is smaller on a compressed filesystem.
 Requires \f[B]\-\-hashfile\f[R].
+.RS
+.PP
+\f[CR]scan_skipped_last_run\f[R] reports what the most recent scan could
+\f[B]not\f[R] read, bucketed by cause (\f[CR]permission\f[R],
+\f[CR]unreadable\f[R], \f[CR]path_too_long\f[R],
+\f[CR]unsupported_fs\f[R]), and \f[CR]scan_skipped_errors_total\f[R] is
+the lifetime sum.
+Alarm on the former: a lifetime total only grows, so it cannot tell last
+night\(cqs lost subtree from one lost months ago.
+Skips the user asked for (\f[B]\-\-exclude\f[R],
+\f[B]\-\-min\-filesize\f[R]) are deliberately \f[I]not\f[R] counted
+here.
+.RE
 .TP
 \f[B]\-L\f[R]
 List every file tracked in the hashfile and exit; \f[B]\-v\f[R] adds

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -236,12 +236,20 @@ directory scans the regular files directly inside it; add **-r** to recurse.
     **\--hashfile**.
 
 **\--json**
+
   ~ Print the hashfile's current metrics as a flat JSON object — files, hashes,
     logical bytes, duplicate groups, reclaimable bytes, plus lifetime
     run-history totals — then exit. Intended for scripting and dashboards (pipe
     to `jq`, Telegraf, a node_exporter textfile). `reclaimable_logical_bytes` is
     a logical upper bound; real disk freed is smaller on a compressed
     filesystem. Requires **\--hashfile**.
+
+    `scan_skipped_last_run` reports what the most recent scan could **not**
+    read, bucketed by cause (`permission`, `unreadable`, `path_too_long`,
+    `unsupported_fs`), and `scan_skipped_errors_total` is the lifetime sum.
+    Alarm on the former: a lifetime total only grows, so it cannot tell last
+    night's lost subtree from one lost months ago. Skips the user asked for
+    (**\--exclude**, **\--min-filesize**) are deliberately *not* counted here.
 
 **-L**
   ~ List every file tracked in the hashfile and exit; **-v** adds per-file

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -358,8 +358,35 @@ static int create_tables(sqlite3 *db)
 "ts INTEGER NOT NULL, duration_ms INTEGER NOT NULL, "			\
 "files_scanned INTEGER NOT NULL, reclaimed INTEGER NOT NULL, "		\
 "groups INTEGER NOT NULL, kernel_bytes INTEGER NOT NULL, "		\
-"deduped INTEGER NOT NULL);"
+"deduped INTEGER NOT NULL, "						\
+"skip_permission INTEGER NOT NULL DEFAULT 0, "				\
+"skip_unreadable INTEGER NOT NULL DEFAULT 0, "				\
+"skip_path_too_long INTEGER NOT NULL DEFAULT 0, "			\
+"skip_unsupported_fs INTEGER NOT NULL DEFAULT 0);"
 	ret = sqlite3_exec(db, CREATE_TABLE_RUN_HISTORY, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
+	/*
+	 * Bring a run_history created before the skip columns existed (#145) up
+	 * to date. Purely additive, so per CLAUDE.md this must NOT bump
+	 * DB_FILE_MINOR: a bump would discard every existing hashfile and force
+	 * a full re-scan for what is only a reporting change, and an older
+	 * binary simply never selects these columns.
+	 *
+	 * "duplicate column name" is the expected steady state - every open
+	 * after the first hits it - so the error is discarded rather than
+	 * probed for with a PRAGMA table_info round-trip.
+	 */
+	static const char * const run_history_adds[] = {
+		"ALTER TABLE run_history ADD COLUMN skip_permission INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE run_history ADD COLUMN skip_unreadable INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE run_history ADD COLUMN skip_path_too_long INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE run_history ADD COLUMN skip_unsupported_fs INTEGER NOT NULL DEFAULT 0",
+	};
+	for (unsigned int i = 0; i < ARRAY_SIZE(run_history_adds); i++)
+		sqlite3_exec(db, run_history_adds[i], NULL, NULL, NULL);
+	ret = SQLITE_OK;
 
 out:
 	if (ret)
@@ -1294,8 +1321,10 @@ int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
 
 	ret = sqlite3_prepare_v2(dbh->db,
 		"insert into run_history(ts, duration_ms, files_scanned, "
-		"reclaimed, groups, kernel_bytes, deduped) "
-		"values (?1, ?2, ?3, ?4, ?5, ?6, ?7)", -1, &stmt, NULL);
+		"reclaimed, groups, kernel_bytes, deduped, skip_permission, "
+		"skip_unreadable, skip_path_too_long, skip_unsupported_fs) "
+		"values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+		-1, &stmt, NULL);
 	if (ret)
 		goto out;
 
@@ -1307,6 +1336,10 @@ int dbfile_record_run(struct dbhandle *dbh, const struct run_record *r)
 	/* Legacy NOT NULL column, no longer read; mirror reclaimed to satisfy it. */
 	sqlite3_bind_int64(stmt, 6, r->reclaimed);
 	sqlite3_bind_int64(stmt, 7, r->deduped);
+	sqlite3_bind_int64(stmt, 8, r->skip_permission);
+	sqlite3_bind_int64(stmt, 9, r->skip_unreadable);
+	sqlite3_bind_int64(stmt, 10, r->skip_path_too_long);
+	sqlite3_bind_int64(stmt, 11, r->skip_unsupported_fs);
 
 	if (sqlite3_step(stmt) != SQLITE_DONE)
 		ret = -1;
@@ -1325,7 +1358,9 @@ int dbfile_get_run_summary(struct dbhandle *dbh, struct run_summary *s)
 	ret = sqlite3_prepare_v2(dbh->db,
 		"select count(*), ifnull(sum(reclaimed),0), "
 		"ifnull(sum(files_scanned),0), ifnull(min(ts),0), "
-		"ifnull(max(ts),0) from run_history", -1, &stmt, NULL);
+		"ifnull(max(ts),0), ifnull(sum(skip_permission "
+		"+ skip_unreadable + skip_path_too_long "
+		"+ skip_unsupported_fs),0) from run_history", -1, &stmt, NULL);
 	if (ret) {
 		perror_sqlite(ret, "reading run summary");
 		return ret;
@@ -1336,6 +1371,29 @@ int dbfile_get_run_summary(struct dbhandle *dbh, struct run_summary *s)
 		s->total_files = sqlite3_column_int64(stmt, 2);
 		s->first_ts = sqlite3_column_int64(stmt, 3);
 		s->last_ts = sqlite3_column_int64(stmt, 4);
+		s->total_skip_errors = sqlite3_column_int64(stmt, 5);
+	}
+
+	/*
+	 * The most recent run's buckets, separately: a lifetime total only ever
+	 * grows, so it cannot tell "last night's run lost a subtree" from "one
+	 * run did, months ago". The alarm belongs on the latest row.
+	 */
+	sqlite3_finalize(stmt);
+	stmt = NULL;
+	ret = sqlite3_prepare_v2(dbh->db,
+		"select skip_permission, skip_unreadable, skip_path_too_long, "
+		"skip_unsupported_fs from run_history order by ts desc limit 1",
+		-1, &stmt, NULL);
+	if (ret) {
+		perror_sqlite(ret, "reading last run skips");
+		return ret;
+	}
+	if (sqlite3_step(stmt) == SQLITE_ROW) {
+		s->last_skip_permission = sqlite3_column_int64(stmt, 0);
+		s->last_skip_unreadable = sqlite3_column_int64(stmt, 1);
+		s->last_skip_path_too_long = sqlite3_column_int64(stmt, 2);
+		s->last_skip_unsupported_fs = sqlite3_column_int64(stmt, 3);
 	}
 	return 0;
 }

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -180,6 +180,18 @@ struct run_record {
 	uint64_t	reclaimed;	/* bytes: space reclaimed (kernel-deduped) */
 	uint64_t	groups;
 	int		deduped;	/* 1 if -d, 0 for a scan-only run */
+	/*
+	 * Scan-phase skips that indicate a problem (#145). Named rather than
+	 * indexed by enum scan_skip_bucket: file_scan.h already includes this
+	 * header, so the dependency cannot run the other way. The
+	 * config-driven buckets (excluded / too_small / not_regular) are a
+	 * property of the run's arguments, not of its health, and are reported
+	 * live rather than persisted.
+	 */
+	uint64_t	skip_permission;
+	uint64_t	skip_unreadable;
+	uint64_t	skip_path_too_long;
+	uint64_t	skip_unsupported_fs;
 };
 int dbfile_record_run(struct dbhandle *db, const struct run_record *r);
 
@@ -190,6 +202,13 @@ struct run_summary {
 	uint64_t	total_files;
 	int64_t		first_ts;
 	int64_t		last_ts;
+	/* Error-skip buckets of the most recent run, for alarming (#145). */
+	uint64_t	last_skip_permission;
+	uint64_t	last_skip_unreadable;
+	uint64_t	last_skip_path_too_long;
+	uint64_t	last_skip_unsupported_fs;
+	/* Lifetime sum of all four, so a total stays honest. */
+	uint64_t	total_skip_errors;
 };
 int dbfile_get_run_summary(struct dbhandle *db, struct run_summary *s);
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -174,6 +174,58 @@ void filescan_get_eta_calibration(uint64_t *overhead_ns, uint64_t *hash_ns,
 	*bytes = atomic_load(&scan_hashed_bytes);
 }
 
+/*
+ * Scan-phase skip accounting (#145). Relaxed ordering is fine: the walkers only
+ * ever increment, and the totals are read once, after the walk has joined.
+ */
+static _Atomic uint64_t scan_skips[SCAN_SKIP__COUNT];
+
+static const struct {
+	const char *key;
+	const char *desc;
+	bool is_error;
+} skip_info[SCAN_SKIP__COUNT] = {
+	[SCAN_SKIP_PERMISSION]	  = { "permission",	"permission denied",	true  },
+	[SCAN_SKIP_UNREADABLE]	  = { "unreadable",	"unreadable",		true  },
+	[SCAN_SKIP_PATH_TOO_LONG] = { "path_too_long",	"path too long",	true  },
+	[SCAN_SKIP_UNSUPPORTED_FS]= { "unsupported_fs",	"unsupported filesystem", true },
+	[SCAN_SKIP_EXCLUDED]	  = { "excluded",	"excluded",		false },
+	[SCAN_SKIP_TOO_SMALL]	  = { "too_small",	"below --min-filesize",	false },
+	[SCAN_SKIP_NOT_REGULAR]	  = { "not_regular",	"not a regular file",	false },
+};
+
+bool scan_skip_is_error(enum scan_skip_bucket b)
+{
+	return skip_info[b].is_error;
+}
+
+const char *scan_skip_key(enum scan_skip_bucket b)
+{
+	return skip_info[b].key;
+}
+
+const char *scan_skip_desc(enum scan_skip_bucket b)
+{
+	return skip_info[b].desc;
+}
+
+void filescan_count_skip(enum scan_skip_bucket b)
+{
+	atomic_fetch_add_explicit(&scan_skips[b], 1, memory_order_relaxed);
+}
+
+void filescan_count_errno_skip(int err)
+{
+	filescan_count_skip((err == EACCES || err == EPERM)
+			    ? SCAN_SKIP_PERMISSION : SCAN_SKIP_UNREADABLE);
+}
+
+void filescan_get_skips(uint64_t out[SCAN_SKIP__COUNT])
+{
+	for (unsigned int i = 0; i < SCAN_SKIP__COUNT; i++)
+		out[i] = atomic_load_explicit(&scan_skips[i], memory_order_relaxed);
+}
+
 static void scan_workq_push(struct file_to_scan *file);
 static void scan_workq_start(unsigned int nworkers);
 static void scan_workq_drain(void);
@@ -630,12 +682,14 @@ static int probe_fs(char *path, struct fs_probe *probe)
 
 	if (fd == -1) {
 		eprintf("Cannot open %s: %s\n", path, strerror(errno));
+		filescan_count_errno_skip(errno);
 		return 1;
 	}
 
 	if (fstatfs(fd, &fs)) {
 		eprintf("Error %d: %s while checking fs type on %s\n",
 			errno, strerror(errno), path);
+		filescan_count_errno_skip(errno);
 		return 1;
 	}
 	probe->is_btrfs = fs.f_type == BTRFS_SUPER_MAGIC;
@@ -647,6 +701,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		if (ret) {
 			eprintf("%s: btrfs_get_fsuuid failed\n",
 				path);
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
 	} else {
@@ -673,6 +728,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		if (ret) {
 			eprintf("Failed to stat %s: %s\n",
 					path, strerror(errno));
+			filescan_count_errno_skip(errno);
 			return 1;
 		}
 
@@ -680,12 +736,14 @@ static int probe_fs(char *path, struct fs_probe *probe)
 			dprintf("%s lives on an unsupported filesystem, skipping. "
 				"Please fill a bug if you think this is a mistake.\n",
 					path);
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
 
 		tb = mnt_new_table_from_file("/proc/self/mountinfo");
 		if (!tb) {
 			perror("unable to read and parse /proc/self/mountinfo");
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
 
@@ -693,6 +751,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		if (!dev) {
 			eprintf("%s: unable to find the mount infos\n",
 					path);
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
 
@@ -701,6 +760,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 
 		if (!first_device) {
 			eprintf("Memory allocation failed\n");
+			filescan_count_skip(SCAN_SKIP_UNREADABLE);
 			return 1;
 		}
 
@@ -711,6 +771,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 					"device %s. Run blkid as root to "
 					"populate the cache.\n",
 					mnt_fs_get_source(dev));
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
 
@@ -740,17 +801,21 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	struct fs_probe probe = {0,};
 	dev_t dev;
 
-	if (is_excluded(path, S_ISDIR(st->stx_mode)))
+	if (is_excluded(path, S_ISDIR(st->stx_mode))) {
+		filescan_count_skip(SCAN_SKIP_EXCLUDED);
 		return false;
+	}
 
 	if (!S_ISREG(st->stx_mode) && !S_ISDIR(st->stx_mode)) {
 		vprintf("Skipping non-regular/non-directory file %s\n", path);
+		filescan_count_skip(SCAN_SKIP_NOT_REGULAR);
 		return false;
 	}
 
 	if (S_ISREG(st->stx_mode) && st->stx_size < options.min_filesize) {
 		vprintf("Skipping file below --min-filesize: %s (%llu < %"PRIu64")\n",
 			path, st->stx_size, options.min_filesize);
+		filescan_count_skip(SCAN_SKIP_TOO_SMALL);
 		return false;
 	}
 
@@ -793,6 +858,7 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		if (!probe.supported) {
 			eprintf("Skipping %s: its filesystem is not btrfs or XFS, "
 				"which oans needs to deduplicate.\n", path);
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return seed_reject(parent_checked);
 		}
 
@@ -818,6 +884,7 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 			eprintf(" will we are locked on fs ");
 			debug_print_uuid(locked_fs.uuid);
 			eprintf(".\n");
+			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return seed_reject(parent_checked);
 		}
 
@@ -883,6 +950,7 @@ static int get_dirent_type(struct dirent *entry, int fd, const char *path)
 		eprintf("Error %d: %s while getting type of file %s/%s. "
 			"Skipping.\n",
 			errno, strerror(errno), path, entry->d_name);
+		filescan_count_errno_skip(errno);
 		return DT_UNKNOWN;
 	}
 
@@ -993,6 +1061,7 @@ static void process_dir(const char *path, struct dbhandle *db)
 	if (dirp == NULL) {
 		eprintf("Error %d: %s while opening directory %s\n",
 			errno, strerror(errno), path);
+		filescan_count_errno_skip(errno);
 		return;
 	}
 
@@ -1015,6 +1084,7 @@ static void process_dir(const char *path, struct dbhandle *db)
 	child = calloc(1, dirlen + 1 + NAME_MAX + 1);
 	if (child == NULL) {
 		eprintf("Out of memory while scanning directory %s\n", path);
+		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return;
 	}
 
@@ -1029,9 +1099,11 @@ static void process_dir(const char *path, struct dbhandle *db)
 		errno = 0;
 		entry = readdir(dirp);
 		if (!entry) {
-			if (errno)
+			if (errno) {
 				eprintf("Error %d: %s while reading directory %s\n",
 					errno, strerror(errno), path);
+				filescan_count_errno_skip(errno);
+			}
 			break;
 		}
 
@@ -1042,8 +1114,20 @@ static void process_dir(const char *path, struct dbhandle *db)
 		entry->d_type = get_dirent_type(entry, dirfd(dirp), path);
 
 		if (entry->d_type != DT_REG &&
-		    !(options.recurse_dirs && entry->d_type == DT_DIR))
+		    !(options.recurse_dirs && entry->d_type == DT_DIR)) {
+			/*
+			 * Count only entries that are genuinely neither a file
+			 * nor a directory (symlinks, sockets, devices - see
+			 * #126). A directory passed over because --recurse was
+			 * not given is the user's own choice, not a skip worth
+			 * reporting, and DT_UNKNOWN was already counted by
+			 * get_dirent_type() as the errno that produced it.
+			 */
+			if (entry->d_type != DT_DIR &&
+			    entry->d_type != DT_UNKNOWN)
+				filescan_count_skip(SCAN_SKIP_NOT_REGULAR);
 			continue;
+		}
 
 		/* A component is bounded by NAME_MAX; guard defensively so the
 		 * child buffer can never overflow. */
@@ -1051,6 +1135,7 @@ static void process_dir(const char *path, struct dbhandle *db)
 		if (namelen > NAME_MAX) {
 			eprintf("Skipping \"%s/%s\": name length %zu exceeds NAME_MAX (%d)\n",
 				path, entry->d_name, namelen, NAME_MAX);
+			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			continue;
 		}
 		/* memcpy, not strcpy: namelen is already known, so this avoids a
@@ -1065,6 +1150,7 @@ static void process_dir(const char *path, struct dbhandle *db)
 		if (statx(dirfd(dirp), entry->d_name, 0, STATX_BASIC_STATS, &st) ||
 		    !(st.stx_mask & STATX_BASIC_STATS)) {
 			eprintf("Failed to stat %s: %s\n", child, strerror(errno));
+			filescan_count_errno_skip(errno);
 			continue;
 		}
 
@@ -1220,6 +1306,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		if (fd == -1) {
 			eprintf("Error %d: %s while opening file \"%s\". "
 				"Skipping.\n", errno, strerror(errno), path);
+			filescan_count_errno_skip(errno);
 			return 0;
 		}
 
@@ -1279,6 +1366,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	dbfile.size = st->stx_size;
 	if (file_set_filename(&dbfile, path)) {
 		eprintf("Out of memory storing \"%s\". Skipping.\n", path);
+		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return 0;
 	}
 	dbfile.mtime = timestamp_to_nano(st->stx_mtime);
@@ -1384,11 +1472,13 @@ int scan_file(char *in_path, struct dbhandle *db)
 				"only the root itself is limited. Scan a shorter "
 				"ancestor, or bind-mount this directory somewhere "
 				"shorter.\n", in_path, PATH_MAX);
+			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			return 0;
 		}
 		eprintf("Error %d: %s while getting path to file %s. "
 			"Skipping.\n",
 			errno, strerror(errno), in_path);
+		filescan_count_errno_skip(errno);
 		return 0;
 	}
 
@@ -1398,6 +1488,7 @@ int scan_file(char *in_path, struct dbhandle *db)
 		eprintf("Error %d: %s while stating file %s. "
 			"Skipping.\n",
 			errno, strerror(errno), path);
+		filescan_count_errno_skip(errno);
 		return 0;
 	}
 
@@ -2014,6 +2105,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	if (ctxt.fd == -1) {
 		eprintf("csum_whole_file: Error %d: %s while opening file \"%s\". "
 			"Skipping.\n", errno, strerror(errno), file->path);
+		filescan_count_errno_skip(errno);
 		return;
 	}
 
@@ -2074,6 +2166,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 			ret = errno;
 			eprintf("Unable to read file %s: %s\n",
 				file->path, strerror(ret));
+			filescan_count_errno_skip(ret);
 			return;
 		}
 

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -46,6 +46,48 @@ void fs_get_locked_uuid(uuid_t *uuid);
  */
 bool filescan_seed_failed(void);
 
+/*
+ * Scan-phase skip accounting (#145).
+ *
+ * Every "I skipped this" path in the walk used to write a line to stderr and be
+ * forgotten: nothing counted them, so an unattended run that lost a whole
+ * subtree to a permissions change looked identical to a healthy one in --json,
+ * --history and the summary.
+ *
+ * Bucketed by cause, chosen so each maps to a distinct operator action. The
+ * first four are problems; the last three are the user's own configuration
+ * doing its job and must be reported apart from them, or "812 skipped" reads
+ * as alarming when 812 of them are --exclude hits.
+ */
+enum scan_skip_bucket {
+	SCAN_SKIP_PERMISSION = 0,	/* EACCES/EPERM from opendir/open/statx */
+	SCAN_SKIP_UNREADABLE,		/* any other errno on the same paths */
+	SCAN_SKIP_PATH_TOO_LONG,	/* over PATH_MAX, or a name over NAME_MAX */
+	SCAN_SKIP_UNSUPPORTED_FS,	/* not btrfs/XFS, or a foreign fs */
+	SCAN_SKIP_EXCLUDED,		/* --exclude matched */
+	SCAN_SKIP_TOO_SMALL,		/* below --min-filesize */
+	SCAN_SKIP_NOT_REGULAR,		/* neither a regular file nor a directory */
+	SCAN_SKIP__COUNT
+};
+
+/* True for the buckets that indicate a problem rather than a config choice. */
+bool scan_skip_is_error(enum scan_skip_bucket b);
+/* Stable snake_case key for --json and the run_history columns. */
+const char *scan_skip_key(enum scan_skip_bucket b);
+/* Human phrase for the summary line, e.g. "unreadable (permission denied)". */
+const char *scan_skip_desc(enum scan_skip_bucket b);
+
+void filescan_count_skip(enum scan_skip_bucket b);
+/* EACCES/EPERM land in PERMISSION, everything else in UNREADABLE. */
+void filescan_count_errno_skip(int err);
+
+/*
+ * Snapshot the counters. Like pscan_files_scanned(), this must be read while
+ * still inside scan_files(): the dedupe phase reuses the progress counters, and
+ * keeping the two reads in one place stops the same trap being re-learned.
+ */
+void filescan_get_skips(uint64_t out[SCAN_SKIP__COUNT]);
+
 /* For dbfile.c */
 struct block_csum {
 	uint64_t	loff;

--- a/src/oans.c
+++ b/src/oans.c
@@ -416,18 +416,30 @@ static int print_hashfile_history(char *filename)
 	printf("\n  %srecent%s   %sdate · reclaimed · elapsed · files · mode%s\n",
 	       col_dim, col_reset, col_dim, col_reset);
 	if (sqlite3_prepare_v2(db->db,
-		"select ts, reclaimed, duration_ms, files_scanned, deduped "
+		"select ts, reclaimed, duration_ms, files_scanned, deduped, "
+		"skip_permission + skip_unreadable + skip_path_too_long "
+		"+ skip_unsupported_fs "
 		"from run_history order by ts desc limit 20", -1, &stmt, NULL) == SQLITE_OK) {
 		while (sqlite3_step(stmt) == SQLITE_ROW) {
 			char when[32];
+			int64_t skipped = sqlite3_column_int64(stmt, 5);
 
 			fmt_localtime(sqlite3_column_int64(stmt, 0), "%Y-%m-%d %H:%M",
 				      when, sizeof(when));
-			printf("    %s  %10s  %7.1fs  %9"PRIu64"  %s\n", when,
+			printf("    %s  %10s  %7.1fs  %9"PRIu64"  %s", when,
 			       human_size(sqlite3_column_int64(stmt, 1)),
 			       sqlite3_column_int64(stmt, 2) / 1000.0,
 			       (uint64_t)sqlite3_column_int64(stmt, 3),
 			       sqlite3_column_int(stmt, 4) ? "dedupe" : "scan");
+			/*
+			 * A degraded run must be visible in the timeline, not
+			 * only in --json: "0 B reclaimed" looks identical to a
+			 * healthy run on a clean tree (#145).
+			 */
+			if (skipped)
+				printf("  %s(%"PRId64" skipped)%s",
+				       col_yellow, skipped, col_reset);
+			printf("\n");
 		}
 	}
 	return 0;
@@ -472,6 +484,18 @@ static int print_metrics_json(char *filename)
 	printf("  \"reclaimable_logical_bytes\": %"PRIu64",\n", reclaimable);
 	printf("  \"runs\": %"PRIu64",\n", sum.runs);
 	printf("  \"reclaimed_total_bytes\": %"PRIu64",\n", sum.total_reclaimed);
+	/*
+	 * Split so a dashboard can alarm on the latest run rather than on a
+	 * lifetime total, which only ever grows and so cannot distinguish "last
+	 * night lost a subtree" from "one run did, months ago" (#145).
+	 */
+	printf("  \"scan_skipped_last_run\": {\n");
+	printf("    \"permission\": %"PRIu64",\n", sum.last_skip_permission);
+	printf("    \"unreadable\": %"PRIu64",\n", sum.last_skip_unreadable);
+	printf("    \"path_too_long\": %"PRIu64",\n", sum.last_skip_path_too_long);
+	printf("    \"unsupported_fs\": %"PRIu64"\n", sum.last_skip_unsupported_fs);
+	printf("  },\n");
+	printf("  \"scan_skipped_errors_total\": %"PRIu64",\n", sum.total_skip_errors);
 	printf("  \"last_run_ts\": %"PRId64"\n", sum.last_ts);
 	printf("}\n");
 	return 0;
@@ -1281,8 +1305,55 @@ static void report_scan_stats(void)
 	}
 }
 
+/*
+ * Report the walk's skip counters (#145).
+ *
+ * Printed even under -q: quiet's contract is "errors and a one-line summary",
+ * and an unattended run that lost a whole subtree to a permissions change is
+ * exactly the error a journal must carry. The config-driven buckets are
+ * verbose-only - they are the user's own --exclude and --min-filesize doing
+ * their job, and 812 of them read as alarming next to the one that matters.
+ */
+static void report_scan_skips(const uint64_t *skips)
+{
+	const char *sep = "";
+	uint64_t errors = 0;
+	unsigned int i;
+
+	for (i = 0; i < SCAN_SKIP__COUNT; i++)
+		if (scan_skip_is_error(i))
+			errors += skips[i];
+
+	if (errors) {
+		printf("  %sSkipped%s        ", col_dim, col_reset);
+		for (i = 0; i < SCAN_SKIP__COUNT; i++) {
+			if (!skips[i] || !scan_skip_is_error(i))
+				continue;
+			printf("%s%"PRIu64" %s", sep, skips[i],
+			       scan_skip_desc(i));
+			sep = ", ";
+		}
+		printf(" %s(rerun with -v for detail)%s\n", col_dim, col_reset);
+	}
+
+	if (!verbose)
+		return;
+
+	sep = "";
+	for (i = 0; i < SCAN_SKIP__COUNT; i++) {
+		if (!skips[i] || scan_skip_is_error(i))
+			continue;
+		if (!*sep)
+			printf("  %sNot scanned%s    ", col_dim, col_reset);
+		printf("%s%"PRIu64" %s", sep, skips[i], scan_skip_desc(i));
+		sep = ", ";
+	}
+	if (*sep)
+		printf("\n");
+}
+
 static int scan_files(char **roots, int nroots, struct dbhandle *db,
-		      uint64_t *files_scanned)
+		      uint64_t *files_scanned, uint64_t *skips)
 {
 	int ret;
 	/* Run the progress thread whenever there's an output to feed - the live
@@ -1345,6 +1416,13 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 	 */
 	if (files_scanned)
 		*files_scanned = pscan_files_scanned();
+
+	/*
+	 * Same latch point, same reason (#145): read the walk's skip counters
+	 * here, while the scan still owns them.
+	 */
+	if (skips)
+		filescan_get_skips(skips);
 
 	report_scan_stats();
 
@@ -1528,6 +1606,7 @@ int main(int argc, char **argv)
 	char **roots;
 	bool replaying = false;
 	uint64_t files_scanned = 0;
+	uint64_t scan_skips[SCAN_SKIP__COUNT] = {0};
 	struct scan_config replay = {0};
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 
@@ -1641,9 +1720,11 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	ret = scan_files(roots, numfiles, db, &files_scanned);
+	ret = scan_files(roots, numfiles, db, &files_scanned, scan_skips);
 	if (ret)
 		goto out;
+
+	report_scan_skips(scan_skips);
 
 	/* Remember this run so a later bare `oans --hashfile=X` replays it. */
 	if (!replaying && !stdin_filelist && options.hashfile)
@@ -1674,6 +1755,10 @@ int main(int argc, char **argv)
 				.reclaimed = reclaimed,
 				.groups = groups,
 				.deduped = options.run_dedupe,
+				.skip_permission = scan_skips[SCAN_SKIP_PERMISSION],
+				.skip_unreadable = scan_skips[SCAN_SKIP_UNREADABLE],
+				.skip_path_too_long = scan_skips[SCAN_SKIP_PATH_TOO_LONG],
+				.skip_unsupported_fs = scan_skips[SCAN_SKIP_UNSUPPORTED_FS],
 			};
 			dbfile_record_run(db, &rec);
 		}

--- a/tests/integration/test_scan_skips.py
+++ b/tests/integration/test_scan_skips.py
@@ -1,0 +1,136 @@
+"""Scan-phase skips must be counted, reported and exported (#145).
+
+oans is built for unattended scheduled runs, but the scan phase used to count
+only what it succeeded at: every "I skipped this" path wrote a line to stderr
+and was then forgotten. A weekly timer that lost /srv/media/photos to a
+permissions change months ago looked identical to a healthy one -- nothing in
+the summary, --json or --history said otherwise.
+
+The buckets are split into problems (permission, unreadable, path_too_long,
+unsupported_fs) and the user's own configuration (excluded, too_small,
+not_regular). The split is the point: "812 skipped" reads as alarming when 812
+of them are --exclude patterns doing their job.
+"""
+
+import json
+import os
+import stat
+import unittest
+
+from harness import DuperemoveTest
+
+
+class ScanSkipsTest(DuperemoveTest):
+    def _unreadable_subtree(self):
+        """A tree with one subdirectory the scanner cannot open."""
+        self.mkdup("tree/a.bin", "tree/b.bin", 200000)
+        sub = self.path("tree/sub/c.bin")
+        self.mkrand("tree/sub/c.bin", 200000)
+        os.chmod(os.path.dirname(sub), 0o000)
+        return os.path.dirname(sub)
+
+    def tearDown(self):
+        # Restore any 000 directory so rmtree can clean up.
+        for root, dirs, _files in os.walk(self.work):
+            for d in dirs:
+                p = os.path.join(root, d)
+                try:
+                    os.chmod(p, stat.S_IRWXU)
+                except OSError:
+                    pass
+        super().tearDown()
+
+    def test_permission_skip_is_reported_under_quiet(self):
+        """The failure an unattended journal must carry survives -q."""
+        self._unreadable_subtree()
+        self.scan(self.path("tree"))
+        self.assertIn("Skipped", self.out,
+                      "an unreadable subtree left no trace in the summary")
+        self.assertIn("permission denied", self.out)
+
+    def test_permission_skip_reaches_json(self):
+        self._unreadable_subtree()
+        self.scan(self.path("tree"))
+
+        out = self.dm("--json", hashfile=True)
+        metrics = json.loads(out)
+        self.assertEqual(1, metrics["scan_skipped_last_run"]["permission"])
+        self.assertEqual(1, metrics["scan_skipped_errors_total"])
+
+    def test_clean_run_reports_no_skips(self):
+        """No false positives: a healthy tree must stay silent."""
+        self.mkdup("tree/a.bin", "tree/b.bin", 200000)
+        self.scan(self.path("tree"))
+        self.assertNotIn("Skipped", self.out)
+
+        metrics = json.loads(self.dm("--json"))
+        for bucket, n in metrics["scan_skipped_last_run"].items():
+            self.assertEqual(0, n, f"clean run reported {bucket}={n}")
+        self.assertEqual(0, metrics["scan_skipped_errors_total"])
+
+    def test_config_skips_are_not_reported_as_errors(self):
+        """--exclude hits are the user's own choice, not a degraded run.
+
+        This is the distinction that makes the number actionable: an operator
+        alarming on scan_skipped_errors_total must not be woken by their own
+        exclude patterns matching, however many files they match.
+        """
+        self.mkdup("tree/a.bin", "tree/b.bin", 200000)
+        self.mkrand("tree/skipme/c.bin", 200000)
+        self.mkrand("tree/skipme/d.bin", 200000)
+        self.scan(self.path("tree"), "--exclude", "skipme/")
+
+        self.assertNotIn("Skipped", self.out,
+                         "--exclude hits were reported as errors")
+        metrics = json.loads(self.dm("--json"))
+        self.assertEqual(0, metrics["scan_skipped_errors_total"])
+
+    def test_history_marks_a_degraded_run(self):
+        """--history must distinguish 'reclaimed nothing' from 'lost a subtree'.
+
+        Both print 0 B, which is exactly why the skip count has to be on the
+        timeline row rather than only in the JSON.
+        """
+        self._unreadable_subtree()
+        self.scan(self.path("tree"))
+
+        out = self.dm("--history")
+        self.assertIn("skipped", out,
+                      "--history did not flag the degraded run")
+
+    def test_history_columns_survive_an_older_hashfile(self):
+        """The new columns are additive: an existing hashfile is migrated.
+
+        Per CLAUDE.md this must not bump DB_FILE_MINOR -- a bump would discard
+        every user's hashfile and force a full re-scan for a reporting change.
+        So a hashfile whose run_history predates the columns must be brought up
+        by ALTER TABLE, keeping its rows.
+        """
+        self.mkdup("tree/a.bin", "tree/b.bin", 200000)
+        self.scan(self.path("tree"))
+        runs_before = self.hf_scalar("select count(*) from run_history")
+        self.assertEqual(1, runs_before)
+
+        # Simulate the pre-#145 schema by dropping the columns back off.
+        con = __import__("sqlite3").connect(self.hf)
+        try:
+            for col in ("skip_permission", "skip_unreadable",
+                        "skip_path_too_long", "skip_unsupported_fs"):
+                con.execute(f"alter table run_history drop column {col}")
+            con.commit()
+        finally:
+            con.close()
+
+        # A later run must migrate rather than fail or discard the history.
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        self.assertEqual(2, self.hf_scalar("select count(*) from run_history"),
+                         "migrating the schema lost the earlier run")
+        self.assertEqual(
+            0, self.hf_scalar("select skip_permission from run_history "
+                              "order by ts limit 1"),
+            "the back-filled column should default to 0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
_Reopened from #163, which GitHub auto-closed when its base branch `quiet-summary` was deleted on merge of #162. Same branch, rebased onto master; no content change._

Fixes #145. Rebased onto master now that #162 has merged; the diff is just this change.

The scan phase counted only what it succeeded at. `grep -rn 'files_skipped\|scan_errors' src/` returned nothing, while `file_scan.c` had ~20 sites that print a skip to stderr and forget it.

## Why it matters

```console
$ chmod 000 /scratch/errprobe/sub
$ oans -rq --hashfile=/tmp/h.db /scratch/errprobe
Cannot open /scratch/errprobe/sub: Permission denied
$ echo $?
0
```

An entire subtree vanished, the run reported success, and nothing in `--json` or `--history` recorded it. A weekly timer that lost `/srv/media/photos` months ago is indistinguishable from a healthy one.

After:

```console
$ oans -rq --hashfile=/tmp/h.db /scratch/errprobe
Cannot open /scratch/errprobe/sub: Permission denied
  Skipped        1 permission denied (rerun with -v for detail)

$ oans --hashfile=/tmp/h.db --json | jq .scan_skipped_last_run
{ "permission": 1, "unreadable": 0, "path_too_long": 0, "unsupported_fs": 0 }
```

## Buckets

| bucket | error? | sites |
|---|---|---|
| `permission` | yes | `EACCES`/`EPERM` from opendir/open/statx |
| `unreadable` | yes | other errno on the same paths, allocation failure |
| `path_too_long` | yes | over `PATH_MAX`, name over `NAME_MAX` |
| `unsupported_fs` | yes | not btrfs/XFS, foreign fs, `probe_fs()` failures |
| `excluded` | no | `--exclude` hits |
| `too_small` | no | below `--min-filesize` |
| `not_regular` | no | neither a regular file nor a directory |

The split is the point: **812 skipped** reads as alarming when 812 of them are the user's own exclude patterns working. Only the error buckets are persisted, alarm, or print by default; the config ones show under `-v`.

## Notes for review

- **`DB_FILE_MINOR` deliberately does not move.** The four `run_history` columns are added via `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ... ADD COLUMN`, exactly as CLAUDE.md prescribes — a bump would discard every user's hashfile and force a full re-scan for a reporting change. There's a test that drops the columns back off and confirms a later run migrates without losing rows.
- **Counters are latched inside `scan_files()`**, next to `pscan_files_scanned()` and for the same documented reason.
- `probe_fs()` failures needed instrumenting at all nine return paths — the permission case a user actually hits (`Cannot open .../sub`) goes through there, not through `process_dir`'s `opendir`, which is what I'd assumed at first.
- Relaxed atomics: walkers only increment, and the totals are read after the walk joins.

## Testing

- New `tests/integration/test_scan_skips.py` — 6 cases: the summary line survives `-q`, the bucket reaches `--json`, a clean run reports zeros in every bucket, `--exclude` hits never raise the error total, `--history` flags a degraded run, and the schema migration keeps existing rows.
- `scripts/verify.sh` passes: build clean, 138 tests, valgrind smoke.

## Follow-up

#146 (non-zero exit on an unreadable tree) becomes implementable on top of this. As noted in that issue, I'd suggest splitting it: the unusable-command-line-root half needs none of these counters and is much less contentious than `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
