### PR TITLE
Add --prune-block-hashes to reclaim unused block digests

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -80,11 +80,12 @@ A summary of the space reclaimed is printed at the end (see
 \f[I]OUTPUT\f[R]).
 .PP
 \f[B]Report and maintenance modes.\f[R] \f[B]\-\-stats\f[R],
-\f[B]\-\-history\f[R], \f[B]\-\-json\f[R], \f[B]\-L\f[R], and
-\f[B]\-R\f[R] each inspect or maintain a hashfile and then exit without
-scanning for dupes.
-All but \f[B]\-R\f[R] open the hashfile \f[B]read\-only\f[R]; see
-\f[I]NOTES\f[R] for running them alongside an active \f[CR]oans\f[R].
+\f[B]\-\-history\f[R], \f[B]\-\-json\f[R], \f[B]\-L\f[R], \f[B]\-R\f[R]
+and \f[B]\-\-prune\-block\-hashes\f[R] each inspect or maintain a
+hashfile and then exit without scanning for dupes.
+All but \f[B]\-R\f[R] and \f[B]\-\-prune\-block\-hashes\f[R] open the
+hashfile \f[B]read\-only\f[R]; see \f[I]NOTES\f[R] for running them
+alongside an active \f[CR]oans\f[R].
 .SH OPTIONS
 The non\-option arguments are the \f[I]files\f[R] and
 \f[I]directories\f[R] to scan, or a single hyphen (\f[B]\-\f[R]) to read
@@ -308,6 +309,30 @@ here.
 List every file tracked in the hashfile and exit; \f[B]\-v\f[R] adds
 per\-file detail.
 Requires \f[B]\-\-hashfile\f[R].
+.TP
+\f[B]\-\-prune\-block\-hashes\f[R]
+Delete every stored \f[B]block\f[R] hash from the hashfile, compact it,
+and exit.
+Requires \f[B]\-\-hashfile\f[R].
+.RS
+.PP
+Block hashes exist only to serve \f[B]\-\-dedupe\-options=partial\f[R],
+which is off by default \(em an ordinary scan stores none, whatever
+\f[B]\-b\f[R] is set to.
+But once written they are removed only when a file is
+\f[I]re\-hashed\f[R], and the point of a hashfile is that unchanged
+files are not re\-hashed.
+A hashfile that ran \f[B]partial\f[R] once therefore keeps them
+indefinitely on a stable tree, where they are typically the bulk of the
+file: a fully\-mapped 1 TiB at \f[B]\-b 4K\f[R] stores roughly 8 GiB of
+block digests.
+.PP
+\f[B]\-\-stats\f[R] flags them when the stored scan configuration no
+longer uses partial matching.
+Pruning is explicit rather than automatic because a later
+\f[B]\-\-dedupe\-options=partial\f[R] run must re\-hash the tree to
+rebuild them.
+.RE
 .TP
 \f[B]\-R\f[R] \f[I]file\f[R]\&...
 Remove the named paths from the hashfile and exit; a single \f[B]\-\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -63,8 +63,9 @@ skipped, so repeated runs over a mostly-stable tree are cheap. A summary of the
 space reclaimed is printed at the end (see *OUTPUT*).
 
 **Report and maintenance modes.**
-**\--stats**, **\--history**, **\--json**, **-L**, and **-R** each inspect or
-maintain a hashfile and then exit without scanning for dupes. All but **-R**
+**\--stats**, **\--history**, **\--json**, **-L**, **-R** and
+**\--prune-block-hashes** each inspect or maintain a hashfile and then exit
+without scanning for dupes. All but **-R** and **\--prune-block-hashes**
 open the hashfile **read-only**; see *NOTES* for running them alongside an
 active `oans`.
 
@@ -254,6 +255,25 @@ directory scans the regular files directly inside it; add **-r** to recurse.
 **-L**
   ~ List every file tracked in the hashfile and exit; **-v** adds per-file
     detail. Requires **\--hashfile**.
+
+**\--prune-block-hashes**
+
+  ~ Delete every stored **block** hash from the hashfile, compact it, and exit.
+    Requires **\--hashfile**.
+
+    Block hashes exist only to serve **\--dedupe-options=partial**, which is
+    off by default — an ordinary scan stores none, whatever **-b** is set to.
+    But once written they are removed only when a file is *re-hashed*, and the
+    point of a hashfile is that unchanged files are not re-hashed. A hashfile
+    that ran **partial** once therefore keeps them indefinitely on a stable
+    tree, where they are typically the bulk of the file: a fully-mapped 1 TiB
+    at **-b 4K** stores roughly 8 GiB of block digests.
+
+    **\--stats** flags them when the stored scan configuration no longer uses
+    partial matching. Pruning is explicit rather than automatic because a later
+    **\--dedupe-options=partial** run must re-hash the tree to rebuild them.
+
+<!-- -->
 
 **-R** *file*...
   ~ Remove the named paths from the hashfile and exit; a single **-** reads the

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1461,6 +1461,33 @@ int dbfile_get_stats(struct dbhandle *db, struct dbfile_stats *stats)
  */
 #define VACUUM_FREE_PCT		25
 
+int64_t dbfile_drop_block_hashes(struct dbhandle *db)
+{
+	int64_t before;
+	int ret;
+
+	before = (int64_t)dbfile_query_u64(db->db, "select count(*) from blocks");
+	if (!before)
+		return 0;
+
+	ret = sqlite3_exec(db->db, "delete from blocks", NULL, NULL, NULL);
+	if (ret) {
+		perror_sqlite(ret, "deleting block hashes");
+		return -1;
+	}
+
+	return before;
+}
+
+int dbfile_vacuum(struct dbhandle *db)
+{
+	int ret = sqlite3_exec(db->db, "VACUUM", NULL, NULL, NULL);
+
+	if (ret)
+		perror_sqlite(ret, "vacuuming hashfile");
+	return ret;
+}
+
 void dbfile_maybe_vacuum(struct dbhandle *db)
 {
 	uint64_t freelist, total;

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -233,6 +233,19 @@ uint64_t dbfile_query_u64(sqlite3 *db, const char *sql);
 /* VACUUM the hashfile, but only when enough of it is free to be worth it. */
 void dbfile_maybe_vacuum(struct dbhandle *db);
 
+/*
+ * Drop every row from the blocks table. Block hashes exist only to serve
+ * --dedupe-options=partial; a hashfile that has stopped using it carries them
+ * as dead weight, and they are only reclaimed incidentally, when a file
+ * happens to be re-hashed (#160).
+ *
+ * Returns the number of rows deleted, or -1 on error.
+ */
+int64_t dbfile_drop_block_hashes(struct dbhandle *db);
+
+/* Unconditional VACUUM, for a maintenance action that just freed a lot. */
+int dbfile_vacuum(struct dbhandle *db);
+
 struct hash_tree;
 
 /*

--- a/src/oans.c
+++ b/src/oans.c
@@ -56,6 +56,7 @@ static int stdin_filelist = 0;
 static unsigned int list_only_opt = 0;
 static unsigned int rm_only_opt = 0;
 static unsigned int stats_only_opt = 0;
+static unsigned int prune_blocks_opt = 0;
 static unsigned int history_only_opt = 0;
 static unsigned int json_only_opt = 0;
 static int opt_no_color = 0;
@@ -327,7 +328,25 @@ static int print_hashfile_stats(char *filename)
 		printf("  %sunread%s          %"PRIu64"   %s(unique size, whole-file mode)%s\n",
 		       col_dim, col_reset, unhashed, col_dim, col_reset);
 	printf("  %sextent hashes%s   %"PRIu64"\n", col_dim, col_reset, st.num_e_hashes);
-	printf("  %sblock hashes%s    %"PRIu64"\n", col_dim, col_reset, st.num_b_hashes);
+	printf("  %sblock hashes%s    %"PRIu64, col_dim, col_reset, st.num_b_hashes);
+	/*
+	 * Block hashes only serve --dedupe-options=partial. If the stored scan
+	 * config no longer uses it they are dead weight that no future run will
+	 * read, and nothing reclaims them: they are dropped per file only when a
+	 * file is re-hashed, which on a stable tree never happens (#160). Say so
+	 * here, where the user is already looking at what the hashfile costs.
+	 */
+	if (st.num_b_hashes) {
+		struct scan_config sc = {0};
+
+		/* >0 means a config was loaded; 0 means none is stored. */
+		if (dbfile_load_scan_config(db, &sc) > 0 && !sc.do_block_hash)
+			printf("   %s(unused by the stored config; "
+			       "--prune-block-hashes reclaims them)%s",
+			       col_yellow, col_reset);
+		scan_config_free(&sc);
+	}
+	printf("\n");
 	printf("  %slogical data%s    %s\n", col_dim, col_reset, human_size(logical));
 	printf("  %sfile sizes%s      avg %s", col_dim, col_reset,
 	       human_size(files ? logical / files : 0));
@@ -511,6 +530,83 @@ static int print_metrics_json(char *filename)
 	return 0;
 }
 
+/*
+ * --prune-block-hashes: drop the blocks table and compact (#160).
+ *
+ * Block hashes serve only --dedupe-options=partial. They are removed per file
+ * by dbfile_remove_hashes() when a file is re-hashed, but a hashfile's whole
+ * point is that unchanged files are *not* re-hashed - so on a stable tree, a
+ * user who ran partial once carries those rows forever, and they can be the
+ * bulk of the file (a fully-mapped 1 TiB at -b 4K stores ~8 GiB of digests).
+ *
+ * Explicit rather than automatic: dropping them silently on any non-partial run
+ * would make the next partial run re-hash the whole tree, which is exactly the
+ * kind of invisible cost the hashfile exists to avoid.
+ */
+static int prune_block_hashes(char *filename)
+{
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
+	struct stat sb;
+	uint64_t before_bytes = 0, after_bytes = 0;
+	int64_t dropped;
+
+	db = dbfile_open_handle(filename);
+	if (!db) {
+		eprintf("Error: Could not open \"%s\"\n", filename);
+		return -1;
+	}
+
+	/* longpath-ok: the hashfile, named by the user, never scanned. */
+	if (stat(filename, &sb) == 0)
+		before_bytes = sb.st_size;
+
+	dropped = dbfile_drop_block_hashes(db);
+	if (dropped < 0)
+		return -1;
+
+	if (dropped == 0) {
+		printf("No block hashes stored; nothing to prune.\n");
+		return 0;
+	}
+
+	/*
+	 * Unconditional, unlike the scan path's dbfile_maybe_vacuum(): we just
+	 * freed the pages the user asked us to reclaim, so deferring compaction
+	 * behind a 25%-free threshold would report a saving that has not
+	 * happened yet.
+	 */
+	printf("Dropped %"PRId64" block hash%s; compacting ... ", dropped,
+	       dropped == 1 ? "" : "es");
+	fflush(stdout);
+	if (dbfile_vacuum(db)) {
+		printf("\n");
+		return -1;
+	}
+	printf("done\n");
+
+	/*
+	 * Close before measuring: in WAL mode VACUUM writes through the WAL and
+	 * the main database file does not shrink until the checkpoint that
+	 * closing performs. stat()ing here instead reports the pre-VACUUM size
+	 * and cheerfully claims "0 B freed" after reclaiming most of the file.
+	 */
+	dbfile_close_handle(db);
+	db = NULL;
+
+	/* longpath-ok: the hashfile, named by the user, never scanned. */
+	if (stat(filename, &sb) == 0)
+		after_bytes = sb.st_size;
+
+	if (before_bytes && after_bytes && after_bytes <= before_bytes)
+		printf("Hashfile %s -> %s (%s freed)\n",
+		       human_size(before_bytes), human_size(after_bytes),
+		       human_size(before_bytes - after_bytes));
+
+	printf("Note: a later --dedupe-options=partial run will re-hash the "
+	       "tree to rebuild them.\n");
+	return 0;
+}
+
 static int list_db_files(char *filename)
 {
 	int ret;
@@ -658,6 +754,7 @@ enum {
 	NO_COLOR_OPTION,
 	MIN_FILESIZE_OPTION,
 	STATS_OPTION,
+	PRUNE_BLOCKS_OPTION,
 	HISTORY_OPTION,
 	JSON_OPTION,
 	PROGRESS_OPTION,
@@ -739,6 +836,8 @@ static void help(void)
 "      --json                  print hashfile metrics as JSON\n"
 "  -L                          list files tracked in the hashfile\n"
 "  -R <file>...                remove the named paths from the hashfile\n"
+"      --prune-block-hashes    drop stored block hashes and compact the\n"
+"                              hashfile (only used by --dedupe-options=partial)\n"
 "\n"
 "Other:\n"
 "  -q, --quiet                 print only errors and a one-line summary\n"
@@ -780,6 +879,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "no-color", 0, NULL, NO_COLOR_OPTION },
 		{ "min-filesize", 1, NULL, MIN_FILESIZE_OPTION },
 		{ "stats", 0, NULL, STATS_OPTION },
+		{ "prune-block-hashes", 0, NULL, PRUNE_BLOCKS_OPTION },
 		{ "history", 0, NULL, HISTORY_OPTION },
 		{ "json", 0, NULL, JSON_OPTION },
 		{ "progress", 1, NULL, PROGRESS_OPTION },
@@ -859,6 +959,9 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 			break;
 		case 'R':
 			rm_only_opt = 1;
+			break;
+		case PRUNE_BLOCKS_OPTION:
+			prune_blocks_opt = 1;
 			break;
 		case STATS_OPTION:
 			stats_only_opt = 1;
@@ -947,25 +1050,28 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 
 	/* -L/-R/--stats/--history/--json are mutually exclusive report modes. */
 	unsigned int report_count = list_only_opt + rm_only_opt + stats_only_opt
-				  + history_only_opt + json_only_opt;
+				  + history_only_opt + json_only_opt
+				  + prune_blocks_opt;
 	/* Every report mode but -R takes no file list. */
 	bool nofile_report = report_count && !rm_only_opt;
 
 	if (report_count > 1) {
 		eprintf("Error: use only one of '-L', '-R', '--stats', "
-			"'--history', '--json'.\n");
+			"'--history', '--json', '--prune-block-hashes'.\n");
 		return 1;
 	}
 
 	if (report_count) {
 		if (!options.hashfile) {
 			eprintf("Error: --hashfile= option is required with "
-				"'-L', '-R', '--stats', '--history' or '--json'.\n");
+				"'-L', '-R', '--stats', '--history', '--json' "
+				"or '--prune-block-hashes'.\n");
 			return 1;
 		}
 		if (nofile_report && numfiles) {
-			eprintf("Error: -L/--stats/--history/--json do not take "
-				"a file list argument\n");
+			eprintf("Error: -L/--stats/--history/--json/"
+				"--prune-block-hashes do not take a file list "
+				"argument\n");
 			return 1;
 		}
 	}
@@ -1694,6 +1800,8 @@ int main(int argc, char **argv)
 		return print_hashfile_history(options.hashfile);
 	else if (json_only_opt)
 		return print_metrics_json(options.hashfile);
+	else if (prune_blocks_opt)
+		return prune_block_hashes(options.hashfile);
 
 	db = dbfile_open_handle(options.hashfile);
 	if (!db)

--- a/tests/integration/test_prune_block_hashes.py
+++ b/tests/integration/test_prune_block_hashes.py
@@ -1,0 +1,154 @@
+"""Reclaiming block hashes a hashfile no longer uses (#160).
+
+Block hashes serve only --dedupe-options=partial, and they are the bulk of a
+hashfile that has them (a fully-mapped 1 TiB at -b 4K stores ~8 GiB of block
+digests). They are dropped per file by dbfile_remove_hashes() when a file is
+re-hashed -- but the whole point of a hashfile is that unchanged files are *not*
+re-hashed, so on a stable tree a user who ran partial once carries those rows
+forever with nothing reading them.
+
+#160 asked for an option to not write them. That already exists: block hashing
+is off unless --dedupe-options=partial is passed. What was missing is a way to
+get rid of the ones already written.
+"""
+
+import os
+import unittest
+
+from harness import DuperemoveTest
+
+PARTIAL = ("-b", "4K", "--dedupe-options=partial")
+PLAIN = ("-b", "4K")
+
+
+class PruneBlockHashesTest(DuperemoveTest):
+    def _seed_with_partial(self, size=1 << 22):
+        """A hashfile carrying block hashes from a partial run."""
+        self.mkdup("tree/a.bin", "tree/b.bin", size)
+        self.sync()
+        self.dm("-r", self.path("tree"), *PARTIAL)
+        self.assertDmOk()
+        self.assertGreater(self.hf_count("blocks"), 0,
+                           "partial run stored no block hashes")
+
+    def test_default_scan_stores_no_block_hashes(self):
+        """The literal ask of #160 is already the default, at any blocksize."""
+        self.mkdup("tree/a.bin", "tree/b.bin", 1 << 20)
+        for bs in ("4K", "128K"):
+            os.path.exists(self.hf) and os.unlink(self.hf)
+            self.dm("-r", self.path("tree"), "-b", bs)
+            self.assertDmOk()
+            self.assertEqual(0, self.hf_count("blocks"),
+                             f"-b {bs} stored block hashes without partial")
+
+    def test_blocksize_does_not_change_extent_or_file_digests(self):
+        """#160's rationale for wanting 4K blocks without partial.
+
+        The claim is that matching -b to the filesystem block size improves
+        extent matching. It cannot: the extent digest is computed over the
+        fiemap extent's own bytes, independent of -b. Pinning that here so the
+        reasoning does not have to be re-derived from the code.
+        """
+        self.mkdup("tree/a.bin", "tree/b.bin", 1 << 21)
+        self.sync()
+        digests = {}
+        for bs in ("4K", "128K"):
+            os.path.exists(self.hf) and os.unlink(self.hf)
+            self.dm("-r", self.path("tree"), "-b", bs)
+            self.assertDmOk()
+            digests[bs] = (
+                self.hf_query("select f.filename, e.loff, e.len, quote(e.digest) "
+                              "from extents e join files f on f.id = e.fileid "
+                              "order by 1, 2"),
+                self.hf_query("select filename, quote(digest) from files "
+                              "order by filename"),
+            )
+        self.assertEqual(digests["4K"], digests["128K"],
+                         "-b changed the extent or file digests")
+
+    def test_block_rows_survive_a_non_partial_rescan(self):
+        """The gap itself: nothing reclaims them while files are unchanged."""
+        self._seed_with_partial()
+        before = self.hf_count("blocks")
+
+        self.dm("-r", self.path("tree"), *PLAIN)
+        self.assertDmOk()
+        self.assertEqual(before, self.hf_count("blocks"),
+                         "this test is stale: block rows are now reclaimed "
+                         "by an ordinary rescan")
+
+    def test_prune_drops_them_and_shrinks_the_file(self):
+        self._seed_with_partial()
+        size_before = os.path.getsize(self.hf)
+
+        self.dm("--prune-block-hashes")
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_count("blocks"))
+        self.assertLess(os.path.getsize(self.hf), size_before,
+                        "hashfile did not shrink after pruning")
+
+    def test_reported_size_reflects_the_real_file(self):
+        """In WAL mode the main file only shrinks at checkpoint.
+
+        stat()ing before closing the handle reports the pre-VACUUM size and
+        claims "0 B freed" right after reclaiming most of the file.
+        """
+        self._seed_with_partial()
+        out = self.dm("--prune-block-hashes")
+        self.assertDmOk()
+        self.assertIn("freed", out)
+        self.assertNotIn("(0 B freed)", out,
+                         "reported a saving of zero after a real one")
+
+    def test_prune_is_idempotent(self):
+        self._seed_with_partial()
+        self.dm("--prune-block-hashes")
+        out = self.dm("--prune-block-hashes")
+        self.assertDmOk()
+        self.assertIn("nothing to prune", out.lower())
+
+    def test_pruning_keeps_the_hashfile_usable(self):
+        """Only block hashes go: files and extents must survive untouched."""
+        self._seed_with_partial()
+        files_before = self.files_fingerprint()
+        extents_before = self.extents_fingerprint()
+
+        self.dm("--prune-block-hashes")
+        self.assertDmOk()
+        self.assertEqual(files_before, self.files_fingerprint())
+        self.assertEqual(extents_before, self.extents_fingerprint())
+
+        # And a later rescan is still incremental, not a full re-hash.
+        self.dm("-r", self.path("tree"), *PLAIN)
+        self.assertDmOk()
+        self.assertEqual(extents_before, self.extents_fingerprint())
+
+    def test_stats_flags_unused_block_hashes(self):
+        self._seed_with_partial()
+        self.dm("-r", self.path("tree"), *PLAIN)   # stored config drops partial
+
+        out = self.dm("--stats")
+        self.assertIn("--prune-block-hashes", out,
+                      "--stats did not surface the reclaimable rows")
+
+    def test_stats_does_not_flag_a_hashfile_still_using_partial(self):
+        """No false positive: these rows are in active use."""
+        self._seed_with_partial()
+        out = self.dm("--stats")
+        self.assertNotIn("--prune-block-hashes", out,
+                         "flagged block hashes the stored config still uses")
+
+    def test_is_mutually_exclusive_with_the_other_report_modes(self):
+        self._seed_with_partial()
+        out = self.dm("--prune-block-hashes", "--stats")
+        self.assertIn("use only one of", out)
+        self.assertNotEqual(0, self.rc)
+
+    def test_requires_a_hashfile(self):
+        out = self.dm("--prune-block-hashes", hashfile=False)
+        self.assertIn("--hashfile", out)
+        self.assertNotEqual(0, self.rc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #160 (reported by @crass) — though not as the issue proposed, because the proposal is already implemented. Details below.

## What #160 asked for is already the default

Block hashing is off unless `--dedupe-options=partial` is passed (`opt.c`: `do_block_hash = false`), so an ordinary scan stores **zero** block rows, at any blocksize:

```console
$ oans -rq -b 4K   --hashfile=d.db tree/   # blocks=0
$ oans -rq -b 128K --hashfile=d.db tree/   # blocks=0
```

## The real gap

Block rows are dropped per file by `dbfile_remove_hashes()`, but only when a file is **re-hashed** — and the point of a hashfile is that unchanged files are *not* re-hashed. So a hashfile that ran `partial` once keeps them indefinitely on a stable tree:

| run | blocks | hashfile |
|---|---|---|
| 1. `--dedupe-options=partial` | 4096 | 332 KiB |
| 2. same hashfile, no partial | **4096** | **332 KiB** |
| 3. after `touch` forces a re-hash | 0 | 68 KiB |

That's exactly the complaint in the issue ("the database can grow quite large"), just with a different cause than the one proposed. At the issue's own scale — a fully-mapped 1 TiB at `-b 4K` — it's ~8 GiB of digests nothing will ever read.

```console
$ oans --hashfile=h.db --stats
  block hashes    4096   (unused by the stored config; --prune-block-hashes reclaims them)

$ oans --hashfile=h.db --prune-block-hashes
Dropped 4096 block hashes; compacting ... done
Hashfile 332.0 KiB -> 68.0 KiB (264.0 KiB freed)
Note: a later --dedupe-options=partial run will re-hash the tree to rebuild them.
```

**Explicit, not automatic.** Dropping them on any non-partial run would make the next `partial` run silently re-hash the whole tree — the sort of invisible cost the hashfile exists to avoid. `--stats` flags them instead, so the dead weight is discoverable where you're already looking at what the hashfile costs.

## The issue's other claim

#160 argues for `-b 4K` without partial because "extents are filesystem block aligned, not oans block aligned, having the block sizes be the same increases the chance that two extents contains the same data."

That isn't how it works: `process_extents()` computes the extent digest over the fiemap extent's own bytes, independent of `-b`. Verified and pinned as a regression test — extent *and* file digests are byte-identical across `-b 4K` and `-b 128K`. So there's no reason to run small blocks without partial in the first place.

## Two traps I hit, in case they bite again

- **`dbfile_load_scan_config()` returns `>0` when a config was loaded**, `0` when none is stored. The natural-looking `if (!dbfile_load_scan_config(...))` silently never fires; the existing caller at `oans.c:261` already uses `> 0`.
- **The handle must be closed before `stat()`ing the file.** In WAL mode `VACUUM` writes through the WAL and the main database doesn't shrink until the checkpoint that closing performs — measuring first reports `0 B freed` immediately after reclaiming most of the file. Both are covered by tests.

## Testing

- New `tests/integration/test_prune_block_hashes.py` — 11 cases: default scan stores no blocks at either blocksize, `-b` doesn't change extent/file digests, block rows do survive a non-partial rescan (the gap itself, which will fail loudly if that ever changes), prune drops them and shrinks the file, the reported saving is real, prune is idempotent, files/extents survive and a later rescan is still incremental, `--stats` flags them only when the stored config dropped partial, and the mode is mutually exclusive and needs a hashfile.
- `scripts/verify.sh` passes: build clean, lint, 163 tests, valgrind smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)