### PR TITLE
Exit non-zero when a run could not use a root it was given

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -554,13 +554,40 @@ only what changed.
 See \f[CR]docs/nas\-quickstart.md\f[R] in the source tree for the full
 walkthrough.
 .SH EXIT STATUS
-\f[CR]oans\f[R] exits \f[B]0\f[R] on success.
-A non\-zero status indicates a fatal error, such as invalid options or a
-hashfile that could not be opened.
-Note that individual per\-file dedupe failures (e.g.\ a file that
-changed between scan and dedupe) are reported in the summary but do
-\f[B]not\f[R] by themselves change the exit status; check the \f[I]Not
-deduped\f[R] line, or run with \f[B]\-v\f[R], to detect them.
+.TP
+\f[B]0\f[R]
+Success.
+.TP
+\f[B]1\f[R]
+A fatal error: invalid options, a hashfile that could not be opened, or
+a replay in which \f[I]none\f[R] of the stored paths still exist
+(\f[CR]oans\f[R] refuses that rather than let the prune empty the
+hashfile).
+.TP
+\f[B]2\f[R]
+The run completed, but covered \f[B]less than it was asked to\f[R]: a
+path named on the command line could not be resolved or stat\(cqed, or a
+replayed configuration had lost one of its stored roots.
+Everything else was still scanned and deduplicated.
+Typical causes are a typo, an unmounted path, a renamed share, or a
+shell glob that was quoted by accident.
+.RS
+.PP
+This is the status an unattended job should alarm on \(em the run looks
+healthy otherwise, and would previously have exited \f[B]0\f[R].
+See \f[I]EXAMPLES\f[R] for an \f[CR]OnFailure=\f[R] setup.
+.RE
+.PP
+Skips the user asked for do \f[B]not\f[R] affect the exit status:
+\f[B]\-\-exclude\f[R] matches, files under \f[B]\-\-min\-filesize\f[R],
+non\-regular files, and read\-only subvolumes are all reported but are
+not failures.
+Neither are files met during the walk that could not be read \(em a
+large tree routinely holds a few \(em nor individual per\-file dedupe
+failures (e.g.\ a file that changed between scan and dedupe).
+Those are counted in the \f[I]Skipped\f[R] and \f[I]Not deduped\f[R]
+summary lines and exported by \f[B]\-\-json\f[R]; use those, or
+\f[B]\-v\f[R], to detect them.
 .SH ENVIRONMENT
 .TP
 \f[B]NO_COLOR\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -469,11 +469,32 @@ See `docs/nas-quickstart.md` in the source tree for the full walkthrough.
 
 # EXIT STATUS
 
-`oans` exits **0** on success. A non-zero status indicates a fatal error, such
-as invalid options or a hashfile that could not be opened. Note that individual
-per-file dedupe failures (e.g. a file that changed between scan and dedupe) are
-reported in the summary but do **not** by themselves change the exit status;
-check the *Not deduped* line, or run with **-v**, to detect them.
+**0**
+  ~ Success.
+
+**1**
+  ~ A fatal error: invalid options, a hashfile that could not be opened, or a
+    replay in which *none* of the stored paths still exist (`oans` refuses that
+    rather than let the prune empty the hashfile).
+
+**2**
+  ~ The run completed, but covered **less than it was asked to**: a path named
+    on the command line could not be resolved or stat'ed, or a replayed
+    configuration had lost one of its stored roots. Everything else was still
+    scanned and deduplicated. Typical causes are a typo, an unmounted path, a
+    renamed share, or a shell glob that was quoted by accident.
+
+    This is the status an unattended job should alarm on — the run looks
+    healthy otherwise, and would previously have exited **0**. See *EXAMPLES*
+    for an `OnFailure=` setup.
+
+Skips the user asked for do **not** affect the exit status: **\--exclude**
+matches, files under **\--min-filesize**, non-regular files, and read-only
+subvolumes are all reported but are not failures. Neither are files met during
+the walk that could not be read — a large tree routinely holds a few — nor
+individual per-file dedupe failures (e.g. a file that changed between scan and
+dedupe). Those are counted in the *Skipped* and *Not deduped* summary lines and
+exported by **\--json**; use those, or **-v**, to detect them.
 
 # ENVIRONMENT
 

--- a/docs/marketing-plan.md
+++ b/docs/marketing-plan.md
@@ -1,0 +1,389 @@
+# oans launch plan
+
+_Not for committing to the public repo — this is a working doc._
+Target launch week: **Mon 2026-07-27 → Fri 2026-07-31.** Status verified against
+the live repo on **2026-07-26**.
+
+_(Already slipped once, 07-20→07-26, because the code kept moving. It is still
+moving: **v1.5.0, v1.5.1 and v1.6.0 all shipped in the 30 hours after this doc
+was last updated.** That is the failure mode — see [Code freeze](#code-freeze)
+below, which is now the most important section here.)_
+
+---
+
+## TL;DR
+
+1. **Zero code is blocking. Three chores are, and all three need you.** Enable
+   GitHub Discussions, publish to the AUR, set the social preview image. Nothing
+   else on the P0/P1 list is open; there are **no open PRs** and master is
+   released as **v1.6.0**.
+2. **Freeze the code today.** Every improvement you find between now and Friday
+   goes in an issue, not in master. You are past the point where more polish buys
+   reach — you have 2 stars, which means the bottleneck is that nobody knows the
+   tool exists, not that it isn't good enough.
+3. **Stagger, don't blast.** One channel per day, starting with the friendliest
+   (r/btrfs), so you can absorb feedback and fix quick issues before the big-reach
+   posts. Being present in the comments is what actually drives ranking.
+4. **Lead with two numbers and the safety guarantee, be upfront about the
+   AI-assisted development.** "7× faster warm re-runs" answers *why re-run it*;
+   "~13× faster on a larger-than-RAM first run, byte-for-byte identical output"
+   answers *why the first run isn't the whole story* — that second number is
+   newer, stronger and better-documented than this doc used to give it credit
+   for. Then "the kernel byte-compares every range, so a bug can waste work but
+   can't corrupt data" defuses the objection you're guaranteed to get.
+
+---
+
+## Positioning
+
+**One-liner:** _oans is a duperemove fork built for dedup on trees too big to fit
+in RAM, re-run on a schedule (NAS, backup target, build server) — fast, hands-off,
+and honest about what it freed._
+
+**Audience, in priority order:**
+1. btrfs users with a lot of data (r/btrfs, r/DataHoarder)
+2. Self-hosters / homelab / NAS owners (r/selfhosted, r/homelab)
+3. Linux storage nerds & the "why not ZFS" crowd (HN, Phoronix, openSUSE/Fedora)
+
+**The four things that make it different (use these everywhere):**
+- **Fast where it counts:** warm re-runs skip everything already hashed _and_
+  already shared — the deduped-2M-file benchmark is ~92 s vs ~11 min upstream
+  (~7×).
+- **Fast on the *first* run too, when the tree is bigger than RAM** — i.e. every
+  real NAS. Streaming dedupe + page-cache prefetch: **13.8 s vs 179.7 s (~13×)**
+  at ~2× lower peak RSS, and `btrfs filesystem du -s` proves both tools leave the
+  **byte-for-byte identical** on-disk layout. Use this whenever someone says "your
+  benchmark is just a warm cache" — it's the honest answer and it's *stronger*
+  than the 7×.
+- **Set-and-forget:** the hashfile remembers your paths/options/excludes; bare
+  `oans --hashfile=FILE` replays incrementally, and there's a systemd timer.
+- **Honest & safe:** live progress with rate+ETA, a summary that reports disk
+  actually freed (not inflated shared-extents), and dedup goes through the
+  kernel's byte-verifying `FIDEDUPERANGE` — it can't corrupt data.
+
+**One extra hook, fresh in v1.6.0 — use it with the NAS/homelab crowd.** Sparse
+files whose size wasn't a block multiple were **silently skipped on every run**
+(#152) — that's VM images, database files and preallocated media, i.e. exactly
+what that audience stores. If they have those files, upgrading dedups them for
+the first time. It's a concrete "here's what you get today", and it doubles as
+evidence the project finds and fixes its own bugs.
+
+---
+
+## Code freeze
+
+**This is the section that decides whether the launch happens.** Everything else
+in this doc has been true and actionable for two weeks; what keeps changing is
+the code, and each change resets the "let me just finish this one thing" clock.
+
+The evidence, from this repo's own log: this doc slipped 07-20→07-26 because
+"the code kept moving", and in the 30 hours *after* that note was written,
+**#137, #138, #139, #140, #141, #142, #143, #144, #151, #152, #153, #154 and
+#155 merged and three releases shipped.** Every one of them was a genuine
+improvement. That is precisely why the freeze has to be a rule and not a
+judgement call — you will never fail to find another real improvement, so
+"is this worth delaying for?" is a question that always answers yes.
+
+**The rule, from now until Fri 2026-07-31:**
+
+- **master is frozen at v1.6.0.** No merges, no releases.
+- **Anything you find goes in a GitHub issue**, immediately, with the
+  reproduction. That is not losing the work — it's a public backlog, which on
+  launch week is itself a signal the project is alive.
+- **Two exceptions only:** data loss, or the tool fails to build/run for a new
+  user on a normal machine. Nothing else qualifies. A perf win doesn't. A
+  cosmetic progress-bar glitch doesn't. A missing FAQ entry is a README edit, not
+  a release.
+- **"I'll post right after this one PR" is the trap.** There is no such PR.
+- **A bug found *during* launch week is an asset, not an embarrassment** —
+  "good catch, fixed in <commit>" in a live thread is the best advertising you
+  will get all week. That's an argument for posting sooner, not for polishing
+  longer. See [After you post](#after-you-post).
+
+The honest cost-benefit: another week of improvements moves the tool maybe 2%.
+The first r/btrfs post moves it from 2 stars to a real user count. **The tool has
+been launch-ready since v1.2.0; it is now three minor releases past that.**
+
+---
+
+## Before you post — pre-launch checklist
+
+Prioritised. **[done]** items are merged to master; **[you]** still needs a human
+(an asset, an account, or a setting I can't change from here). Status verified
+against the live repo on **2026-07-26**.
+
+### P0 — do these or the launch underperforms
+
+- **[done] Ship a release.** ✅ **v1.6.0 is out** (2026-07-26 13:47), with the
+  prebuilt `oans-1.6.0-linux-x86_64.tar.gz` + `.sha256` attached, and master is
+  **clean — zero open PRs**. This item asked for v1.5.0; you shipped 1.5.0, 1.5.1
+  *and* 1.6.0 in a day. **Launch against v1.6.0 and stop here** — "out this week"
+  is as good a hook as "out today", and another release is another week.
+- **[you] Enable GitHub Discussions.** Confirmed still **off** today, but
+  `.github/ISSUE_TEMPLATE/config.yml` sends "Question or usage help" to
+  `/discussions` — a dead link on exactly the surface a launch drives traffic to,
+  and usage questions are the single most common thing a launch generates. One
+  toggle in Settings → Features.
+- **Make install one command.** From-source `make && sudo make install` alone
+  loses a chunk of r/btrfs and r/DataHoarder.
+  - **[done]** In-tree AUR `PKGBUILD`s: `packaging/aur/oans` (release) and
+    `oans-git` (master), each with a `duperemove` provides/conflicts. Groundwork
+    is committed and the README points at it.
+  - **[you] Still not published — re-checked today, `aur.archlinux.org/packages/oans`
+    and `oans-git` both still 404.** This is the last real gap in the install
+    story; until it's done, "one-command install" is really "clone and makepkg".
+    Needs your AUR account + SSH key: `cd packaging/aur/oans && makepkg
+    --printsrcinfo > .SRCINFO` then push to `ssh://aur@aur.archlinux.org/oans.git`.
+    (See `packaging/aur/README.md`.) The blocker this item used to have is gone —
+    v1.6.0 is tagged, so **point the PKGBUILD at `v1.6.0` and publish now.**
+  - **[done]** Prebuilt x86_64 binary attached to every release automatically
+    (`.github/workflows/release.yml`, PR #75) — **verified working**: v1.2.0,
+    v1.3.0 and v1.4.0 all carry `oans-X.Y.Z-linux-x86_64.tar.gz` + `.sha256`, so
+    the backfill note here is obsolete. (A Copr/OBS build for Fedora/openSUSE
+    stays optional.)
+- **[done] Demo GIF in the README.** A scripted, reproducible screencast
+  (`scripts/demo/`, PR #76) records scan → dedupe → `--stats`/`--history` and is
+  embedded as the hero image at the top of the README. Your single best piece of
+  post collateral — done.
+- **[done] "How it compares" FAQ (bees / ZFS / duperemove)** added to the README
+  and the man page NOTES, so you can link instead of retyping.
+
+### P1 — strongly recommended
+
+- **[you] Custom social preview image** (Settings → Social preview, 1280×640).
+  **Re-checked today: still not set** — `usesCustomOpenGraphImage` is `false`, so every
+  reddit / HN / Mastodon / Lemmy link renders GitHub's generic auto-card. This is
+  the single most-viewed asset of the whole push and it's ~15 minutes: a
+  *good-enough* static export of the mountain wordmark plus the one-liner beats
+  the auto-card — it doesn't need to be a perfect vector. You already have
+  `assets/logo.png` and the demo GIF to cut from.
+- **[done] Preempt the AI-assisted skepticism.** The README's attribution
+  paragraph now sits the byte-verified-kernel safety guarantee right next to the
+  "developed with AI tooling" line.
+- **[done] Discovery topics** added: `nas`, `homelab`, `selfhosted`, `storage`,
+  `linux` (on top of btrfs/xfs/dedupe/duperemove/reflink/filesystem).
+- **[done] Confirm the XFS claim.** CI now runs a `scratch_fs: [btrfs, xfs]`
+  matrix (`.github/workflows/ci.yml`): the full integration suite runs against an
+  `mkfs.xfs -m reflink=1` loopback image as well as btrfs, so the XFS support
+  claim is CI-proven, not just manually smoked. The XFS leg runs unprivileged, so
+  it also exercises the unprivileged `FS_IOC_GETFSUUID` path (Linux 6.4+); the
+  harness auto-skips the few btrfs-only (fragmentation) tests on XFS.
+- **[done] Sanitizers in CI — new since this plan was written, and it upgrades
+  your best answer to the AI-skepticism question.** CI now runs clang **ASAN**,
+  **UBSAN** and **ThreadSanitizer** legs over both test suites (#125, #127, #129,
+  #131), builds with warnings-as-errors, and still runs the valgrind leg — all on
+  a real btrfs *and* XFS. TSAN found a genuine use-after-free, which was fixed
+  (#129). Say "ASAN/UBSAN/TSAN and valgrind clean in CI on real btrfs and XFS"
+  wherever the drafts below say "valgrind-clean".
+
+### P2 — nice to have, not blocking
+
+- **[done] CONTRIBUTING.md + issue templates** (bug/feature YAML forms +
+  Discussions/NAS-guide contact links) landed. ⚠️ The Discussions contact link
+  is dead until you flip the toggle — see P0.
+- **[skip] CHANGELOG** — leaning on the GitHub release notes (v1.0.0→v1.5.0 are
+  already there, each with grouped notes); a separate file is maintenance for
+  little gain.
+- **[done] Benchmark methodology note** — `docs/benchmarks.md` documents the
+  exact tree, cold-vs-warm commands and the duperemove 0.15.2 comparison, linked
+  from the README so the 7× number is defensible.
+
+---
+
+## Where to post
+
+| Channel | Fit | Reach | Rules / notes |
+|---|---|---|---|
+| **r/btrfs** | ★★★ | small, dense | Your home crowd. Technical, receptive, forgiving of a "I made a tool" post. **Launch here first** to shake out feedback. |
+| **r/DataHoarder** | ★★★ | large | Dedup = free space; extremely on-topic. Read their self-promo rules; frame as show-and-tell + engage, don't drive-by. |
+| **r/selfhosted** | ★★★ | large | NAS/homelab dedup is squarely on-topic. Often has a specific self-promo day/flair — check the sidebar. |
+| **r/homelab** | ★★ | large | Good follow-up a couple days later; more hardware-flavored, but the NAS angle lands. |
+| **Hacker News (Show HN)** | ★★ | large, spiky | "Show HN: oans – …". High reach, brutal comments (expect "why not ZFS/bees", and AI questions). Post a weekday US morning; be online to reply for the first 2–3 h. |
+| **Phoronix** | ★★ | large | Michael Larabel covers btrfs/dedup tooling. Email a short tip / link the release; a Phoronix writeup outruns any single reddit post. |
+| **openSUSE / Fedora forums + Mastodon (#btrfs #linux)** | ★★ | medium | openSUSE ships btrfs by default. Fediverse Linux crowd is real and friendly to honest FOSS. |
+| **Lemmy** (`selfhosted`, `linux`) | ★ | growing | Cheap cross-post of the reddit content. |
+| **btrfs mailing list** | ★ | niche | A brief, humble "fork announcement" is appropriate and earns upstream goodwill. |
+
+Skip for now: r/linux (strict self-promo rules, big but noisy), r/truenas (ZFS-centric).
+
+---
+
+## When to post (week of 2026-07-27)
+
+Stagger one primary channel per day so you're never answering two firehoses at
+once. Post when the **US audience is waking up** — roughly **15:00–17:00 CET
+(09:00–11:00 ET)**, **Tue–Thu** are best; avoid Fri afternoon → weekend.
+
+| Day | Action |
+|---|---|
+| **Mon 07-27** | Prep only, no posting. **Three chores, ~1 h total:** enable Discussions (one toggle) → set the social preview (~15 min) → publish the AUR packages against `v1.6.0`. The release is already done. That's the whole remaining list. |
+| **Tue 07-28** | **r/btrfs** ~15:00 CET. Watch comments all evening; fix quick issues, note FAQ gaps. |
+| **Wed 07-29** | **r/DataHoarder** + **r/selfhosted** (morning apart, not simultaneously), using the r/btrfs feedback to sharpen the post. |
+| **Thu 07-30** | **Show HN** ~15:00 CET + **Mastodon** + email the **Phoronix** tip. Clear your afternoon to reply on HN. |
+| **Fri 07-31** | Light: **Lemmy** cross-post, **btrfs mailing list** note. Don't start a big thread going into the weekend. |
+| **Following week** | **r/homelab**, openSUSE/Fedora forums as second-wave, once you've got stars/feedback to point at. |
+
+**Don't let this slip again.** The Monday list is three human-only chores of
+maybe an hour total, and not one of them is code. Baseline to measure against:
+**2 stars, 1 fork, 1 watcher** on 2026-07-26. If this doc gets edited a third
+time with a new target week, the problem is not the plan — see
+[Code freeze](#code-freeze).
+
+**Rule of thumb:** never post somewhere you can't babysit for the next 2–3 hours.
+First-hour engagement is what decides whether a post ranks or dies.
+
+---
+
+## What to write (copy-paste drafts)
+
+Keep it first-person, humble, technical. No marketing-speak — this audience
+smells it instantly. Adjust to each sub's flair/rules.
+
+### r/btrfs
+
+> **Title:** oans — a duperemove fork focused on fast, repeatable dedup for big btrfs trees
+>
+> I run dedup on a large, mostly-stable btrfs tree on a schedule, and re-runs on
+> duperemove got slow because it re-hashes and re-checks a lot it doesn't need to.
+> So I forked it. **oans** skips everything already hashed _and_ everything already
+> shared on a re-run — on a deduped ~2M-file / 230 GiB tree a warm re-run is ~92 s
+> vs ~11 min with duperemove 0.15.2 here (~7×).
+>
+> That one's a warm cache, so the fairer number is the cold one: when the tree is
+> **larger than RAM** — any real NAS — the kernel's dedup byte-compare re-reads
+> from disk. oans streams the dedup phase and prefetches that read, so a *first*
+> run under a 4 GiB cap is **13.8 s vs 179.7 s (~13×)** at ~2× lower peak RSS —
+> and `btrfs filesystem du -s` says both tools leave byte-for-byte identical
+> sharing. Method, raw rounds and repro script are in the repo.
+>
+> Other than speed it's built to be set-and-forget: the hashfile remembers your
+> paths/options/excludes, so `oans --hashfile=FILE` with no other args replays
+> incrementally, and there's a systemd timer for weekly idle-priority runs. It also
+> has `--stats`/`--history`/`--json`, a live progress display with rate+ETA, and a
+> summary that reports disk actually freed instead of an inflated shared-extents
+> number.
+>
+> Dedup goes through the kernel's `FIDEDUPERANGE` ioctl, which byte-compares every
+> range before sharing — so a bug can waste work or miss a dedup, but can't corrupt
+> data. There's an integration suite CI runs against a real btrfs *and* XFS, under
+> ASAN, UBSAN, ThreadSanitizer and valgrind.
+>
+> v1.6.0 (this week) also fixes a bug worth calling out: sparse files whose size
+> isn't a multiple of the block size were silently skipped on *every* run — so VM
+> images, DB files and preallocated media never got deduped at all. If you have
+> those, this one finally hashes them. Heads-up for existing users: `--exclude`
+> now uses `.gitignore` syntax instead of `fnmatch`, which is a breaking change,
+> but the old behaviour matched at most one literal directory and usually nothing
+> — silently. Check your patterns; there's a warning now when one matches nothing.
+>
+> Full credit to Mark Fasheh and the duperemove contributors — it's their engine.
+> Fork improvements were developed with AI assistance and then reviewed, tested and
+> benchmarked on real data before landing. Repo + benchmarks: <link>. Feedback very
+> welcome — especially edge cases I haven't hit.
+
+### r/DataHoarder / r/selfhosted
+
+> **Title:** I forked duperemove so repeated dedup on a big NAS is actually fast (oans)
+>
+> _(same body, but open with the space-saving angle: "reclaimed 133 GiB across a
+> media tree in 92 s on a re-run" — that's the real `Reclaimed 133.1 GiB across
+> 164872 groups` line from the README's sample output, so it's quotable — then
+> lean on the systemd-timer set-and-forget story, which is what this crowd wants.)_
+>
+> _Two things to promote for **this** audience specifically: (1) the sparse-file
+> fix — VM images and preallocated media were being skipped entirely, and this
+> crowd has exactly those; (2) the **larger-than-RAM** benchmark, because their
+> trees are always larger than RAM and "13× on a first run, identical output" is
+> the claim that survives contact with a 40 TB array. Say up front that
+> `Reclaimed` is logical, not disk, on compressed btrfs — this sub will check
+> with `compsize` and you want to have said it first._
+
+### Show HN
+
+> **Title:** Show HN: Oans – fast offline dedup for btrfs and XFS (duperemove fork)
+>
+> _(tighter, more technical. Lead with the mechanism — offline/batch extent dedup
+> via `FIDEDUPERANGE`, incremental hashfile, skip-already-shared, streaming dedupe
+> pipeline with prefetch — then the benchmark, then the safety guarantee. Have the
+> bees/ZFS answers ready in the first comment; don't wait to be asked.)_
+>
+> _For HN specifically, **lead with the 13× larger-than-RAM number, not the 7×**.
+> This crowd will immediately identify the warm re-run as a cache effect and say
+> so; leading with the cold, memory-capped, byte-verified-identical benchmark
+> pre-empts that and shows the methodology up front. "Both tools read the same
+> 16.7 GiB and produce the same on-disk layout, verified with `btrfs filesystem
+> du -s`; the difference is how the dedupe phase reads it back" is the sentence
+> that earns the thread._
+
+**Title tips:** put the concrete benefit and "duperemove fork" in the title (that's
+the searchable hook), keep the fun name but don't rely on it to carry the click.
+
+---
+
+## Hard questions — have answers ready (and in the README FAQ)
+
+These _will_ come up. Prewrite them; link instead of retyping.
+
+- **"Why not bees?"** bees is a always-on daemon doing continuous block-level
+  dedup across the whole filesystem; great for that. oans is offline/batch
+  file+extent dedup you point at specific trees and run on a schedule — lower
+  overhead when you don't want a resident daemon, and it gives you stats/history
+  and honest per-run accounting. Different tool for a different workflow, not a
+  competitor claim.
+- **"Why not just ZFS dedup?"** ZFS dedup is inline and needs a big always-resident
+  dedup table (RAM-hungry, hard to undo). oans is offline dedup for btrfs/XFS you
+  already run — no dedup table, no permanent RAM cost, run it when you want.
+- **"AI-assisted tool touching my data? no thanks."** Fair concern, so: dedup is
+  performed by the kernel's `FIDEDUPERANGE`, which byte-compares every range before
+  sharing — the tool literally cannot make the kernel share non-identical data.
+  Worst case is wasted work or a missed dedup, both harmless. On top of that, CI
+  runs the integration suite on real btrfs and XFS under ASAN, UBSAN,
+  ThreadSanitizer and valgrind, with warnings as errors. That's not decoration:
+  TSAN caught a real use-after-free (fixed in v1.5.0), valgrind-on-the-suite
+  caught another, and v1.6.0 fixed a silent sparse-file skip and a miscounted
+  dedupe summary — all found and fixed in the open, each with a regression test.
+  Every change was reviewed, tested and benchmarked. **Don't be defensive here:**
+  "here are the bugs we found and how" is a far better answer than "there are no
+  bugs", and it's the one that's actually true of every codebase.
+- **"Is the 7× real?"** Yes, with caveats, and volunteer them: it's a _warm
+  re-run_ on an already-deduped 2M-file/230 GiB btrfs tree. **Then immediately
+  give them the better number** — the larger-than-RAM benchmark is a *cold* first
+  run under a hard 4 GiB cgroup cap, 10 interleaved rounds, median 13.8 s vs
+  179.7 s, with both tools verified to produce byte-for-byte identical sharing.
+  One machine, one NVMe, and on a slow HDD the gap would be *larger*, not smaller.
+  Exact tree, commands and repro script: <link to methodology>.
+- **"Why is the first-run gain so much bigger than the warm-run gain? That's
+  backwards."** Because they're different bottlenecks. Warm re-runs win by
+  *skipping* work already done (~7×). The larger-than-RAM win is the dedupe phase:
+  `FIDEDUPERANGE` byte-compares every range, and when the tree doesn't fit in the
+  page cache that compare re-reads from disk cold. oans streams the dedupe
+  pipeline and prefetches, so the kernel compares from RAM (~13×). Same work,
+  different read pattern.
+- **"Should I upgrade from 1.5.x? Anything that'll bite me?"** Yes and yes, one
+  thing: `--exclude` switched from `fnmatch`-on-the-full-path to `.gitignore`
+  syntax in 1.6.0. That's deliberate and it's a fix — the old semantics matched at
+  most one literal directory and usually nothing at all, *silently*, so
+  `--exclude node_modules` did nothing. Patterns stored in an existing hashfile
+  replay under the new meaning. Re-check your patterns; 1.6.0 warns when one
+  matches nothing. Also in 1.6.0: sparse files with a non-block-multiple size were
+  being skipped on every run and now aren't.
+- **"Hashfile compatibility with duperemove?"** Intentionally not interchangeable
+  (branded `application_id`); each rebuilds rather than misreads the other's. It's
+  only a cache, so nothing is lost.
+- **"On compressed btrfs the number looks too big."** `Reclaimed` is a _logical_
+  figure; real disk freed is ~compression-ratio smaller because dedup shares
+  logical extents. Verify with `compsize` Disk Usage before/after.
+
+---
+
+## After you post
+
+- **Reply to everything in the first 2–3 hours.** Upvotes follow engagement.
+- **Ship small fixes live.** "Good catch — fixed in <commit>" on launch day is the
+  best possible advertisement.
+- **Don't argue.** For "why not X", answer once, factually, and move on. The
+  bees/ZFS debate is unwinnable and unnecessary — you're a different workflow.
+- **Track:** stars/day, referral sources (GitHub Insights → Traffic), which
+  channel converts, and recurring questions → fold them back into the README FAQ.
+- **Roll feedback forward.** Whatever r/btrfs asks on Tue becomes a README/FAQ
+  improvement before the r/DataHoarder and HN posts.

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -101,6 +101,28 @@ oans --history --hashfile=/var/cache/oans/media.hash    # reclaimed over time
 oans --json    --hashfile=/var/cache/oans/media.hash    # metrics for a dashboard
 ```
 
+**Get told when a run covers less than you asked for.** oans exits **2** when
+it completed but could not use one of its stored roots — an unmounted drive, a
+renamed share, a deleted directory. The run still deduplicates everything else
+and otherwise looks perfectly healthy, so this is the case worth alarming on:
+
+```sh
+systemctl is-failed oans@media.service     # 'failed' after an exit-2 run
+journalctl -u oans@media.service | grep -i 'no longer exists'
+```
+
+`oans@.service` deliberately does not whitelist 2 in `SuccessExitStatus=`, so
+the unit fails and an `OnFailure=` of your own fires:
+
+```sh
+sudo systemctl edit oans@media.service     # add: [Unit] / OnFailure=...
+```
+
+Exit **1** means it refused to run at all — usually because *every* stored path
+is gone, which oans treats as "the drive is not mounted" rather than "delete
+every hash". Skips you configured (`--exclude`, `--min-filesize`, snapshots)
+never change the exit status; they are reported in the summary and in `--json`.
+
 For **live** progress of a run in flight — to feed a dashboard or a health
 check rather than watch the terminal — run it with `--progress=json`. oans then
 streams one JSON object per phase (about once a second) to **stderr**, ending

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -471,6 +471,24 @@ static bool seed_fs_lock_failed;
 static unsigned int nr_roots_seeded;
 
 /*
+ * Scan roots named explicitly by the user (argv, or a "-" stdin list) that
+ * could not be resolved or stat()ed (#146).
+ *
+ * Distinct from the general skip counters: a root is *user input*, so failing
+ * to use one is always worth an error, where a file met mid-walk that the
+ * scanner cannot open is a routine event on a real NAS tree. Nothing here
+ * counts a root dropped by the user's own configuration - an --exclude match,
+ * --min-filesize, a read-only subvolume - since those are the user asking for
+ * the skip.
+ */
+static unsigned int nr_roots_unusable;
+
+unsigned int filescan_roots_unusable(void)
+{
+	return nr_roots_unusable;
+}
+
+/*
  * Reject a path in check_file(). On a top-level seed (not a child discovered
  * mid-walk) also record that it could not be locked onto a supported fs, so
  * scan_files() can fail loudly instead of silently reporting nothing to do.
@@ -1636,12 +1654,14 @@ int scan_file(char *in_path, struct dbhandle *db)
 				"ancestor, or bind-mount this directory somewhere "
 				"shorter.\n", in_path, PATH_MAX);
 			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
+			nr_roots_unusable++;
 			return 0;
 		}
 		eprintf("Error %d: %s while getting path to file %s. "
 			"Skipping.\n",
 			errno, strerror(errno), in_path);
 		filescan_count_errno_skip(errno);
+		nr_roots_unusable++;
 		return 0;
 	}
 
@@ -1652,6 +1672,7 @@ int scan_file(char *in_path, struct dbhandle *db)
 			"Skipping.\n",
 			errno, strerror(errno), path);
 		filescan_count_errno_skip(errno);
+		nr_roots_unusable++;
 		return 0;
 	}
 

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -47,6 +47,15 @@ void fs_get_locked_uuid(uuid_t *uuid);
 bool filescan_seed_failed(void);
 
 /*
+ * How many scan roots named on the command line (or in a "-" stdin list) could
+ * not be resolved or stat()ed (#146). A typo, an unmounted path, a renamed
+ * share or an accidentally-quoted glob all land here, and each means the run
+ * covered less than it was asked to - so the caller reports it in the exit
+ * status instead of exiting 0. Config-driven skips are deliberately excluded.
+ */
+unsigned int filescan_roots_unusable(void);
+
+/*
  * Scan-phase skip accounting (#145).
  *
  * Every "I skipped this" path in the walk used to write a line to stderr and be

--- a/src/oans.c
+++ b/src/oans.c
@@ -56,6 +56,18 @@ static int stdin_filelist = 0;
 static unsigned int list_only_opt = 0;
 static unsigned int rm_only_opt = 0;
 static unsigned int stats_only_opt = 0;
+
+/*
+ * Exit status for a run that completed but covered less than it was asked to:
+ * a root named on the command line could not be resolved or stat()ed (#146).
+ *
+ * Distinct from 1 so a wrapper can tell "degraded" from "broken" without
+ * parsing --json: a typo, an unmounted path or a renamed share leaves the good
+ * roots scanned and deduped, and only the status says something was missed.
+ * Previously this was indistinguishable from success, so a Type=oneshot
+ * systemd unit could never notice it and OnFailure= never fired.
+ */
+#define EXIT_INCOMPLETE		2
 static unsigned int prune_blocks_opt = 0;
 static unsigned int history_only_opt = 0;
 static unsigned int json_only_opt = 0;
@@ -1625,9 +1637,11 @@ static int apply_scan_config(const struct scan_config *sc)
  * survive is the caller's job: scanning zero roots would let the stat-based
  * prune wipe the whole hashfile (e.g. an unmounted drive).
  */
-static int drop_missing_roots(struct scan_config *sc)
+static int drop_missing_roots(struct scan_config *sc, int *dropped)
 {
 	int i, live = 0;
+
+	*dropped = 0;
 
 	for (i = 0; i < sc->nroots; i++) {
 		struct stat st;
@@ -1640,6 +1654,7 @@ static int drop_missing_roots(struct scan_config *sc)
 			eprintf("Warning: stored path \"%s\" no longer exists, "
 				"skipping.\n", sc->roots[i]);
 			free(sc->roots[i]);
+			(*dropped)++;
 		}
 	}
 	/* Shrink the count to the compacted survivors; scan_config_free() then
@@ -1752,6 +1767,7 @@ int main(int argc, char **argv)
 	bool replaying = false;
 	uint64_t files_scanned = 0;
 	uint64_t scan_skips[SCAN_SKIP__COUNT] = {0};
+	int roots_dropped = 0;	/* replayed roots that no longer exist (#146) */
 	struct scan_config replay = {0};
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = NULL;
 
@@ -1843,7 +1859,7 @@ int main(int argc, char **argv)
 			ret = 1;
 			goto out;
 		}
-		numfiles = drop_missing_roots(&replay);
+		numfiles = drop_missing_roots(&replay, &roots_dropped);
 		if (numfiles == 0) {
 			eprintf("Error: none of the stored paths exist; refusing "
 				"to run (this would prune the whole hashfile).\n");
@@ -1915,6 +1931,20 @@ int main(int argc, char **argv)
 	/* Reclaim space if a prune this run left the hashfile mostly free. */
 	if (options.hashfile)
 		dbfile_maybe_vacuum(db);
+
+	/*
+	 * Report the unusable root only once the run is otherwise complete: the
+	 * remaining roots are still scanned and deduped, exactly as before. An
+	 * existing failure keeps its own status - this must not mask a real one.
+	 */
+	/*
+	 * A replayed root that has vanished counts too, and is the case that
+	 * matters most: a timer whose stored config lost one of three shares to
+	 * an unmount goes on narrowing every run, exiting 0 each time. Losing
+	 * *every* root already fails hard above, before any pruning.
+	 */
+	if (!ret && (filescan_roots_unusable() || roots_dropped))
+		ret = EXIT_INCOMPLETE;
 
 out:
 	scan_config_free(&replay);

--- a/systemd/oans@.service
+++ b/systemd/oans@.service
@@ -26,6 +26,13 @@ CacheDirectory=oans
 # to a short summary. Runs as root so it can read and re-extent the configured
 # tree wherever it lives.
 ExecStart=/usr/bin/oans --quiet --hashfile=/var/cache/oans/%i.hash
+# Exit 2 means the run completed but covered less than its stored config asked
+# for - typically a root that no longer exists because a drive is unmounted or
+# a share was renamed. It is deliberately NOT listed in SuccessExitStatus=, so
+# the unit fails and any OnFailure= you add fires. Add one to be told:
+#     OnFailure=status-email@%i.service
+# (Losing *every* stored root exits 1 and refuses to run, so the stat-based
+# prune can never empty the hashfile.)
 # Deduplication only ever rewrites extent sharing via the byte-verified
 # FIDEDUPERANGE ioctl, so an interrupted run is safe; allow a clean stop.
 TimeoutStopSec=30

--- a/tests/integration/test_exit_status.py
+++ b/tests/integration/test_exit_status.py
@@ -1,0 +1,142 @@
+"""A run that could not cover what it was given must say so in $? (#146).
+
+oans exited 0 when a path named on the command line could not be resolved, and
+when a replayed scan config had lost a root. For the scheduled deployment that
+is the difference between a monitored job and an unmonitored one: systemd marks
+the unit SUCCESS, OnFailure= never fires, and `if oans ...; then` takes the
+happy path. The shipped oans@.service is Type=oneshot with no OnFailure=, so
+there was no configuration of it that could notice.
+
+Exit 2 means "completed, but covered less than asked", leaving 1 for a real
+failure so a wrapper can tell degraded from broken without parsing --json.
+
+Deliberately NOT covered by exit 2: skips the user asked for (--exclude,
+--min-filesize, a non-regular file), and files met mid-walk that could not be
+read -- a real NAS tree routinely contains a handful of those, and failing
+every run over one unreadable lock file is the wrong default. That is the
+broader --strict question, left open on the issue.
+"""
+
+import os
+import stat
+import unittest
+
+from harness import DuperemoveTest
+
+EXIT_INCOMPLETE = 2
+
+
+class ExitStatusTest(DuperemoveTest):
+    def tearDown(self):
+        for root, dirs, _files in os.walk(self.work):
+            for d in dirs:
+                try:
+                    os.chmod(os.path.join(root, d), stat.S_IRWXU)
+                except OSError:
+                    pass
+        super().tearDown()
+
+    def _tree(self):
+        self.mkdup("tree/a.bin", "tree/b.bin", 100000)
+        self.sync()
+        return self.path("tree")
+
+    # -- the cases that must fail ------------------------------------------
+
+    def test_nonexistent_root_exits_incomplete(self):
+        self._tree()
+        self.dm("-r", self.path("nope"))
+        self.assertEqual(EXIT_INCOMPLETE, self.rc)
+
+    def test_one_bad_root_among_good_ones_still_scans_the_good_ones(self):
+        """Degraded, not aborted: the rest of the tree is still processed."""
+        tree = self._tree()
+        self.dm("-r", tree, self.path("nope"))
+        self.assertEqual(EXIT_INCOMPLETE, self.rc)
+        self.assertEqual(2, self.hf_count("files"),
+                         "a bad root stopped the good one being scanned")
+
+    def test_quoted_glob_exits_incomplete(self):
+        """The issue's reproduction: an accidentally-quoted shell glob."""
+        tree = self._tree()
+        self.dm("-r", os.path.join(tree, "*"))
+        self.assertEqual(EXIT_INCOMPLETE, self.rc)
+
+    def test_replayed_config_that_lost_a_root_exits_incomplete(self):
+        """The scheduled-job case: an unmounted share narrows every run."""
+        self.mkrand("r1/x.bin", 50000)
+        self.mkrand("r2/y.bin", 50000)
+        self.sync()
+        self.dm("-r", self.path("r1"), self.path("r2"))
+        self.assertDmOk()
+
+        # Bare replay while both roots exist: healthy.
+        self.dm()
+        self.assertEqual(0, self.rc)
+
+        import shutil
+        shutil.rmtree(self.path("r2"))
+        self.dm()
+        self.assertEqual(EXIT_INCOMPLETE, self.rc,
+                         "a replay that lost a root reported success")
+
+    # -- the cases that must NOT fail --------------------------------------
+
+    def test_clean_run_exits_zero(self):
+        self.dm("-r", self._tree())
+        self.assertEqual(0, self.rc)
+
+    def test_excluded_root_exits_zero(self):
+        """The user asked for this skip; it is not a failure."""
+        tree = self._tree()
+        self.dm("-r", tree, "--exclude", "tree/")
+        self.assertEqual(0, self.rc)
+
+    def test_root_below_min_filesize_exits_zero(self):
+        self.write("tiny.bin", b"x" * 10)
+        self.sync()
+        self.dm("-r", self.path("tiny.bin"), "--min-filesize=1M")
+        self.assertEqual(0, self.rc)
+
+    def test_non_regular_root_exits_zero(self):
+        os.symlink("/dev/null", self.path("link"))
+        self.dm("-r", self.path("link"))
+        self.assertEqual(0, self.rc)
+
+    def test_unreadable_directory_mid_walk_still_exits_zero(self):
+        """Out of scope on purpose: that is the broader --strict question.
+
+        A NAS tree routinely holds a few files the scanner cannot open, so
+        failing the whole run over one is the wrong default. #145's counters
+        already make these visible; only the exit status is left alone.
+        """
+        self.mkrand("tree2/ok.bin", 1000)
+        self.mkrand("tree2/locked/x.bin", 1000)
+        os.chmod(self.path("tree2/locked"), 0o000)
+        self.sync()
+        self.dm("-r", self.path("tree2"))
+        self.assertEqual(0, self.rc)
+        # ...but it is still reported, per #145.
+        self.assertIn("Skipped", self.out)
+
+    def test_replay_with_all_roots_gone_still_fails_hard(self):
+        """Unchanged: that refuses to run at all, so it keeps exit 1.
+
+        Scanning zero roots would let the stat-based prune wipe the hashfile,
+        so this must stay a hard failure and not be softened to 'incomplete'.
+        """
+        self.mkrand("r1/x.bin", 50000)
+        self.sync()
+        self.dm("-r", self.path("r1"))
+        self.assertDmOk()
+
+        import shutil
+        shutil.rmtree(self.path("r1"))
+        self.dm()
+        self.assertEqual(1, self.rc)
+        self.assertGreater(self.hf_count("files"), 0,
+                           "refusing to run must not have pruned the hashfile")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_self_describing.py
+++ b/tests/integration/test_self_describing.py
@@ -98,7 +98,10 @@ class SelfDescribingConfigTest(DuperemoveTest):
 
         shutil.rmtree(self.path("one"))     # one of two roots vanishes
         self.dm()
-        self.assertEqual(self.rc, 0)
+        # Exit 2 = "completed, but covered less than asked" (#146). Asserting
+        # the exact code rather than just non-zero keeps this a crash
+        # regression too: a double-free would show up as a signal, not as 2.
+        self.assertEqual(self.rc, 2)
         self.assertIn("no longer exists", self.out)
         # A replay does not rewrite the stored config, so the temporarily
         # missing root is kept and retried next time (e.g. an unmounted drive),


### PR DESCRIPTION
Closes #146 — the narrow half you split out, plus the replay case, which turned out to matter more.

## Before

```console
$ oans -rq --hashfile=/tmp/h.db '/srv/media/*'
Error 2: No such file or directory while getting path to file /srv/media/*. Skipping.
Warning: not storing root "/srv/media/*" in the hashfile: No such file or directory.
$ echo $?
0
```

## What now exits 2

- **A root named on the command line** (or in a `-` stdin list) that can't be resolved or `stat`ed. A root is *user input*, so failing to use one is always worth an error.
- **A replayed config that lost a stored root.** This goes beyond what the issue asked for, and I think it's the more valuable half: a timer whose stored config lost one of three shares to an unmount goes on quietly narrowing every run, exiting 0 each time. That's the exact scenario `oans@.timer` exists for.

`2`, not `1`, so a wrapper can tell degraded from broken without parsing `--json` — the remaining roots are still scanned and deduped, and only the status says something was missed. Losing *every* stored root already exits 1 and refuses to run (so the prune can't empty the hashfile); unchanged.

## What deliberately still exits 0

Everything the user asked for: `--exclude` matches, `--min-filesize`, non-regular files, read-only subvolumes. And an unreadable directory met **during the walk** — that's the broader `--strict` question you left open, and failing every run over one unreadable lock file is the wrong default. #145's counters already make those visible:

```console
$ oans -rq --hashfile=h.db tree2/     # tree2/locked is chmod 000
  Skipped        1 permission denied (rerun with -v for detail)
$ echo $?
0
```

Both directions are pinned by tests, so whichever way you later take `--strict`, the line is documented in code.

## One pre-existing test changed

`test_some_roots_missing_skips_and_keeps_going` asserted exit 0 for the replay case. Its actual purpose is the double-free regression and that the survivor still gets scanned, so it now asserts **exactly 2** — which is stronger than the old check, because a crash no longer passes it.

## Docs

- Man page **EXIT STATUS** rewritten as 0/1/2 with an explicit list of what does *not* affect the status.
- `systemd/oans@.service` — a comment explaining that 2 is deliberately absent from `SuccessExitStatus=` so `OnFailure=` fires, with an example.
- `docs/nas-quickstart.md` — a "get told when a run covers less than you asked for" block in the Monitor step.

## Testing

- New `tests/integration/test_exit_status.py` — 10 cases covering both directions: nonexistent root, one bad root among good ones (and the good one still scanned), the quoted-glob repro, a replay that lost a root; and clean run, excluded root, under-min-filesize root, non-regular root, mid-walk permission error, and all-roots-gone still failing hard **without** pruning the hashfile.
- `scripts/verify.sh` passes: build clean, lint, 173 tests, valgrind smoke.

Leaves the `--strict` half of #146 open; worth revisiting once real-world bucket counts from #145 show what a typical NAS tree actually skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)