### PR TITLE
Warn when a replayed config would never deduplicate

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -128,6 +128,9 @@ Because the hashfile also records the run\(cqs options, paths, and
 \f[B]\f[CB]oans \-\-hashfile=FILE\f[B]\f[R] with no \f[I]file\f[R]
 arguments \f[B]replays the last run\f[R] (any other options on that
 command line are ignored).
+That includes \f[B]\-d\f[R]: a hashfile seeded by a read\-only preview
+run replays as read\-only forever, so \f[CR]oans\f[R] warns on such a
+replay and prints the command to update it.
 If none of the stored paths still exist \f[CR]oans\f[R] refuses rather
 than prune every entry \(em guarding against, e.g., an unmounted drive
 \(em while individually missing paths are skipped with a warning.
@@ -292,6 +295,12 @@ a node_exporter textfile).
 freed is smaller on a compressed filesystem.
 Requires \f[B]\-\-hashfile\f[R].
 .RS
+.PP
+\f[CR]scan_configured_dedupe\f[R] is \f[CR]false\f[R] when the stored
+scan configuration has no \f[B]\-d\f[R] \(em a job in that state hashes
+but never deduplicates, and reports \f[CR]0 B\f[R] reclaimed forever,
+which is also what a healthy job on a clean tree reports.
+This is what tells them apart.
 .PP
 \f[CR]scan_skipped_last_run\f[R] reports what the most recent scan could
 \f[B]not\f[R] read, bucketed by cause (\f[CR]permission\f[R],

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -106,7 +106,9 @@ directory scans the regular files directly inside it; add **-r** to recurse.
     Because the hashfile also records the run's options, paths, and **\--exclude**
     patterns, you need not repeat them: **`oans --hashfile=FILE`** with no *file*
     arguments **replays the last run** (any other options on that command line
-    are ignored). If none of the stored paths still exist `oans` refuses rather
+    are ignored). That includes **-d**: a hashfile seeded by a read-only preview
+    run replays as read-only forever, so `oans` warns on such a replay and
+    prints the command to update it. If none of the stored paths still exist `oans` refuses rather
     than prune every entry — guarding against, e.g., an unmounted drive — while
     individually missing paths are skipped with a warning.
 
@@ -244,6 +246,11 @@ directory scans the regular files directly inside it; add **-r** to recurse.
     to `jq`, Telegraf, a node_exporter textfile). `reclaimable_logical_bytes` is
     a logical upper bound; real disk freed is smaller on a compressed
     filesystem. Requires **\--hashfile**.
+
+    `scan_configured_dedupe` is `false` when the stored scan configuration has
+    no **-d** — a job in that state hashes but never deduplicates, and reports
+    `0 B` reclaimed forever, which is also what a healthy job on a clean tree
+    reports. This is what tells them apart.
 
     `scan_skipped_last_run` reports what the most recent scan could **not**
     read, bucketed by cause (`permission`, `unreadable`, `path_too_long`,

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -58,6 +58,13 @@ sudo install -d -m 0755 /var/cache/oans
 sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
 ```
 
+> **The `-d` here is load-bearing.** Every later scheduled run replays this
+> one, so if you seed the hashfile with a preview run (no `-d`), the timer
+> inherits it and will hash forever without ever deduplicating — exiting 0 and
+> reporting `0 B` reclaimed each time, which looks exactly like a healthy job on
+> an already-deduped tree. A replay in that state warns and prints the command
+> to fix it; `oans --json` reports `"scan_configured_dedupe": false`.
+
 This is the expensive pass: it hashes everything and deduplicates. It
 
 - records the options and paths, so later runs need no arguments,

--- a/src/oans.c
+++ b/src/oans.c
@@ -532,6 +532,19 @@ static int print_metrics_json(char *filename)
 	printf("  },\n");
 	printf("  \"scan_skipped_errors_total\": %"PRIu64",\n", sum.total_skip_errors);
 	/*
+	 * Whether the stored config deduplicates at all. A job seeded without -d
+	 * reports 0 reclaimed forever, which is also what a healthy job on a
+	 * clean tree reports - this is what tells them apart (#149).
+	 */
+	{
+		struct scan_config sc = {0};
+
+		if (dbfile_load_scan_config(db, &sc) > 0)
+			printf("  \"scan_configured_dedupe\": %s,\n",
+			       sc.run_dedupe ? "true" : "false");
+		scan_config_free(&sc);
+	}
+	/*
 	 * Deliberately outside the error object: a skipped snapshot is a saving,
 	 * not a fault, but it does mean the run covered less than the tree (#156).
 	 */
@@ -1628,6 +1641,36 @@ static int apply_scan_config(const struct scan_config *sc)
 			return 1;
 		}
 	}
+
+	/*
+	 * A replay inherits -d from the run that seeded the hashfile, and the
+	 * setup flow makes that easy to get wrong: the docs walk the user
+	 * through a first run to establish the hashfile, and the man page
+	 * actively suggests a preview run *without* -d. Seed it that way and the
+	 * timer inherits run_dedupe = 0 - after which it walks the tree, updates
+	 * hashes, records a run, exits 0 and reclaims nothing, every week,
+	 * indistinguishably from a healthy job. --history shows a growing list of
+	 * runs with 0 B reclaimed, which is also what a healthy job on an
+	 * already-deduped tree looks like.
+	 *
+	 * Not an error: a hash-only scheduled job is a legitimate setup (keeping
+	 * a hashfile warm so a later -d run is fast), so refusing would break
+	 * working configurations. Just say so, with the command that fixes it -
+	 * the whole point of a replay is that the user no longer remembers the
+	 * arguments. On stderr, so -q (what the shipped unit runs) still shows it.
+	 */
+	if (!sc->run_dedupe) {
+		eprintf("WARNING: the stored configuration for %s has no -d, so "
+			"this run will hash but not deduplicate.\n",
+			options.hashfile);
+		eprintf("         Re-run once with -d and the paths to update "
+			"it:\n           oans -%sd --hashfile=%s",
+			sc->recurse ? "r" : "", options.hashfile);
+		for (i = 0; i < sc->nroots; i++)
+			eprintf(" %s", sc->roots[i]);
+		eprintf("\n");
+	}
+
 	return 0;
 }
 

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -39,6 +39,11 @@ sudo install -d -m 0755 /var/cache/oans
 sudo oans -dr --hashfile=/var/cache/oans/media.hash /srv/media
 ```
 
+**Include `-d` in this run.** The timer replays whatever this one recorded, so
+seeding with a read-only preview gives you a job that hashes weekly and never
+deduplicates — exit 0, `0 B` reclaimed, indistinguishable from a healthy run.
+A replay in that state warns and prints the command that fixes it.
+
 Then enable the timer for that job:
 
 ```sh

--- a/systemd/oans@.service
+++ b/systemd/oans@.service
@@ -8,6 +8,10 @@
 #
 # Example: `systemctl start oans@media` deduplicates using
 # /var/cache/oans/media.hash.
+#
+# That first run must include -d: this unit replays what it recorded, so a
+# hashfile seeded by a read-only preview yields a job that hashes every week and
+# never deduplicates. oans warns on such a replay and prints the fix.
 
 [Unit]
 Description=oans deduplication (%i)

--- a/tests/integration/test_replay_no_dedupe.py
+++ b/tests/integration/test_replay_no_dedupe.py
@@ -1,0 +1,103 @@
+"""A replayed config with no -d must say so (#149).
+
+An oans@.timer job can run every week forever, exit 0 every time, and never
+deduplicate anything -- because the run that seeded its hashfile was missing
+-d. The replay mechanism is working as designed; the problem is that the setup
+flow leads users into it (the docs walk through a first run to establish the
+hashfile, and the man page actively suggests a preview run without -d), and the
+resulting job is indistinguishable from a healthy one: it walks the tree,
+updates hashes, records a run, exits 0, and reclaims nothing. --history shows a
+growing list of runs with 0 B reclaimed, which is also exactly what a healthy
+job on an already-deduped tree looks like.
+
+Not an error: a hash-only scheduled job is a legitimate setup, so this warns
+rather than refuses.
+"""
+
+import json
+import unittest
+
+from harness import DuperemoveTest, requires_reflink
+
+WARNING = "has no -d"
+
+
+class ReplayNoDedupeTest(DuperemoveTest):
+    def _tree(self):
+        self.mkdup("tree/a.bin", "tree/b.bin", 100000)
+        self.sync()
+        return self.path("tree")
+
+    def test_replay_of_a_scan_only_config_warns(self):
+        self.dm("-r", self._tree())          # seeded WITHOUT -d
+        self.assertDmOk()
+
+        self.dm()                            # bare replay
+        self.assertIn(WARNING, self.out,
+                      "a timer that never dedupes gave no indication")
+
+    def test_the_warning_names_the_command_that_fixes_it(self):
+        """The point of a replay is that the user forgot the arguments."""
+        tree = self._tree()
+        self.dm("-r", tree)
+        self.dm()
+        self.assertIn("-rd", self.out, "no fix-up command offered")
+        self.assertIn(self.hf, self.out, "fix-up command omits the hashfile")
+        self.assertIn(tree, self.out, "fix-up command omits the stored path")
+
+    def test_the_warning_survives_quiet(self):
+        """-q is what the shipped systemd unit runs, so it must show there."""
+        self.dm("-r", self._tree())
+        self.dm(quiet=True)
+        self.assertIn(WARNING, self.out)
+
+    @requires_reflink
+    def test_a_dedupe_config_replays_silently(self):
+        """No false positive on the healthy setup."""
+        self.dm("-rd", self._tree())
+        self.assertDmOk()
+        self.dm()
+        self.assertDmOk()
+        self.assertNotIn(WARNING, self.out,
+                         "warned about a config that does deduplicate")
+
+    def test_an_explicit_scan_only_run_does_not_warn(self):
+        """Only a replay is silent about its own options; a command line is not.
+
+        Someone who types `oans -r <path>` can see there is no -d. Warning
+        there would fire on every ordinary preview run.
+        """
+        self.dm("-r", self._tree())
+        self.assertNotIn(WARNING, self.out)
+
+    def test_json_exposes_the_configured_mode(self):
+        """A dashboard should be able to spot the read-only job."""
+        self.dm("-r", self._tree())
+        metrics = json.loads(self.dm("--json"))
+        self.assertIs(False, metrics["scan_configured_dedupe"])
+
+    @requires_reflink
+    def test_json_reports_a_dedupe_config_as_such(self):
+        self.dm("-rd", self._tree())
+        metrics = json.loads(self.dm("--json"))
+        self.assertIs(True, metrics["scan_configured_dedupe"])
+
+    @requires_reflink
+    def test_the_suggested_command_actually_fixes_it(self):
+        """End to end: follow the advice, and the warning stops."""
+        tree = self._tree()
+        self.dm("-r", tree)
+        self.dm()
+        self.assertIn(WARNING, self.out)
+
+        # What the warning tells the user to run.
+        self.dm("-rd", tree)
+        self.assertDmOk()
+
+        self.dm()
+        self.assertNotIn(WARNING, self.out,
+                         "following the suggested command did not fix it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #149.

A `oans@.timer` job can run every week forever, exit 0 every time, and never deduplicate anything — because the run that seeded its hashfile was missing `-d`. The replay mechanism is working as designed; the setup flow is what leads users into it, and the result is indistinguishable from a healthy job.

## After

```console
$ oans -r  --hashfile=/var/cache/oans/media.hash /srv/media   # seeded without -d
$ oans --hashfile=/var/cache/oans/media.hash                  # what the timer runs
WARNING: the stored configuration for /var/cache/oans/media.hash has no -d, so this run will hash but not deduplicate.
         Re-run once with -d and the paths to update it:
           oans -rd --hashfile=/var/cache/oans/media.hash /srv/media
```

The command is built from the stored config — including whether `-r` was set and the stored roots — because the whole point of a replay is that the user no longer remembers the arguments. There's a test that follows the advice end to end and checks the warning stops.

## Scope decisions

- **On stderr**, so `-q` — what the shipped unit runs — still shows it.
- **Replay path only.** Someone typing `oans -r <path>` can see there's no `-d`; warning there would fire on every ordinary preview run.
- **A warning, not a refusal**, per the issue: a hash-only scheduled job is a legitimate setup (keeping a hashfile warm so a later `-d` run is fast), and failing it would break working configurations.
- **Driven off `opt_run_dedupe`, not "N runs with 0 reclaimed"** — the latter is also what a correctly-working job on a clean tree looks like, so it would cry wolf.

One thing to weigh: a *deliberate* hash-only timer now gets this warning every run. I think that's right — it documents in the journal that the job doesn't dedupe — but if it turns out to be noise, a suppression flag is an easy follow-up.

## Also

`--json` gains `scan_configured_dedupe`, so a dashboard can tell a read-only job from one that simply found nothing (both report `0 B` forever). The issue suggested this as a follow-on to #145, which has since landed.

Docs, since this is a footgun the guides themselves lead into: `docs/nas-quickstart.md` and `systemd/README.md` now state the seeding run's `-d` is load-bearing, `systemd/oans@.service` gains a comment, and the man page notes it under both `--hashfile`'s replay contract and `--json`.

## Testing

- New `tests/integration/test_replay_no_dedupe.py` — 8 cases: the warning fires on a scan-only replay, names the hashfile and stored path in a runnable command, survives `-q`, stays silent for a `-d` config and for an explicit command-line preview, both `--json` values, and the suggested command actually fixes it.
- `scripts/verify.sh` passes: build clean, lint, 181 tests, valgrind smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)