### PR TITLE
doc: describe how symlinks are handled

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -92,6 +92,18 @@ The non\-option arguments are the \f[I]files\f[R] and
 the list from standard input, one path per line.
 Naming a directory scans the regular files directly inside it; add
 \f[B]\-r\f[R] to recurse.
+.PP
+\f[B]Symlinks.\f[R] A path given as an argument is resolved, so naming a
+symlink to a directory scans what it points at, and the files are
+recorded under their canonical paths.
+Symlinks \f[I]encountered during\f[R] the walk are not followed: only
+regular files and directories are descended into.
+This keeps a run\(cqs scope equal to what was named on the command line
+\(em one symlink pointing outside the tree would otherwise silently
+enlarge a job that deduplicates data.
+To include such a target, name it as an additional argument; scanning a
+directory and a symlink to it in the same run is safe, as both resolve
+to the same canonical path and the file is recorded once.
 .SS Operation
 .TP
 \f[B]\-d\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -75,6 +75,16 @@ The non-option arguments are the *files* and *directories* to scan, or a single
 hyphen (**-**) to read the list from standard input, one path per line. Naming a
 directory scans the regular files directly inside it; add **-r** to recurse.
 
+**Symlinks.** A path given as an argument is resolved, so naming a symlink to a
+directory scans what it points at, and the files are recorded under their
+canonical paths. Symlinks *encountered during* the walk are not followed: only
+regular files and directories are descended into. This keeps a run's scope equal
+to what was named on the command line — one symlink pointing outside the tree
+would otherwise silently enlarge a job that deduplicates data. To include such a
+target, name it as an additional argument; scanning a directory and a symlink to
+it in the same run is safe, as both resolve to the same canonical path and the
+file is recorded once.
+
 ## Operation
 
 **-d**


### PR DESCRIPTION
Closes #126, as documentation rather than a feature — the investigation showed the gap is much narrower than the issue assumes.

## What I measured on current master

**A symlink named as a root is already followed.** `scan_file()` resolves it with `realpath()`:

```console
$ oans -rq --hashfile=h.db $T/rootlink        # rootlink -> $T/outside/sub
files=2
  $T/outside/sub/a.bin
  $T/outside/sub/b.bin                        # canonical paths, as the issue wants
```

**The same directory reached two ways is already collapsed.** Scanning a directory *and* a symlink to it in one run records 2 files, not 4 — so the "multiple records with the same canonical path" concern in the issue is already handled by realpath + `UNIQUE(path_hash)` + `seen_inodes`.

**Only symlinks met mid-walk are skipped**, and the workaround is one extra argument: name the target as a root.

**The PATH_MAX motivation doesn't hold.** `scan_file()` resolves the root into a `char[PATH_MAX]`, so a short symlink to a deep target still fails — making that work needs the hand-rolled canonicalizer the issue itself flags, which is a far bigger job than the symlink walk, and the man page already recommends bind-mounting for it.

## Why not implement the walk half anyway

The blocker isn't cycles — a visited `(dev,ino)` set handles those, though it would add shared mutable state to the walker threads that CLAUDE.md warns against. It's **scope escape on a tool that modifies data**: one symlink to `/` or to a backup mount silently enlarges a job the user thought they had bounded by naming its roots, under `-d`. Naming the target explicitly costs one argument and can't surprise anyone.

So this adds a short **Symlinks** paragraph to the man page's OPTIONS preamble covering both halves and pointing at the workaround. No behaviour change, no new flag.

`scripts/verify.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)