### PR TITLE
dedupe: a read-only subvolume can only ever be the source

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -391,10 +391,14 @@ subvolume is only ever used as a dedupe \f[B]source\f[R], never as a
 destination: \f[CR]FIDEDUPERANGE\f[R] rewrites the destination and
 nothing else, so writing to one would modify a snapshot that is meant to
 be immutable.
-A group containing such a file therefore takes it as the target and
-points the writable copies at it, which is the direction that reclaims
-space; any further read\-only members are skipped and counted on the
-\f[I]Read\-only\f[R] summary line.
+.PP
+Where a whole\-file group has such a member it is preferred as the
+target, so the writable copies are pointed at it and the space is
+reclaimed.
+Everywhere else \(em extent\-level groups, and groups already anchored
+to a target by an earlier pass \(em a read\-only member is simply
+skipped rather than written, and counted on the \f[I]Read\-only\f[R]
+summary line.
 .RE
 .TP
 \f[B]\-q\f[R], \f[B]\-\-quiet\f[R]

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -385,6 +385,16 @@ directory name, so it never fires on a writable directory that merely
 happens to be called \f[CR].snapshots\f[R].
 The number skipped is reported in the run summary and in
 \f[B]\-\-json\f[R]; the choice is stored in the hashfile and replayed.
+.PP
+With \f[B]\-\-no\-skip\-readonly\-subvols\f[R], a file in a read\-only
+subvolume is only ever used as a dedupe \f[B]source\f[R], never as a
+destination: \f[CR]FIDEDUPERANGE\f[R] rewrites the destination and
+nothing else, so writing to one would modify a snapshot that is meant to
+be immutable.
+A group containing such a file therefore takes it as the target and
+points the writable copies at it, which is the direction that reclaims
+space; any further read\-only members are skipped and counted on the
+\f[I]Read\-only\f[R] summary line.
 .RE
 .TP
 \f[B]\-q\f[R], \f[B]\-\-quiet\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -321,10 +321,13 @@ file is recorded once.
     With **\--no-skip-readonly-subvols**, a file in a read-only subvolume is
     only ever used as a dedupe **source**, never as a destination:
     `FIDEDUPERANGE` rewrites the destination and nothing else, so writing to one
-    would modify a snapshot that is meant to be immutable. A group containing
-    such a file therefore takes it as the target and points the writable copies
-    at it, which is the direction that reclaims space; any further read-only
-    members are skipped and counted on the *Read-only* summary line.
+    would modify a snapshot that is meant to be immutable.
+
+    Where a whole-file group has such a member it is preferred as the target, so
+    the writable copies are pointed at it and the space is reclaimed. Everywhere
+    else — extent-level groups, and groups already anchored to a target by an
+    earlier pass — a read-only member is simply skipped rather than written, and
+    counted on the *Read-only* summary line.
 
 <!-- -->
 

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -318,6 +318,14 @@ file is recorded once.
     called `.snapshots`. The number skipped is reported in the run summary and
     in **\--json**; the choice is stored in the hashfile and replayed.
 
+    With **\--no-skip-readonly-subvols**, a file in a read-only subvolume is
+    only ever used as a dedupe **source**, never as a destination:
+    `FIDEDUPERANGE` rewrites the destination and nothing else, so writing to one
+    would modify a snapshot that is meant to be immutable. A group containing
+    such a file therefore takes it as the target and points the writable copies
+    at it, which is the direction that reclaims space; any further read-only
+    members are skipped and counted on the *Read-only* summary line.
+
 <!-- -->
 
 **-q**, **\--quiet**

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -712,39 +712,41 @@ static void verified_dev_free(void)
  * .snapshots, and -- being an implicit default -- would never reach
  * scan_excludes, so a replay's scope would depend on the binary version.
  */
-struct ro_subvol_ent {
-	bool known;
-	bool rdonly;
-};
-static GHashTable *ro_subvols;		/* dev_t -> struct ro_subvol_ent * */
+static bool skipping_readonly_subvols(void);
+
+static GHashTable *ro_subvols;		/* dev_t -> (gpointer)(bool) read-only */
 static GMutex ro_subvol_lock;
 
-static void ro_subvol_free(void)
+/*
+ * Deliberately NOT called from filescan_free(): the dedupe phase queries this
+ * cache long after the walk is over (see filescan_fd_is_readonly_subvol), so
+ * freeing it there would empty it exactly when the second consumer starts and
+ * silently re-probe every device.
+ */
+void filescan_free_late(void)
 {
 	g_clear_pointer(&ro_subvols, g_hash_table_destroy);
 }
 
 /*
- * Core lookup: is `fd`'s subvolume read-only? `fd` must already be open on a
- * file or directory inside it. Sets *first when this call is what resolved the
- * device, so a caller that wants to count discoveries can do so exactly once.
+ * Core lookup: is `fd`'s subvolume read-only? `fd` must be open on a file or
+ * directory inside it, and `dev` is its device, used as the cache key.
+ *
+ * count_skip belongs to the walk: it reports "N read-only subvolumes skipped",
+ * which must be counted once per subvolume rather than once per query, so only
+ * the call that actually resolves the device counts. The dedupe phase asks the
+ * same question about the same devices and must not inflate that number.
  */
-static bool ro_subvol_lookup(int fd, dev_t dev, bool *first)
+static bool ro_subvol_lookup(int fd, dev_t dev, bool count_skip)
 {
-	struct ro_subvol_ent *ent;
+	gpointer key = GSIZE_TO_POINTER((gsize)dev), val;
 	bool rdonly = false;
 
-	*first = false;
-
 	g_mutex_lock(&ro_subvol_lock);
-	if (!ro_subvols)
-		ro_subvols = g_hash_table_new_full(g_direct_hash, g_direct_equal,
-						   NULL, g_free);
-	ent = g_hash_table_lookup(ro_subvols, GSIZE_TO_POINTER((gsize)dev));
-	if (ent && ent->known) {
-		rdonly = ent->rdonly;
+	if (ro_subvols &&
+	    g_hash_table_lookup_extended(ro_subvols, key, NULL, &val)) {
 		g_mutex_unlock(&ro_subvol_lock);
-		return rdonly;
+		return GPOINTER_TO_INT(val);
 	}
 	g_mutex_unlock(&ro_subvol_lock);
 
@@ -757,52 +759,55 @@ static bool ro_subvol_lookup(int fd, dev_t dev, bool *first)
 		rdonly = false;	/* not a subvolume, or an old kernel */
 
 	g_mutex_lock(&ro_subvol_lock);
-	ent = g_hash_table_lookup(ro_subvols, GSIZE_TO_POINTER((gsize)dev));
-	if (!ent) {
-		ent = g_malloc0(sizeof(*ent));
-		g_hash_table_insert(ro_subvols, GSIZE_TO_POINTER((gsize)dev), ent);
+	if (!ro_subvols)
+		ro_subvols = g_hash_table_new(g_direct_hash, g_direct_equal);
+	if (g_hash_table_lookup_extended(ro_subvols, key, NULL, &val)) {
+		rdonly = GPOINTER_TO_INT(val);	/* lost the race; agree */
+	} else {
+		g_hash_table_insert(ro_subvols, key,
+				    GINT_TO_POINTER((int)rdonly));
+		if (rdonly && count_skip)
+			filescan_count_skip(SCAN_SKIP_READONLY_SUBVOL);
 	}
-	if (!ent->known) {
-		ent->known = true;
-		ent->rdonly = rdonly;
-		*first = true;
-	}
-	rdonly = ent->rdonly;
 	g_mutex_unlock(&ro_subvol_lock);
 
 	return rdonly;
 }
 
-bool filescan_fd_is_readonly_subvol(int fd, dev_t dev)
+bool filescan_fd_is_readonly_subvol(int fd)
 {
-	bool first;
+	struct stat st;
 
-	return ro_subvol_lookup(fd, dev, &first);
+	/*
+	 * On the default path the walk keeps read-only subvolumes out of the
+	 * hashfile entirely, so no group can contain one and the answer is
+	 * false by construction. Bail before the fstat so the common case pays
+	 * nothing for a feature only --no-skip-readonly-subvols can reach.
+	 */
+	if (!locked_fs.is_btrfs || skipping_readonly_subvols())
+		return false;
+
+	if (fstat(fd, &st))
+		return false;
+
+	return ro_subvol_lookup(fd, st.st_dev, false);
 }
 
 /*
  * True when `path` (on device `dev`) lives in a read-only btrfs subvolume.
  * One ioctl per device; the answer is cached for every later path on it, and
- * shared with the dedupe phase (see filescan_fd_is_readonly_subvol).
+ * for the dedupe phase (see filescan_fd_is_readonly_subvol).
  */
 static bool dev_is_readonly_subvol(dev_t dev, const char *path)
 {
-	bool rdonly, first;
+	bool rdonly;
 	int fd;
 
 	fd = longpath_open(path, O_RDONLY);
 	if (fd == -1)
 		return false;	/* unreadable is someone else's error to report */
-	rdonly = ro_subvol_lookup(fd, dev, &first);
+	rdonly = ro_subvol_lookup(fd, dev, true);
 	close(fd);
-
-	/*
-	 * Count subvolumes, not files: the skip happens at the subvolume's root
-	 * directory and never descends, so this fires once per snapshot --
-	 * the number the summary should report.
-	 */
-	if (rdonly && first)
-		filescan_count_skip(SCAN_SKIP_READONLY_SUBVOL);
 
 	return rdonly;
 }
@@ -2899,7 +2904,6 @@ void filescan_free(void)
 	scan_writer_close();
 	subvol_cache_free();
 	verified_dev_free();
-	ro_subvol_free();
 	seen_inodes_free();
 
 	g_clear_pointer(&excludes, glob_set_free);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -725,14 +725,16 @@ static void ro_subvol_free(void)
 }
 
 /*
- * True when `path` (on device `dev`) lives in a read-only btrfs subvolume.
- * One ioctl per device; the answer is cached for every later path on it.
+ * Core lookup: is `fd`'s subvolume read-only? `fd` must already be open on a
+ * file or directory inside it. Sets *first when this call is what resolved the
+ * device, so a caller that wants to count discoveries can do so exactly once.
  */
-static bool dev_is_readonly_subvol(dev_t dev, const char *path)
+static bool ro_subvol_lookup(int fd, dev_t dev, bool *first)
 {
 	struct ro_subvol_ent *ent;
 	bool rdonly = false;
-	int fd;
+
+	*first = false;
 
 	g_mutex_lock(&ro_subvol_lock);
 	if (!ro_subvols)
@@ -748,15 +750,11 @@ static bool dev_is_readonly_subvol(dev_t dev, const char *path)
 
 	/*
 	 * Probe outside the lock: the ioctl is the slow part, and a duplicate
-	 * probe from a second walker is harmless (same answer, idempotent
+	 * probe from a second thread is harmless (same answer, idempotent
 	 * insert) where holding the lock across it would serialise the walk.
 	 */
-	fd = longpath_open(path, O_RDONLY);
-	if (fd == -1)
-		return false;	/* unreadable is someone else's error to report */
 	if (btrfs_subvol_is_readonly(fd, &rdonly))
-		rdonly = false;	/* not a subvolume, or an old kernel: scan it */
-	close(fd);
+		rdonly = false;	/* not a subvolume, or an old kernel */
 
 	g_mutex_lock(&ro_subvol_lock);
 	ent = g_hash_table_lookup(ro_subvols, GSIZE_TO_POINTER((gsize)dev));
@@ -767,16 +765,44 @@ static bool dev_is_readonly_subvol(dev_t dev, const char *path)
 	if (!ent->known) {
 		ent->known = true;
 		ent->rdonly = rdonly;
-		/*
-		 * Count subvolumes, not files: the skip happens at the
-		 * subvolume's root directory and never descends, so this fires
-		 * once per snapshot -- the number the summary should report.
-		 */
-		if (rdonly)
-			filescan_count_skip(SCAN_SKIP_READONLY_SUBVOL);
+		*first = true;
 	}
 	rdonly = ent->rdonly;
 	g_mutex_unlock(&ro_subvol_lock);
+
+	return rdonly;
+}
+
+bool filescan_fd_is_readonly_subvol(int fd, dev_t dev)
+{
+	bool first;
+
+	return ro_subvol_lookup(fd, dev, &first);
+}
+
+/*
+ * True when `path` (on device `dev`) lives in a read-only btrfs subvolume.
+ * One ioctl per device; the answer is cached for every later path on it, and
+ * shared with the dedupe phase (see filescan_fd_is_readonly_subvol).
+ */
+static bool dev_is_readonly_subvol(dev_t dev, const char *path)
+{
+	bool rdonly, first;
+	int fd;
+
+	fd = longpath_open(path, O_RDONLY);
+	if (fd == -1)
+		return false;	/* unreadable is someone else's error to report */
+	rdonly = ro_subvol_lookup(fd, dev, &first);
+	close(fd);
+
+	/*
+	 * Count subvolumes, not files: the skip happens at the subvolume's root
+	 * directory and never descends, so this fires once per snapshot --
+	 * the number the summary should report.
+	 */
+	if (rdonly && first)
+		filescan_count_skip(SCAN_SKIP_READONLY_SUBVOL);
 
 	return rdonly;
 }

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -99,15 +99,24 @@ void filescan_count_errno_skip(int err);
 void filescan_get_skips(uint64_t out[SCAN_SKIP__COUNT]);
 
 /*
- * True when the already-open `fd` (on device `dev`) lives in a read-only btrfs
- * subvolume. One ioctl per device, cached and shared with the walk's own
- * lookups. False for anything that is not a btrfs subvolume.
+ * True when the already-open `fd` lives in a read-only btrfs subvolume. One
+ * ioctl per device, cached and genuinely shared with the walk's own lookups.
+ * False for anything that is not a btrfs subvolume, and false by construction
+ * whenever the walk is skipping read-only subvolumes (the default), since then
+ * none can be in the hashfile to ask about.
  *
  * Used by the dedupe phase, which must never make such a file a dedupe
  * *destination*: FIDEDUPERANGE only ever rewrites the destination, so a
  * read-only member can legally be the source and nothing else (#171).
  */
-bool filescan_fd_is_readonly_subvol(int fd, dev_t dev);
+bool filescan_fd_is_readonly_subvol(int fd);
+
+/*
+ * Release scan state that the dedupe phase still needs, so it cannot be freed
+ * by filescan_free() while a second consumer is about to read it. Call once,
+ * after the dedupe phase.
+ */
+void filescan_free_late(void);
 
 /* For dbfile.c */
 struct block_csum {

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -98,6 +98,17 @@ void filescan_count_errno_skip(int err);
  */
 void filescan_get_skips(uint64_t out[SCAN_SKIP__COUNT]);
 
+/*
+ * True when the already-open `fd` (on device `dev`) lives in a read-only btrfs
+ * subvolume. One ioctl per device, cached and shared with the walk's own
+ * lookups. False for anything that is not a btrfs subvolume.
+ *
+ * Used by the dedupe phase, which must never make such a file a dedupe
+ * *destination*: FIDEDUPERANGE only ever rewrites the destination, so a
+ * read-only member can legally be the source and nothing else (#171).
+ */
+bool filescan_fd_is_readonly_subvol(int fd, dev_t dev);
+
 /* For dbfile.c */
 struct block_csum {
 	uint64_t	loff;

--- a/src/oans.c
+++ b/src/oans.c
@@ -1992,6 +1992,8 @@ int main(int argc, char **argv)
 out:
 	scan_config_free(&replay);
 	free_all_filerecs();
+	/* Outlives filescan_free(): the dedupe phase queries it. */
+	filescan_free_late();
 
 #ifdef DEBUG_BUILD
 	print_mem_stats();

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -401,34 +401,31 @@ static void pick_dedupe_target(struct dupe_extents *dext)
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
 		unsigned int n;
-		bool rdonly = false;
-		struct stat st;
+		bool rdonly;
 
 		if (filerec_open(extent->e_file, true))
 			continue;
 		/* Count-only fiemap: we need the extent count, not the map. */
 		n = fiemap_count_extents(extent->e_file->fd, extent->e_loff,
 					 extent_len(extent));
-		if (fstat(extent->e_file->fd, &st) == 0)
-			rdonly = filescan_fd_is_readonly_subvol(
-					extent->e_file->fd, st.st_dev);
+		/* n == 0 means the fiemap failed; ignore that candidate before
+		 * paying for anything else. */
+		if (!n) {
+			filerec_close(extent->e_file);
+			continue;
+		}
+		rdonly = filescan_fd_is_readonly_subvol(extent->e_file->fd);
 		filerec_close(extent->e_file);
 
-		/* n == 0 means the fiemap failed; ignore that candidate. */
-		if (!n)
-			continue;
-
 		/*
-		 * Read-only-ness outranks fragmentation (#171). A member in a
+		 * Rank on (read-only, then fewest extents). A member in a
 		 * read-only subvolume is the only one that can legally be the
-		 * source, so making it the target is what lets the group
-		 * deduplicate at all; every other member would be refused as a
-		 * destination below. Among equals, keep preferring the
-		 * least-fragmented copy so the others do not inherit a bad
-		 * on-disk layout.
+		 * source, so electing it is what lets the group deduplicate at
+		 * all; every other member would be refused as a destination
+		 * below. Among equals the least-fragmented copy still wins, so
+		 * groups without one behave exactly as before.
 		 */
-		if (best == NULL ||
-		    (rdonly && !best_rdonly) ||
+		if (best == NULL || rdonly > best_rdonly ||
 		    (rdonly == best_rdonly && n < best_extents)) {
 			best = extent;
 			best_extents = n;
@@ -529,11 +526,10 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		add_shared_extents(dext, &shared_prev);
 
 	/*
-	 * Prefer the least-fragmented copy as the dedupe target so the others
-	 * don't inherit a bad on-disk layout. Only for whole files, and only
-	 * when the group has no anchor from an earlier pass - an anchored group
-	 * must keep its anchor (loaded first) as target so every pass converges
-	 * the copies onto the same physical extent.
+	 * Only for whole files, and only when the group has no anchor from an
+	 * earlier pass - an anchored group must keep its anchor (loaded first)
+	 * as target so every pass converges the copies onto the same physical
+	 * extent. See pick_dedupe_target() for how the target is chosen.
 	 */
 	if (whole_file_dedup && !dext->de_anchored)
 		pick_dedupe_target(dext);
@@ -543,8 +539,6 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	slot_show_group(slot, dext);
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
-		dev_t member_dev = 0;	/* 0 = fstat failed, see below */
-
 		if (list_is_last(&extent->e_list, &dext->de_extents))
 			last = 1;
 
@@ -598,10 +592,7 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		{
 			struct stat st;
 
-			if (fstat(extent->e_file->fd, &st) == 0)
-				member_dev = st.st_dev;
-
-			if (member_dev &&
+			if (fstat(extent->e_file->fd, &st) == 0 &&
 			    (whole_file_dedup ?
 			     (uint64_t)st.st_size != len :
 			     (uint64_t)st.st_size + 4095 < extent->e_loff + len)) {
@@ -663,23 +654,12 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		}
 
 		/*
-		 * Never rewrite a file in a read-only subvolume (#171).
-		 *
-		 * FIDEDUPERANGE only ever modifies the destination, so a member
-		 * of a read-only subvolume can legally be the source and
-		 * nothing else. Whether the kernel enforces that is
-		 * version-dependent: some return EROFS, others accept it and
-		 * rewrite the extent mapping of a snapshot that is supposed to
-		 * be immutable. Refuse here rather than rely on the kernel to
-		 * refuse for us.
-		 *
-		 * The target is exempt: being the source is exactly what a
-		 * read-only member is for, and pick_dedupe_target() prefers one
-		 * for that reason.
+		 * A read-only member can only ever be the source; see
+		 * dedupe_dest_readonly. The target is exempt - being the source
+		 * is what pick_dedupe_target() elects it for.
 		 */
-		if (extent != tgt_extent && member_dev &&
-		    filescan_fd_is_readonly_subvol(extent->e_file->fd,
-						   member_dev)) {
+		if (extent != tgt_extent &&
+		    filescan_fd_is_readonly_subvol(extent->e_file->fd)) {
 			atomic_fetch_add(&dedupe_dest_readonly, 1);
 			group_tick(gp, len);	/* skipped, but credit its work */
 			vprintf("[%p] %s is in a read-only subvolume; it can "

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -43,6 +43,7 @@
 #include "dbfile.h"
 #include "fiemap.h"
 #include "find_dupes.h"
+#include "file_scan.h"
 #include "tsan.h"
 
 #include "run_dedupe.h"
@@ -192,6 +193,15 @@ static _Atomic uint64_t dedupe_dest_errors;
 /* Destinations skipped because they already shared all storage with the
  * target (deduping them would have been a no-op). See fiemap_ranges_shared(). */
 static _Atomic uint64_t dedupe_dest_already_shared;
+/*
+ * Destinations skipped because they live in a read-only subvolume (#171).
+ * FIDEDUPERANGE only ever rewrites the *destination*, so such a file can
+ * legally be the source and nothing else. Whether the kernel enforces that is
+ * version-dependent - some return EROFS, others accept it and rewrite a
+ * snapshot that is supposed to be immutable - so oans refuses on its own
+ * rather than relying on the kernel to refuse for it.
+ */
+static _Atomic uint64_t dedupe_dest_readonly;
 
 static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 				   uint64_t *kern_bytes)
@@ -372,6 +382,9 @@ static void clean_deduped(struct dupe_extents **ret_dext,
 }
 
 /*
+ * Choose which member of the group becomes the dedupe target, i.e. the source
+ * the kernel reads and every other member is pointed at.
+ *
  * Deduping every copy against a fragmented target makes each copy inherit that
  * fragmentation: one extent-tree op per target extent per copy, and all copies
  * left fragmented on disk (measured ~linear in target extents once past a fixed
@@ -380,25 +393,46 @@ static void clean_deduped(struct dupe_extents **ret_dext,
  * it to the front of the list; the loop below always dedupes against the first
  * entry. Extent-dedupe members are single extents, so this is skipped there.
  */
-static void pick_least_fragmented_target(struct dupe_extents *dext)
+static void pick_dedupe_target(struct dupe_extents *dext)
 {
 	struct extent *extent, *best = NULL;
 	unsigned int best_extents = 0;
+	bool best_rdonly = false;
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
 		unsigned int n;
+		bool rdonly = false;
+		struct stat st;
 
 		if (filerec_open(extent->e_file, true))
 			continue;
 		/* Count-only fiemap: we need the extent count, not the map. */
 		n = fiemap_count_extents(extent->e_file->fd, extent->e_loff,
 					 extent_len(extent));
+		if (fstat(extent->e_file->fd, &st) == 0)
+			rdonly = filescan_fd_is_readonly_subvol(
+					extent->e_file->fd, st.st_dev);
 		filerec_close(extent->e_file);
 
 		/* n == 0 means the fiemap failed; ignore that candidate. */
-		if (n && (best == NULL || n < best_extents)) {
+		if (!n)
+			continue;
+
+		/*
+		 * Read-only-ness outranks fragmentation (#171). A member in a
+		 * read-only subvolume is the only one that can legally be the
+		 * source, so making it the target is what lets the group
+		 * deduplicate at all; every other member would be refused as a
+		 * destination below. Among equals, keep preferring the
+		 * least-fragmented copy so the others do not inherit a bad
+		 * on-disk layout.
+		 */
+		if (best == NULL ||
+		    (rdonly && !best_rdonly) ||
+		    (rdonly == best_rdonly && n < best_extents)) {
 			best = extent;
 			best_extents = n;
+			best_rdonly = rdonly;
 		}
 	}
 
@@ -502,13 +536,15 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	 * the copies onto the same physical extent.
 	 */
 	if (whole_file_dedup && !dext->de_anchored)
-		pick_least_fragmented_target(dext);
+		pick_dedupe_target(dext);
 
 	/* clean_deduped/target selection may have changed the group; show the
 	 * real target and remaining work on this thread's status line. */
 	slot_show_group(slot, dext);
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
+		dev_t member_dev = 0;	/* 0 = fstat failed, see below */
+
 		if (list_is_last(&extent->e_list, &dext->de_extents))
 			last = 1;
 
@@ -562,7 +598,10 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		{
 			struct stat st;
 
-			if (fstat(extent->e_file->fd, &st) == 0 &&
+			if (fstat(extent->e_file->fd, &st) == 0)
+				member_dev = st.st_dev;
+
+			if (member_dev &&
 			    (whole_file_dedup ?
 			     (uint64_t)st.st_size != len :
 			     (uint64_t)st.st_size + 4095 < extent->e_loff + len)) {
@@ -621,6 +660,34 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			 */
 			if (tgt_extent == extent)
 				continue;
+		}
+
+		/*
+		 * Never rewrite a file in a read-only subvolume (#171).
+		 *
+		 * FIDEDUPERANGE only ever modifies the destination, so a member
+		 * of a read-only subvolume can legally be the source and
+		 * nothing else. Whether the kernel enforces that is
+		 * version-dependent: some return EROFS, others accept it and
+		 * rewrite the extent mapping of a snapshot that is supposed to
+		 * be immutable. Refuse here rather than rely on the kernel to
+		 * refuse for us.
+		 *
+		 * The target is exempt: being the source is exactly what a
+		 * read-only member is for, and pick_dedupe_target() prefers one
+		 * for that reason.
+		 */
+		if (extent != tgt_extent && member_dev &&
+		    filescan_fd_is_readonly_subvol(extent->e_file->fd,
+						   member_dev)) {
+			atomic_fetch_add(&dedupe_dest_readonly, 1);
+			group_tick(gp, len);	/* skipped, but credit its work */
+			vprintf("[%p] %s is in a read-only subvolume; it can "
+				"only be a dedupe source, skipping.\n",
+				g_thread_self(), extent->e_file->filename);
+			if (ctxt && last)
+				goto run_dedupe;
+			continue;
 		}
 
 		/*
@@ -1265,6 +1332,11 @@ void dedupe_phase_end(void)
 			       "needed)\n", col_dim, col_reset,
 			       (uint64_t)dedupe_dest_already_shared,
 			       dedupe_dest_already_shared == 1 ? "" : "s");
+		if (dedupe_dest_readonly)
+			printf("  %sRead-only%s      %lu file%s skipped (can "
+			       "only be a dedupe source)\n", col_dim, col_reset,
+			       (uint64_t)dedupe_dest_readonly,
+			       dedupe_dest_readonly == 1 ? "" : "s");
 	}
 
 	/*

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -179,6 +179,12 @@ requires_btrfs = unittest.skipUnless(
     BTRFS, "test needs btrfs (copy-on-write fragmentation)")
 
 
+def btrfs_ok(*args):
+    """Run `btrfs <args>` quietly; True on success."""
+    return subprocess.run(["btrfs", *args], stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL).returncode == 0
+
+
 # --------------------------------------------------------------------------
 # Base test case
 # --------------------------------------------------------------------------
@@ -229,8 +235,12 @@ class DuperemoveTest(unittest.TestCase):
         self.hf = os.path.join(self.work, "hashfile.db")
         self.out = ""       # combined output of the last dm() call
         self.rc = 0         # its exit code
+        self._subvols = []  # created via subvol()/snapshot(), see tearDown
 
     def tearDown(self):
+        # Innermost first: a snapshot must go before the subvolume it lives in.
+        for path in reversed(self._subvols):
+            btrfs_ok("subvolume", "delete", path)
         shutil.rmtree(self.work, ignore_errors=True)
 
     # -- running oans ------------------------------------------------
@@ -432,3 +442,51 @@ class DuperemoveTest(unittest.TestCase):
         dst = self.path(rel_dst)
         os.link(self.path(rel_src), dst)
         return dst
+
+    # -- btrfs subvolumes --------------------------------------------------
+    #
+    # Subvolumes cannot be removed with rmtree (a read-only one refuses even
+    # to have its files unlinked), so anything created here is tracked and
+    # deleted with the ioctl in tearDown, innermost first.
+
+    def subvol(self, name):
+        """Create a btrfs subvolume under the scratch dir; skips if it can't."""
+        p = os.path.join(self.work, name)
+        if not btrfs_ok("subvolume", "create", p):
+            self.skipTest("cannot create a btrfs subvolume here")
+        self._subvols.append(p)
+        return p
+
+    def snapshot(self, src, name, readonly=True):
+        """Snapshot `src` to `name`; read-only by default."""
+        args = ["subvolume", "snapshot"] + (["-r"] if readonly else [])
+        dst = os.path.join(self.work, name)
+        self.assertTrue(btrfs_ok(*args, src, dst),
+                        f"could not snapshot {src} into {name}")
+        self._subvols.append(dst)
+        return dst
+
+    def fragment(self, relpath, content):
+        """Write content, then rewrite alternate 4K blocks in place.
+
+        btrfs is copy-on-write, so the rewrites land elsewhere and the file
+        ends up split across many physical extents. Needs btrfs; on xfs the
+        overwrite happens in place and the file stays contiguous.
+        """
+        p = relpath if os.path.isabs(relpath) else self.path(relpath)
+        with open(p, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        fd = os.open(p, os.O_WRONLY)
+        try:
+            for off in range(0, len(content), 8192):
+                os.pwrite(fd, content[off:off + 4096], off)
+                os.fsync(fd)
+        finally:
+            os.close(fd)
+        return p
+
+    def scanned_files(self):
+        """Set of every path recorded in the hashfile."""
+        return {r[0] for r in self.hf_query("select filename from files")}

--- a/tests/integration/test_least_fragmented_target.py
+++ b/tests/integration/test_least_fragmented_target.py
@@ -16,27 +16,10 @@ class LeastFragmentedTargetTest(DuperemoveTest):
     # Extent-layout sensitive: see DuperemoveTest.serial.
     serial = True
 
-    def _fragment(self, rel, content):
-        """Write content, then rewrite alternate 4K blocks in place (COW) so the
-        file ends up split across many physical extents."""
-        p = self.path(rel)
-        with open(p, "wb") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        fd = os.open(p, os.O_WRONLY)
-        try:
-            for off in range(0, len(content), 8192):
-                os.pwrite(fd, content[off:off + 4096], off)
-                os.fsync(fd)
-        finally:
-            os.close(fd)
-        return p
-
     def test_dedupe_prefers_contiguous_target(self):
         content = os.urandom(8 * MiB)
         # Several fragmented copies plus one clean, contiguous copy.
-        frags = [self._fragment(f"tree/frag{i}", content) for i in range(3)]
+        frags = [self.fragment(f"tree/frag{i}", content) for i in range(3)]
         contig = self.write("tree/contig", content)
         self.sync()
 

--- a/tests/integration/test_readonly_subvols.py
+++ b/tests/integration/test_readonly_subvols.py
@@ -15,39 +15,19 @@ never fires on a writable directory that merely happens to be called
 
 import json
 import os
-import subprocess
 import unittest
 
 from harness import DuperemoveTest, requires_btrfs
-
-
-def _btrfs(*args):
-    return subprocess.run(["btrfs", *args], stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL).returncode == 0
 
 
 @requires_btrfs
 class ReadonlySubvolTest(DuperemoveTest):
     def setUp(self):
         super().setUp()
-        self.live = os.path.join(self.work, "live")
-        if not _btrfs("subvolume", "create", self.live):
-            self.skipTest("cannot create a btrfs subvolume here")
-
-    def tearDown(self):
-        # Subvolumes must be deleted with the ioctl, not rmtree.
-        for name in ("snap1", "snap2", "live"):
-            _btrfs("subvolume", "delete", os.path.join(self.work, name))
-        super().tearDown()
+        self.live = self.subvol("live")
 
     def _snapshot(self, name, readonly=True):
-        args = ["subvolume", "snapshot"]
-        if readonly:
-            args.append("-r")
-        dst = os.path.join(self.work, name)
-        self.assertTrue(_btrfs(*args, self.live, dst),
-                        f"could not snapshot into {name}")
-        return dst
+        return self.snapshot(self.live, name, readonly=readonly)
 
     def _live_dups(self):
         """Two duplicate files inside the live subvolume."""

--- a/tests/integration/test_readonly_target.py
+++ b/tests/integration/test_readonly_target.py
@@ -18,17 +18,12 @@ read-only subvolumes out of the scan entirely.
 """
 
 import os
-import subprocess
 import unittest
 
 from harness import DuperemoveTest, phys_extents, requires_btrfs
 
 NO_SKIP = "--no-skip-readonly-subvols"
-
-
-def _btrfs(*args):
-    return subprocess.run(["btrfs", *args], stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL).returncode == 0
+SIZE = 1 << 21
 
 
 @requires_btrfs
@@ -37,48 +32,18 @@ class ReadonlyTargetTest(DuperemoveTest):
     # writeback against the rest of the suite.
     serial = True
 
-    def setUp(self):
-        super().setUp()
-        self.subvols = []
-
-    def tearDown(self):
-        for path in reversed(self.subvols):
-            _btrfs("subvolume", "delete", path)
-        super().tearDown()
-
-    def _subvol(self, name):
-        p = os.path.join(self.work, name)
-        if not _btrfs("subvolume", "create", p):
-            self.skipTest("cannot create a btrfs subvolume here")
-        self.subvols.append(p)
-        return p
-
-    def _snapshot(self, src, name):
-        dst = os.path.join(self.work, name)
-        self.assertTrue(_btrfs("subvolume", "snapshot", "-r", src, dst),
-                        f"could not snapshot into {name}")
-        self.subvols.append(dst)
-        return dst
-
-    def _independent_copy(self, src, rel):
-        """A byte-identical copy that shares no extents with src."""
-        dst = self.path(rel)
-        subprocess.run(["cp", "--reflink=never", src, dst], check=True)
-        return dst
-
-    def _fragment(self, path, content):
-        """Write content, then rewrite alternate 4K blocks so COW splits it."""
-        with open(path, "wb") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        fd = os.open(path, os.O_WRONLY)
-        try:
-            for off in range(0, len(content), 8192):
-                os.pwrite(fd, content[off:off + 4096], off)
-                os.fsync(fd)
-        finally:
-            os.close(fd)
+    def _snapshot_of(self, name, data, fragmented=False):
+        """A read-only snapshot holding f.bin with `data`."""
+        live = self.subvol(f"live_{name}")
+        f = os.path.join(live, "f.bin")
+        if fragmented:
+            self.fragment(f, data)
+        else:
+            with open(f, "wb") as fh:
+                fh.write(data)
+        self.sync()
+        snap = self.snapshot(live, name)
+        return os.path.join(snap, "f.bin")
 
     def test_writable_copy_is_deduped_onto_the_snapshot(self):
         """The whole point: the saving is taken, in the legal direction.
@@ -88,30 +53,26 @@ class ReadonlyTargetTest(DuperemoveTest):
         the target and rewritten the snapshot. Read-only-ness has to outrank
         fragmentation for this to come out right.
         """
-        live = self._subvol("live")
-        data = os.urandom(1 << 21)
-        self._fragment(os.path.join(live, "f.bin"), data)
-        self.sync()
-        snap = self._snapshot(live, "snap")
-        # A contiguous, independently-stored copy: fewer extents than the
-        # snapshot's, so fragmentation alone would elect it as target.
+        data = os.urandom(SIZE)
+        snap_file = self._snapshot_of("snap", data, fragmented=True)
+        # Contiguous and independently stored (a plain write never reflinks),
+        # so fragmentation alone would elect it as target.
         rw = self.write("rw/f.bin", data)
         self.sync()
 
-        snap_file = os.path.join(snap, "f.bin")
         snap_before = phys_extents(snap_file)
         self.assertGreater(len(snap_before), len(phys_extents(rw)),
                            "setup: the snapshot copy must be more fragmented")
-        self.assertNotEqual(snap_before, phys_extents(rw),
-                            "setup is wrong: the copies already share extents")
+        self.assertNotShared(snap_file, rw,
+                             "setup: the copies must not already share")
 
-        self.dm("-rd", NO_SKIP, snap, self.path("rw"))
+        self.dm("-rd", NO_SKIP, os.path.dirname(snap_file), self.path("rw"))
         self.assertDmOk()
 
         self.assertEqual(snap_before, phys_extents(snap_file),
                          "the read-only snapshot was rewritten")
-        self.assertTrue(phys_extents(rw) & snap_before,
-                        "the writable copy was not pointed at the snapshot")
+        self.assertShared(rw, snap_file,
+                          "the writable copy was not pointed at the snapshot")
 
     def test_a_readonly_member_is_never_a_destination(self):
         """With two read-only members, one cannot be the target -- skip it.
@@ -119,22 +80,16 @@ class ReadonlyTargetTest(DuperemoveTest):
         Before #171 the loser was handed to the kernel as a destination, which
         on a permissive kernel rewrites a snapshot's extent mapping.
         """
-        live_a = self._subvol("live_a")
-        live_b = self._subvol("live_b")
-        data = os.urandom(1 << 21)
-        for sv in (live_a, live_b):
-            with open(os.path.join(sv, "f.bin"), "wb") as f:
-                f.write(data)
-        self.sync()
-        snap_a = self._snapshot(live_a, "snap_a")
-        snap_b = self._snapshot(live_b, "snap_b")
-        rw = self._independent_copy(os.path.join(snap_a, "f.bin"), "rw/f.bin")
+        data = os.urandom(SIZE)
+        a_file = self._snapshot_of("snap_a", data)
+        b_file = self._snapshot_of("snap_b", data)
+        rw = self.write("rw/f.bin", data)
         self.sync()
 
-        a_file, b_file = os.path.join(snap_a, "f.bin"), os.path.join(snap_b, "f.bin")
         a_before, b_before = phys_extents(a_file), phys_extents(b_file)
 
-        self.dm("-rd", NO_SKIP, snap_a, snap_b, self.path("rw"))
+        self.dm("-rd", NO_SKIP, os.path.dirname(a_file),
+                os.path.dirname(b_file), self.path("rw"))
         self.assertDmOk()
 
         self.assertEqual(a_before, phys_extents(a_file),
@@ -143,43 +98,35 @@ class ReadonlyTargetTest(DuperemoveTest):
                          "snapshot B was rewritten -- a read-only member was "
                          "used as a dedupe destination")
         # The writable copy still got deduped onto whichever snapshot won.
-        self.assertTrue(phys_extents(rw) in (a_before, b_before),
+        self.assertTrue(phys_extents(rw) & (a_before | b_before),
                         "the writable copy was not deduped at all")
 
     def test_the_skip_is_reported(self):
         """Silently doing less is the failure mode #145/#147/#156 exist to stop."""
-        live_a = self._subvol("live_a")
-        live_b = self._subvol("live_b")
-        data = os.urandom(1 << 21)
-        for sv in (live_a, live_b):
-            with open(os.path.join(sv, "f.bin"), "wb") as f:
-                f.write(data)
-        self.sync()
-        snap_a = self._snapshot(live_a, "snap_a")
-        snap_b = self._snapshot(live_b, "snap_b")
+        data = os.urandom(SIZE)
+        a_file = self._snapshot_of("snap_a", data)
+        b_file = self._snapshot_of("snap_b", data)
         self.sync()
 
-        self.dm("-rd", NO_SKIP, snap_a, snap_b, quiet=False)
+        self.dm("-rd", NO_SKIP, os.path.dirname(a_file),
+                os.path.dirname(b_file), quiet=False)
         self.assertDmOk()
         self.assertIn("Read-only", self.out,
                       "a skipped read-only destination was not reported")
 
     def test_default_still_keeps_snapshots_out_of_the_scan(self):
         """#156's behaviour is unchanged; this only affects the opt-in path."""
-        live = self._subvol("live")
         data = os.urandom(1 << 20)
-        with open(os.path.join(live, "f.bin"), "wb") as f:
-            f.write(data)
-        self.sync()
-        snap = self._snapshot(live, "snap")
-        self._independent_copy(os.path.join(snap, "f.bin"), "rw/f.bin")
+        snap_file = self._snapshot_of("snap", data)
+        self.write("rw/f.bin", data)
         self.sync()
 
-        self.dm("-rd", snap, self.path("rw"))
+        snap_dir = os.path.dirname(snap_file)
+        self.dm("-rd", snap_dir, self.path("rw"))
         self.assertDmOk()
-        scanned = {r[0] for r in self.hf_query("select filename from files")}
-        self.assertFalse(any(s.startswith(snap) for s in scanned),
-                         "the default scanned into a read-only subvolume")
+        self.assertFalse(
+            any(p.startswith(snap_dir) for p in self.scanned_files()),
+            "the default scanned into a read-only subvolume")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_readonly_target.py
+++ b/tests/integration/test_readonly_target.py
@@ -1,0 +1,186 @@
+"""A read-only subvolume can only ever be a dedupe *source* (#171).
+
+FIDEDUPERANGE rewrites the destination and only the destination, so a member of
+a read-only subvolume can legally be the group's target (the source the kernel
+reads) and nothing else. Two things follow, and both are tested here:
+
+  * a read-only member must never be used as a destination, and
+  * when a group has one, it should be *preferred* as the target -- otherwise
+    the group either fails or, on kernels that do not enforce this, silently
+    rewrites the extent mapping of a snapshot that is supposed to be immutable.
+
+Whether the kernel refuses is version-dependent: a user on r/btrfs reports
+EROFS, while on 7.1.3 the ioctl accepts a read-only destination and rewrites it.
+oans therefore refuses on its own rather than relying on the kernel to refuse.
+
+These only apply with --no-skip-readonly-subvols; the default (#156) keeps
+read-only subvolumes out of the scan entirely.
+"""
+
+import os
+import subprocess
+import unittest
+
+from harness import DuperemoveTest, phys_extents, requires_btrfs
+
+NO_SKIP = "--no-skip-readonly-subvols"
+
+
+def _btrfs(*args):
+    return subprocess.run(["btrfs", *args], stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL).returncode == 0
+
+
+@requires_btrfs
+class ReadonlyTargetTest(DuperemoveTest):
+    # Asserts on the physical extent layout, so it must not race btrfs
+    # writeback against the rest of the suite.
+    serial = True
+
+    def setUp(self):
+        super().setUp()
+        self.subvols = []
+
+    def tearDown(self):
+        for path in reversed(self.subvols):
+            _btrfs("subvolume", "delete", path)
+        super().tearDown()
+
+    def _subvol(self, name):
+        p = os.path.join(self.work, name)
+        if not _btrfs("subvolume", "create", p):
+            self.skipTest("cannot create a btrfs subvolume here")
+        self.subvols.append(p)
+        return p
+
+    def _snapshot(self, src, name):
+        dst = os.path.join(self.work, name)
+        self.assertTrue(_btrfs("subvolume", "snapshot", "-r", src, dst),
+                        f"could not snapshot into {name}")
+        self.subvols.append(dst)
+        return dst
+
+    def _independent_copy(self, src, rel):
+        """A byte-identical copy that shares no extents with src."""
+        dst = self.path(rel)
+        subprocess.run(["cp", "--reflink=never", src, dst], check=True)
+        return dst
+
+    def _fragment(self, path, content):
+        """Write content, then rewrite alternate 4K blocks so COW splits it."""
+        with open(path, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        fd = os.open(path, os.O_WRONLY)
+        try:
+            for off in range(0, len(content), 8192):
+                os.pwrite(fd, content[off:off + 4096], off)
+                os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def test_writable_copy_is_deduped_onto_the_snapshot(self):
+        """The whole point: the saving is taken, in the legal direction.
+
+        The snapshot's copy is deliberately the *more fragmented* one, so the
+        pre-#171 least-fragmented rule would have picked the writable file as
+        the target and rewritten the snapshot. Read-only-ness has to outrank
+        fragmentation for this to come out right.
+        """
+        live = self._subvol("live")
+        data = os.urandom(1 << 21)
+        self._fragment(os.path.join(live, "f.bin"), data)
+        self.sync()
+        snap = self._snapshot(live, "snap")
+        # A contiguous, independently-stored copy: fewer extents than the
+        # snapshot's, so fragmentation alone would elect it as target.
+        rw = self.write("rw/f.bin", data)
+        self.sync()
+
+        snap_file = os.path.join(snap, "f.bin")
+        snap_before = phys_extents(snap_file)
+        self.assertGreater(len(snap_before), len(phys_extents(rw)),
+                           "setup: the snapshot copy must be more fragmented")
+        self.assertNotEqual(snap_before, phys_extents(rw),
+                            "setup is wrong: the copies already share extents")
+
+        self.dm("-rd", NO_SKIP, snap, self.path("rw"))
+        self.assertDmOk()
+
+        self.assertEqual(snap_before, phys_extents(snap_file),
+                         "the read-only snapshot was rewritten")
+        self.assertTrue(phys_extents(rw) & snap_before,
+                        "the writable copy was not pointed at the snapshot")
+
+    def test_a_readonly_member_is_never_a_destination(self):
+        """With two read-only members, one cannot be the target -- skip it.
+
+        Before #171 the loser was handed to the kernel as a destination, which
+        on a permissive kernel rewrites a snapshot's extent mapping.
+        """
+        live_a = self._subvol("live_a")
+        live_b = self._subvol("live_b")
+        data = os.urandom(1 << 21)
+        for sv in (live_a, live_b):
+            with open(os.path.join(sv, "f.bin"), "wb") as f:
+                f.write(data)
+        self.sync()
+        snap_a = self._snapshot(live_a, "snap_a")
+        snap_b = self._snapshot(live_b, "snap_b")
+        rw = self._independent_copy(os.path.join(snap_a, "f.bin"), "rw/f.bin")
+        self.sync()
+
+        a_file, b_file = os.path.join(snap_a, "f.bin"), os.path.join(snap_b, "f.bin")
+        a_before, b_before = phys_extents(a_file), phys_extents(b_file)
+
+        self.dm("-rd", NO_SKIP, snap_a, snap_b, self.path("rw"))
+        self.assertDmOk()
+
+        self.assertEqual(a_before, phys_extents(a_file),
+                         "snapshot A was rewritten")
+        self.assertEqual(b_before, phys_extents(b_file),
+                         "snapshot B was rewritten -- a read-only member was "
+                         "used as a dedupe destination")
+        # The writable copy still got deduped onto whichever snapshot won.
+        self.assertTrue(phys_extents(rw) in (a_before, b_before),
+                        "the writable copy was not deduped at all")
+
+    def test_the_skip_is_reported(self):
+        """Silently doing less is the failure mode #145/#147/#156 exist to stop."""
+        live_a = self._subvol("live_a")
+        live_b = self._subvol("live_b")
+        data = os.urandom(1 << 21)
+        for sv in (live_a, live_b):
+            with open(os.path.join(sv, "f.bin"), "wb") as f:
+                f.write(data)
+        self.sync()
+        snap_a = self._snapshot(live_a, "snap_a")
+        snap_b = self._snapshot(live_b, "snap_b")
+        self.sync()
+
+        self.dm("-rd", NO_SKIP, snap_a, snap_b, quiet=False)
+        self.assertDmOk()
+        self.assertIn("Read-only", self.out,
+                      "a skipped read-only destination was not reported")
+
+    def test_default_still_keeps_snapshots_out_of_the_scan(self):
+        """#156's behaviour is unchanged; this only affects the opt-in path."""
+        live = self._subvol("live")
+        data = os.urandom(1 << 20)
+        with open(os.path.join(live, "f.bin"), "wb") as f:
+            f.write(data)
+        self.sync()
+        snap = self._snapshot(live, "snap")
+        self._independent_copy(os.path.join(snap, "f.bin"), "rw/f.bin")
+        self.sync()
+
+        self.dm("-rd", snap, self.path("rw"))
+        self.assertDmOk()
+        scanned = {r[0] for r in self.hf_query("select filename from files")}
+        self.assertFalse(any(s.startswith(snap) for s in scanned),
+                         "the default scanned into a read-only subvolume")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #171.

`FIDEDUPERANGE` rewrites the destination and nothing else, so a file in a read-only subvolume can legally be a group's **target** (the source the kernel reads) and cannot be anything else. Nothing in oans knew that — target selection went by least-fragmented-target and anchoring, so with `--no-skip-readonly-subvols` the direction was a coin flip.

## Why losing that flip matters more than expected

#156 (mine, merged earlier) claimed the kernel refuses a read-only destination. **That is version-dependent.** On 7.1.3-200.fc44 a minimal `FIDEDUPERANGE` probe with both fds opened `O_RDONLY` *accepted* a destination inside a read-only snapshot and rewrote its extent mapping — verified cold-cache with `filefrag`, while `touch` on the same file correctly returned `EROFS`. The r/btrfs user who prompted this sees `EROFS`. So depending on the kernel, the bad direction either fails loudly or **silently mutates a snapshot that is supposed to be immutable**.

That makes this a safety fix, not just a hit-rate one, and it's why oans now refuses on its own rather than relying on the kernel to refuse for it.

## Two changes

1. **`pick_least_fragmented_target()` → `pick_dedupe_target()`**, ranking read-only-ness above fragmentation. Among members with equal read-only status the least-fragmented copy still wins, so groups without a read-only member behave exactly as before.
2. **The dedupe loop refuses any read-only destination outright**, counted and reported on a new `Read-only N files skipped` summary line. This covers what target selection can't: extent-dedupe groups (which never run target selection) and anchored groups (whose target is pinned across passes for convergence).

The lookup reuses #156's `dev_t` cache, which grows an fd-based entry point — the dedupe loop already has an open fd *and* an `fstat`, so this costs one ioctl per subvolume and nothing per file.

## Measured

```console
$ oans -dr --no-skip-readonly-subvols --hashfile=h.db $T
  Reclaimed      2.0 MiB across 1 group
  Read-only      1 file skipped (can only be a dedupe source)

before: snap=17693534  snapB=17650948  rw2=17774650
after:  snap=17693534  snapB=17650948  rw2=17693534
```

`snapB` keeps its own extent instead of being rewritten; the writable copy deduplicates onto the target.

## Testing

New `tests/integration/test_readonly_target.py`, 4 cases, `serial = True` since they assert on physical extent layout. **Three of the four fail against a binary built from current master**, which I checked explicitly rather than assuming:

```
test_a_readonly_member_is_never_a_destination ... FAIL
test_the_skip_is_reported                     ... FAIL
test_writable_copy_is_deduped_onto_the_snapshot ... FAIL
test_default_still_keeps_snapshots_out_of_the_scan ... ok   (unchanged by design)
```

The third only fails pre-fix because the snapshot's copy is deliberately made *more fragmented* than the writable one — otherwise the old rule picks the read-only member by luck and the test proves nothing.

`scripts/verify.sh` passes; full suite 185 tests.

## Note on #156

Its rationale ("a read-only subvolume can never be a dedupe destination — the kernel refuses") is wrong and is repeated in its commit message. The feature and default it shipped are still right; only that justification was. #171 records the correction so it doesn't get built on again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)