### PR TITLE
tests: hold the unaligned-shared-tail test back to the serial pass

### DIFF
--- a/tests/integration/test_einval.py
+++ b/tests/integration/test_einval.py
@@ -13,6 +13,16 @@ from harness import DuperemoveTest, requires_reflink
 
 @requires_reflink
 class EinvalTest(DuperemoveTest):
+    # test_unaligned_shared_tail builds a *unique* head, a hole, then a *shared*
+    # tail, so the tail is the only shareable region and has to land as its own
+    # extent for the dedupe to have anything to do. That depends on btrfs
+    # writeback placing the hole boundary where the setup intends, which
+    # concurrent I/O from the rest of the suite perturbs -- the same reason
+    # test_extent_order_independent and test_streaming_dedupe are held back.
+    # Seen once on a CI runner (UBSAN leg, master @ e8e6a3d): assertShared
+    # failed while the other seven legs passed on the same commit.
+    serial = True
+
     def test_unaligned_shared_tail(self):
         # Unique aligned head, a hole, then an identical unaligned tail. The
         # tail is the shared extent whose block-rounded length overshoots EOF.


### PR DESCRIPTION
Fixes the flake seen on master @ `e8e6a3d` (run [31188122775](https://github.com/martinus/oans/actions/runs/31188122775), UBSAN leg):

```
FAIL: test_unaligned_shared_tail (test_einval.EinvalTest.test_unaligned_shared_tail)
AssertionError: False is not true : the unaligned tail got shared
```

## Why it is a flake, not a regression from #172

- **The #172 code is inert on that path.** `test_einval` runs plain `-rd`, so `skipping_readonly_subvols()` is true, `filescan_fd_is_readonly_subvol()` early-returns before any syscall, the target ranking degenerates to exactly the old `n < best_extents` rule, and the read-only destination guard can never fire.
- **7 of 8 legs passed on that identical commit**, and the PR run of the same code passed all 8.
- **Not reproducible locally** in 20 full-suite runs (12 normal + 8 with a `CC=clang SANITIZE=undefined` build matching the failing leg).
- **Only failure in the last 25 master runs**, so it is rare rather than systematic.

## The actual gap

`test_unaligned_shared_tail` builds a *unique* head, a hole, then a *shared* tail. The tail is the only shareable region, and it has to land as its own extent for the dedupe to have anything to do — which depends on btrfs writeback placing the hole boundary where the setup intends. Concurrent I/O from the rest of the parallel suite perturbs exactly that.

This is the case CLAUDE.md already documents: *"A test asserting on the physical extent layout must set `serial = True`… CI caught exactly this on btrfs (`test_extent_order_independent`, `test_streaming_dedupe`) while xfs passed."* This test asserts on physical sharing and was not marked.

I audited the other layout-touching tests rather than blanket-serialising: the rest use plain `mkdup` plus "did these two share", which is robust — dedupe either happened or it did not, with no dependence on a particular boundary. Only this one has a setup whose correctness is a layout property. Its sibling `test_small_unaligned_whole_file` is robust but moves too, since `serial` is per-class.

Suite is 185 tests, now `+16 serial` instead of `+14`. `scripts/verify.sh` passes.

No release impact — this is test-only, so v1.7.0 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)