### PR TITLE
dedupe: don't refuse a read-only destination

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -386,19 +386,23 @@ happens to be called \f[CR].snapshots\f[R].
 The number skipped is reported in the run summary and in
 \f[B]\-\-json\f[R]; the choice is stored in the hashfile and replayed.
 .PP
-With \f[B]\-\-no\-skip\-readonly\-subvols\f[R], a file in a read\-only
-subvolume is only ever used as a dedupe \f[B]source\f[R], never as a
-destination: \f[CR]FIDEDUPERANGE\f[R] rewrites the destination and
-nothing else, so writing to one would modify a snapshot that is meant to
-be immutable.
+With \f[B]\-\-no\-skip\-readonly\-subvols\f[R], a whole\-file group that
+has a member in a read\-only subvolume prefers it as the dedupe
+\f[B]target\f[R], so the writable copies are rewritten to point at it
+rather than the other way round.
 .PP
-Where a whole\-file group has such a member it is preferred as the
-target, so the writable copies are pointed at it and the space is
-reclaimed.
-Everywhere else \(em extent\-level groups, and groups already anchored
-to a target by an earlier pass \(em a read\-only member is simply
-skipped rather than written, and counted on the \f[I]Read\-only\f[R]
-summary line.
+This is a preference, not a restriction.
+The kernel deduplicates \f[I]into\f[R] a read\-only subvolume quite
+happily \(em the content is byte\-verified and never changes, only which
+extents back it \(em and deduplicating snapshots against each other is a
+normal way to shrink a backup target.
+.PP
+If you do see \f[CR]EROFS\f[R] (error 30) from the dedupe ioctl, the
+cause is a read\-only \f[B]mount\f[R], not the subvolume flag: the
+kernel\(cqs \f[CR]vfs_dedupe_file_range_one()\f[R] tests the mount.
+\f[CR]findmnt \-T\f[R] \f[I]path\f[R] will show it.
+A read\-only subvolume reached through an ordinary read\-write mount is
+unaffected.
 .RE
 .TP
 \f[B]\-q\f[R], \f[B]\-\-quiet\f[R]

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -318,16 +318,20 @@ file is recorded once.
     called `.snapshots`. The number skipped is reported in the run summary and
     in **\--json**; the choice is stored in the hashfile and replayed.
 
-    With **\--no-skip-readonly-subvols**, a file in a read-only subvolume is
-    only ever used as a dedupe **source**, never as a destination:
-    `FIDEDUPERANGE` rewrites the destination and nothing else, so writing to one
-    would modify a snapshot that is meant to be immutable.
+    With **\--no-skip-readonly-subvols**, a whole-file group that has a member
+    in a read-only subvolume prefers it as the dedupe **target**, so the writable
+    copies are rewritten to point at it rather than the other way round.
 
-    Where a whole-file group has such a member it is preferred as the target, so
-    the writable copies are pointed at it and the space is reclaimed. Everywhere
-    else — extent-level groups, and groups already anchored to a target by an
-    earlier pass — a read-only member is simply skipped rather than written, and
-    counted on the *Read-only* summary line.
+    This is a preference, not a restriction. The kernel deduplicates *into* a
+    read-only subvolume quite happily — the content is byte-verified and never
+    changes, only which extents back it — and deduplicating snapshots against
+    each other is a normal way to shrink a backup target.
+
+    If you do see `EROFS` (error 30) from the dedupe ioctl, the cause is a
+    read-only **mount**, not the subvolume flag: the kernel's
+    `vfs_dedupe_file_range_one()` tests the mount. `findmnt -T` *path* will show
+    it. A read-only subvolume reached through an ordinary read-write mount is
+    unaffected.
 
 <!-- -->
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -193,15 +193,6 @@ static _Atomic uint64_t dedupe_dest_errors;
 /* Destinations skipped because they already shared all storage with the
  * target (deduping them would have been a no-op). See fiemap_ranges_shared(). */
 static _Atomic uint64_t dedupe_dest_already_shared;
-/*
- * Destinations skipped because they live in a read-only subvolume (#171).
- * FIDEDUPERANGE only ever rewrites the *destination*, so such a file can
- * legally be the source and nothing else. Whether the kernel enforces that is
- * version-dependent - some return EROFS, others accept it and rewrite a
- * snapshot that is supposed to be immutable - so oans refuses on its own
- * rather than relying on the kernel to refuse for it.
- */
-static _Atomic uint64_t dedupe_dest_readonly;
 
 static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 				   uint64_t *kern_bytes)
@@ -418,12 +409,18 @@ static void pick_dedupe_target(struct dupe_extents *dext)
 		filerec_close(extent->e_file);
 
 		/*
-		 * Rank on (read-only, then fewest extents). A member in a
-		 * read-only subvolume is the only one that can legally be the
-		 * source, so electing it is what lets the group deduplicate at
-		 * all; every other member would be refused as a destination
-		 * below. Among equals the least-fragmented copy still wins, so
-		 * groups without one behave exactly as before.
+		 * Rank on (read-only, then fewest extents).
+		 *
+		 * The kernel is happy to dedupe *into* a read-only subvolume -
+		 * content is byte-verified and never changes, only which
+		 * extents back it - and people rely on that to shrink snapshot
+		 * backups, so this is a preference and never a refusal. What it
+		 * buys: where the destination is reached through a read-only
+		 * *mount* the ioctl does fail (mnt_want_write_file), and
+		 * electing the read-only member as the source is the direction
+		 * that still works. It also leaves snapshots alone in favour of
+		 * rewriting the writable copy, which is the less surprising
+		 * outcome. Among equals the least-fragmented copy still wins.
 		 */
 		if (best == NULL || rdonly > best_rdonly ||
 		    (rdonly == best_rdonly && n < best_extents)) {
@@ -651,23 +648,6 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			 */
 			if (tgt_extent == extent)
 				continue;
-		}
-
-		/*
-		 * A read-only member can only ever be the source; see
-		 * dedupe_dest_readonly. The target is exempt - being the source
-		 * is what pick_dedupe_target() elects it for.
-		 */
-		if (extent != tgt_extent &&
-		    filescan_fd_is_readonly_subvol(extent->e_file->fd)) {
-			atomic_fetch_add(&dedupe_dest_readonly, 1);
-			group_tick(gp, len);	/* skipped, but credit its work */
-			vprintf("[%p] %s is in a read-only subvolume; it can "
-				"only be a dedupe source, skipping.\n",
-				g_thread_self(), extent->e_file->filename);
-			if (ctxt && last)
-				goto run_dedupe;
-			continue;
 		}
 
 		/*
@@ -1312,11 +1292,6 @@ void dedupe_phase_end(void)
 			       "needed)\n", col_dim, col_reset,
 			       (uint64_t)dedupe_dest_already_shared,
 			       dedupe_dest_already_shared == 1 ? "" : "s");
-		if (dedupe_dest_readonly)
-			printf("  %sRead-only%s      %lu file%s skipped (can "
-			       "only be a dedupe source)\n", col_dim, col_reset,
-			       (uint64_t)dedupe_dest_readonly,
-			       dedupe_dest_readonly == 1 ? "" : "s");
 	}
 
 	/*

--- a/tests/integration/test_readonly_target.py
+++ b/tests/integration/test_readonly_target.py
@@ -1,17 +1,21 @@
-"""A read-only subvolume can only ever be a dedupe *source* (#171).
+"""A read-only subvolume is *preferred* as the dedupe source, never refused (#171).
 
-FIDEDUPERANGE rewrites the destination and only the destination, so a member of
-a read-only subvolume can legally be the group's target (the source the kernel
-reads) and nothing else. Two things follow, and both are tested here:
+FIDEDUPERANGE rewrites the destination and only the destination, so which member
+of a group becomes the target decides which file gets rewritten. Where a group
+has a member in a read-only subvolume, electing it as the target leaves the
+snapshot alone and rewrites the writable copies instead.
 
-  * a read-only member must never be used as a destination, and
-  * when a group has one, it should be *preferred* as the target -- otherwise
-    the group either fails or, on kernels that do not enforce this, silently
-    rewrites the extent mapping of a snapshot that is supposed to be immutable.
+It is only a preference. The kernel deduplicates *into* a read-only subvolume
+quite happily: the content is byte-verified and never changes, only which
+extents back it, and people have relied on that since at least 2019 to shrink
+snapshot-based backups. Refusing it broke that workflow (see
+test_two_readonly_snapshots_still_dedupe, which is the regression guard).
 
-Whether the kernel refuses is version-dependent: a user on r/btrfs reports
-EROFS, while on 7.1.3 the ioctl accepts a read-only destination and rewrites it.
-oans therefore refuses on its own rather than relying on the kernel to refuse.
+The EROFS people do sometimes hit comes from a read-only *mount*, not from the
+subvolume flag: vfs_dedupe_file_range_one() calls mnt_want_write_file(), which
+tests the mount. A read-only subvolume under an ordinary read-write mount does
+not trip it, which is why the same operation works for most people and fails for
+someone whose snapshots are mounted -o ro.
 
 These only apply with --no-skip-readonly-subvols; the default (#156) keeps
 read-only subvolumes out of the scan entirely.
@@ -45,74 +49,52 @@ class ReadonlyTargetTest(DuperemoveTest):
         snap = self.snapshot(live, name)
         return os.path.join(snap, "f.bin")
 
-    def test_writable_copy_is_deduped_onto_the_snapshot(self):
-        """The whole point: the saving is taken, in the legal direction.
+    def test_two_readonly_snapshots_still_dedupe(self):
+        """Regression: refusing read-only destinations broke this outright.
+
+        Deduplicating snapshots against each other is the whole point of
+        running offline dedup on a backup target, and the kernel allows it.
+        oans must not second-guess that -- especially not when the user asked
+        for the snapshots to be included in the first place.
+        """
+        data = os.urandom(SIZE)
+        a_file = self._snapshot_of("snap_a", data)
+        b_file = self._snapshot_of("snap_b", data)
+        self.sync()
+
+        self.assertNotShared(a_file, b_file, "setup: must start unshared")
+
+        self.dm("-rd", NO_SKIP, os.path.dirname(a_file),
+                os.path.dirname(b_file))
+        self.assertDmOk()
+
+        self.assertShared(a_file, b_file,
+                          "two read-only snapshots were not deduplicated")
+
+    def test_a_readonly_member_is_preferred_as_the_target(self):
+        """The snapshot is left alone; the writable copy is the one rewritten.
 
         The snapshot's copy is deliberately the *more fragmented* one, so the
-        pre-#171 least-fragmented rule would have picked the writable file as
-        the target and rewritten the snapshot. Read-only-ness has to outrank
-        fragmentation for this to come out right.
+        least-fragmented rule alone would have elected the writable file and
+        rewritten the snapshot instead.
         """
         data = os.urandom(SIZE)
         snap_file = self._snapshot_of("snap", data, fragmented=True)
-        # Contiguous and independently stored (a plain write never reflinks),
-        # so fragmentation alone would elect it as target.
         rw = self.write("rw/f.bin", data)
         self.sync()
 
         snap_before = phys_extents(snap_file)
         self.assertGreater(len(snap_before), len(phys_extents(rw)),
                            "setup: the snapshot copy must be more fragmented")
-        self.assertNotShared(snap_file, rw,
-                             "setup: the copies must not already share")
+        self.assertNotShared(snap_file, rw, "setup: must start unshared")
 
         self.dm("-rd", NO_SKIP, os.path.dirname(snap_file), self.path("rw"))
         self.assertDmOk()
 
         self.assertEqual(snap_before, phys_extents(snap_file),
-                         "the read-only snapshot was rewritten")
+                         "the snapshot was rewritten instead of the copy")
         self.assertShared(rw, snap_file,
                           "the writable copy was not pointed at the snapshot")
-
-    def test_a_readonly_member_is_never_a_destination(self):
-        """With two read-only members, one cannot be the target -- skip it.
-
-        Before #171 the loser was handed to the kernel as a destination, which
-        on a permissive kernel rewrites a snapshot's extent mapping.
-        """
-        data = os.urandom(SIZE)
-        a_file = self._snapshot_of("snap_a", data)
-        b_file = self._snapshot_of("snap_b", data)
-        rw = self.write("rw/f.bin", data)
-        self.sync()
-
-        a_before, b_before = phys_extents(a_file), phys_extents(b_file)
-
-        self.dm("-rd", NO_SKIP, os.path.dirname(a_file),
-                os.path.dirname(b_file), self.path("rw"))
-        self.assertDmOk()
-
-        self.assertEqual(a_before, phys_extents(a_file),
-                         "snapshot A was rewritten")
-        self.assertEqual(b_before, phys_extents(b_file),
-                         "snapshot B was rewritten -- a read-only member was "
-                         "used as a dedupe destination")
-        # The writable copy still got deduped onto whichever snapshot won.
-        self.assertTrue(phys_extents(rw) & (a_before | b_before),
-                        "the writable copy was not deduped at all")
-
-    def test_the_skip_is_reported(self):
-        """Silently doing less is the failure mode #145/#147/#156 exist to stop."""
-        data = os.urandom(SIZE)
-        a_file = self._snapshot_of("snap_a", data)
-        b_file = self._snapshot_of("snap_b", data)
-        self.sync()
-
-        self.dm("-rd", NO_SKIP, os.path.dirname(a_file),
-                os.path.dirname(b_file), quiet=False)
-        self.assertDmOk()
-        self.assertIn("Read-only", self.out,
-                      "a skipped read-only destination was not reported")
 
     def test_default_still_keeps_snapshots_out_of_the_scan(self):
         """#156's behaviour is unchanged; this only affects the opt-in path."""


### PR DESCRIPTION
Reverts the destination guard from #172, which **shipped in v1.7.0 and broke a working workflow**. Keeps the target preference. Needs a 1.7.1.

## The regression

Deduplicating read-only snapshots against each other is a normal way to shrink a backup target, and it has worked for years. A user on r/btrfs posted a transcript of exactly that, which is how this surfaced. Measured on their case — two read-only snapshots holding one identical 100 MiB file:

| | result | `test2_ro` extent |
|---|---|---|
| pre-#172 (`cf852fc`) | **Reclaimed 100.0 MiB** | 21005928 → 15767323 (shared) |
| **v1.7.0** | **Reclaimed 0 B** | unchanged |

## Two things I got wrong

**The premise.** I assumed the kernel refuses a read-only destination, generalising from a single EROFS report. It doesn't — the content is byte-verified and never changes, only which extents back it, so this is deliberately allowed.

**The mechanism.** EROFS on dedupe comes from a read-only **mount**, not the subvolume flag: `vfs_dedupe_file_range_one()` calls `mnt_want_write_file()`, which tests the mount. Same kernel, same file, two paths to it:

```
dest = snapshot via its normal path (ro subvolume, rw mount):  status=0   deduped 4194304 bytes
dest = the SAME file via a read-only bind mount:               status=-30 (Read-only file system)
```

So the guard was keyed on the wrong property: a file on a read-only bind mount of a *writable* subvolume still fails, and the guard wouldn't fire. It broke a working workflow **and** failed to prevent the error it existed for.

There's a third thing I missed: **the default already protects snapshots** by not scanning them (#156). Anyone passing `--no-skip-readonly-subvols` has explicitly asked to include them, so refusing to write to them contradicted the request.

## What survives

The target **preference** stays, and is still right:
- It leaves the snapshot alone and rewrites the writable copy instead — the less surprising outcome.
- Where the destination is behind a read-only mount, electing the read-only member as source is the direction that still works.
- It never *prevents* anything, which is exactly where the guard went wrong.

## Testing

- New `test_two_readonly_snapshots_still_dedupe` pins the workflow and **fails against v1.7.0**, verified against a build of that tag.
- `test_a_readonly_member_is_preferred_as_the_target` keeps the surviving half honest — the snapshot copy is deliberately the more fragmented one, so the least-fragmented rule alone would elect the writable file.
- `scripts/verify.sh` passes.

The man page now documents the mount-vs-subvolume distinction and points at `findmnt -T`, since that's the diagnostic anyone hitting error 30 actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)