### PR TITLE
aur: bring the PKGBUILDs up to 1.7.1 and fix the version string

### DIFF
--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -9,25 +9,46 @@ alongside the code:
 Both install a `duperemove` compatibility symlink, so they `provides`/`conflicts`
 with the `duperemove` package.
 
-## Publishing to the AUR
+`.SRCINFO` is committed next to each `PKGBUILD` so the two never drift, and so
+publishing is a copy rather than a regeneration on a machine that may not have
+`makepkg`.
 
-The AUR expects each package in its own git repo containing `PKGBUILD` and a
-generated `.SRCINFO`. To publish or update `oans`:
+## First-time publishing
+
+One-off, and it needs a human: an AUR account with an SSH key uploaded at
+<https://aur.archlinux.org/account>.
 
 ```sh
-cd packaging/aur/oans
-makepkg --printsrcinfo > .SRCINFO   # regenerate whenever PKGBUILD changes
-# then push PKGBUILD + .SRCINFO to ssh://aur@aur.archlinux.org/oans.git
+git clone ssh://aur@aur.archlinux.org/oans.git aur-oans   # empty on first use
+cp packaging/aur/oans/{PKGBUILD,.SRCINFO} aur-oans/
+cd aur-oans && git add PKGBUILD .SRCINFO
+git commit -m "Initial import: oans 1.7.1" && git push origin master
 ```
+
+Repeat with `oans-git`. The push is what creates the package; there is no
+separate "submit" step.
 
 ## On a new release
 
-Bump `pkgver`, reset `pkgrel=1`, and refresh the checksum in
-[`oans/PKGBUILD`](oans/PKGBUILD):
+1. Bump `pkgver` and reset `pkgrel=1` in [`oans/PKGBUILD`](oans/PKGBUILD).
+2. Refresh the checksum. On Arch that is `updpkgsums`; anywhere else:
 
-```sh
-updpkgsums          # rewrites sha256sums from the release tarball
-```
+   ```sh
+   curl -sL https://github.com/martinus/oans/archive/refs/tags/vX.Y.Z.tar.gz | sha256sum
+   ```
 
-`oans-git` needs no checksum or manual `pkgver` bump — its `pkgver()` derives the
-version from `git describe`.
+3. Mirror both into [`oans/.SRCINFO`](oans/.SRCINFO) (`pkgver`, `source`,
+   `sha256sums`), or regenerate it with `makepkg --printsrcinfo > .SRCINFO`.
+4. Copy both files into the AUR clone, commit, push.
+
+`oans-git` needs none of this: no checksum, and its `pkgver()` derives the
+version from `git describe` at build time.
+
+## Why the PKGBUILD passes VERSION
+
+The Makefile takes its version from `git describe`, which a release tarball has
+no metadata for, so an unpatched build reports `oans unknown`. The `_make`
+wrapper passes `VERSION="v$pkgver"` to **every** make invocation — not just
+`build()`. The Makefile rebuilds when `VERSTRING` changes, so a `package()` that
+omitted it would quietly rebuild the binary back to `unknown` after `build()` got
+it right.

--- a/packaging/aur/oans-git/.SRCINFO
+++ b/packaging/aur/oans-git/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = oans-git
+	pkgdesc = Fast, safe filesystem deduplication for btrfs & xfs — a duperemove fork (VCS)
+	pkgver = 1.2.0.r0.g0000000
+	pkgrel = 1
+	url = https://github.com/martinus/oans
+	arch = x86_64
+	license = GPL-2.0-only
+	makedepends = git
+	makedepends = pkgconf
+	depends = glib2
+	depends = sqlite
+	depends = xxhash
+	depends = util-linux-libs
+	depends = libbsd
+	provides = oans
+	provides = duperemove
+	conflicts = oans
+	conflicts = duperemove
+	source = git+https://github.com/martinus/oans.git
+	sha256sums = SKIP
+
+pkgname = oans-git

--- a/packaging/aur/oans/.SRCINFO
+++ b/packaging/aur/oans/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = oans
+	pkgdesc = Fast, safe filesystem deduplication for btrfs & xfs — a duperemove fork
+	pkgver = 1.7.1
+	pkgrel = 1
+	url = https://github.com/martinus/oans
+	arch = x86_64
+	license = GPL-2.0-only
+	makedepends = pkgconf
+	depends = glib2
+	depends = sqlite
+	depends = xxhash
+	depends = util-linux-libs
+	depends = libbsd
+	provides = duperemove
+	conflicts = duperemove
+	source = oans-1.7.1.tar.gz::https://github.com/martinus/oans/archive/refs/tags/v1.7.1.tar.gz
+	sha256sums = 9f7a402206e9017619a8df2d7dabdb64567073f7d16decb0d482b4ef6bff560b
+
+pkgname = oans

--- a/packaging/aur/oans/PKGBUILD
+++ b/packaging/aur/oans/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: martinus <martin.ankerl@gmail.com>
 pkgname=oans
-pkgver=1.2.0
+pkgver=1.7.1
 pkgrel=1
 pkgdesc="Fast, safe filesystem deduplication for btrfs & xfs — a duperemove fork"
 arch=('x86_64')
@@ -11,15 +11,32 @@ makedepends=('pkgconf')
 provides=('duperemove')
 conflicts=('duperemove')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('257580e6dd3c1099750e7780fbbcd7b9d59b99b6097cd3346c5862caa9483413')
+sha256sums=('9f7a402206e9017619a8df2d7dabdb64567073f7d16decb0d482b4ef6bff560b')
+
+# The Makefile derives VERSION from `git describe`, which a release tarball has
+# no metadata for - without this the binary reports "oans unknown". It must be
+# passed to *every* make invocation: the Makefile rebuilds when VERSTRING
+# changes, so an unset VERSION in package() would quietly rebuild it back to
+# "unknown".
+_make() {
+  make VERSION="v$pkgver" "$@"
+}
 
 build() {
   cd "$pkgname-$pkgver"
-  make
+  _make
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  # Unit tests only: the integration suite needs a reflink-capable scratch
+  # filesystem, which a build chroot does not have. `make test` builds and runs.
+  _make test
 }
 
 package() {
   cd "$pkgname-$pkgver"
-  make install DESTDIR="$pkgdir" PREFIX=/usr
-  make install-systemd DESTDIR="$pkgdir" PREFIX=/usr
+  _make install DESTDIR="$pkgdir" PREFIX=/usr
+  _make install-systemd DESTDIR="$pkgdir" PREFIX=/usr
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
Prep for actually publishing to the AUR. The stable PKGBUILD was at **pkgver=1.2.0**, five releases behind, and would have shipped a binary reporting `oans unknown`.

## The version bug

The Makefile takes `VERSION` from `git describe`, and a GitHub release tarball has no git metadata. Built from the real v1.7.1 tarball:

```console
$ ./oans --version
oans unknown
```

**The fix has a trap.** The Makefile rebuilds when `VERSTRING` changes, so passing `VERSION` only in `build()` is not enough — `package()` runs make again, sees an empty `VERSION`, and quietly rebuilds the binary back to `unknown` after `build()` had it right:

```
build + install, both with VERSION   ->  oans v1.7.1
build with VERSION, install without  ->  oans unknown
```

Hence a `_make` wrapper that passes it to every invocation.

## Also

- `pkgver` 1.2.0 → 1.7.1, with the sha256 of the actual release tarball (`9f7a4022…`).
- `check()` runs the unit tests. Deliberately *not* the integration suite — it needs a reflink-capable scratch filesystem, which a build chroot doesn't have.
- `package()` installs `LICENSE`, which Arch guidelines expect.
- **`.SRCINFO` is now committed** next to each `PKGBUILD`, so the two can't drift and publishing is a copy rather than a regeneration on a machine without `makepkg`.
- The README now documents first-time publishing, the per-release checklist, and a non-Arch way to get the checksum.

## Verified end to end

Against the real v1.7.1 tarball: builds, unit tests pass, and `make install` + `make install-systemd` with `DESTDIR`/`PREFIX` lay down exactly:

```
/usr/bin/oans
/usr/bin/duperemove                        (symlink)
/usr/share/man/man8/oans.8
/usr/share/man/man8/duperemove.8           (symlink)
/usr/share/zsh/site-functions/_oans
/usr/lib/systemd/system/oans@.service
/usr/lib/systemd/system/oans@.timer
```

I can't run `makepkg` here (this is Fedora), so the `.SRCINFO` files are hand-written in makepkg's field order and tab indentation. Worth a `namcap`/`makepkg --printsrcinfo` sanity check on an Arch box before the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)