### PR TITLE
progress: route every print around the live block (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,27 +470,30 @@ count, so it moves smoothly 0→100% (like hashing) even through one giant group
 
 ## Nothing prints past the live block (#179)
 
-The block is redrawn by moving the cursor up `drawn_lines`. **Every byte written
-while a block is on screen must go through `pscan_printf()`** (i.e. the
-`dprintf`/`vprintf`/`qprintf`/`eprintf` macros), or the cursor drifts down
-without `drawn_lines` following, the next `progress_home()` lands *inside* the
-block, and its erase-below both strands the rows above the landing point and
-wipes the message that caused it.
+The block is redrawn by moving the cursor up `drawn_lines`, so **every byte
+written while one is on screen must go through `progress_printf()`** — i.e. the
+`dprintf`/`vprintf`/`qprintf`/`eprintf` macros, never a bare `printf`. The
+mechanism and the failure mode are documented at the definition in `progress.c`;
+what belongs here is when it bites:
 
 - **"A block is on screen" ≠ "a printer thread is running."** The scan hands its
   block straight to the dedupe phase (`pscan_join(continues=true)` …
-  `pdedupe_begin()`) with no printer alive across the gap. `progress_print()`
-  therefore routes on `is_progress_printer_running() || progress_block_live()`
-  (`tty && drawn_lines`); keying it on the printer alone is what #179 was, and
-  it silently ate the scan-skip report on every run that had one.
-- **Route whole lines.** Each routed call is a home/wipe/print/redraw cycle, so a
-  message assembled from several `printf`s would redraw the block between the
-  pieces — `report_scan_skips()` builds its report in a `GString` first.
-- Non-tty output is untouched (`progress_block_live()` is gated on `tty`), which
-  is also why the plain integration suite can't see any of this. The regression
-  test drives a real pty and replays the stream through a small ANSI emulator:
+  `pdedupe_begin()`) with no printer alive across the gap, so `progress_printf()`
+  routes on `printer || block_live()`. Keying it on the printer alone was #179:
+  one stranded worker row per unrouted line, *and* the scan-skip report silently
+  erased on every run that had one.
+- **Route whole lines.** One call is one erase/print/redraw cycle, so a message
+  assembled from several calls redraws the block between the pieces —
+  `report_scan_skips()` builds its whole report in a `GString` first.
+- Non-tty output is untouched (`block_live()` is gated on `tty`), which is also
+  why the plain integration suite can't see any of this. The regression test
+  drives a real pty and replays the stream through a small ANSI emulator:
   `tests/integration/test_progress_tty.py`. Its invariant — *no worker-slot row
   may survive the end of a run* — catches the whole class, not just this site.
+- **Known gap, not yet fixed:** a routed `eprintf` lands on **stdout**, because
+  `print_above_block()` only knows the stream the block lives on. So an error's
+  destination depends on whether a block happened to be up. Pre-existing; fixing
+  it means flushing across the two streams mid-redraw.
 
 ## Valgrind
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,6 +468,30 @@ count, so it moves smoothly 0→100% (like hashing) even through one giant group
   monotone clamp — machine consumers want truth); `pdedupe_end()` emits one
   final dedupe record so the last line shows the settled `done == total`.
 
+## Nothing prints past the live block (#179)
+
+The block is redrawn by moving the cursor up `drawn_lines`. **Every byte written
+while a block is on screen must go through `pscan_printf()`** (i.e. the
+`dprintf`/`vprintf`/`qprintf`/`eprintf` macros), or the cursor drifts down
+without `drawn_lines` following, the next `progress_home()` lands *inside* the
+block, and its erase-below both strands the rows above the landing point and
+wipes the message that caused it.
+
+- **"A block is on screen" ≠ "a printer thread is running."** The scan hands its
+  block straight to the dedupe phase (`pscan_join(continues=true)` …
+  `pdedupe_begin()`) with no printer alive across the gap. `progress_print()`
+  therefore routes on `is_progress_printer_running() || progress_block_live()`
+  (`tty && drawn_lines`); keying it on the printer alone is what #179 was, and
+  it silently ate the scan-skip report on every run that had one.
+- **Route whole lines.** Each routed call is a home/wipe/print/redraw cycle, so a
+  message assembled from several `printf`s would redraw the block between the
+  pieces — `report_scan_skips()` builds its report in a `GString` first.
+- Non-tty output is untouched (`progress_block_live()` is gated on `tty`), which
+  is also why the plain integration suite can't see any of this. The regression
+  test drives a real pty and replays the stream through a small ANSI emulator:
+  `tests/integration/test_progress_tty.py`. Its invariant — *no worker-slot row
+  may survive the end of a run* — catches the whole class, not just this site.
+
 ## Valgrind
 
 `verify.sh` runs the smoke. Manual, with the suppressions file (filters the one

--- a/src/debug.h
+++ b/src/debug.h
@@ -30,8 +30,16 @@ extern int quiet;
 #define likely(x)	__builtin_expect(!!(x), 1)
 #define unlikely(x)	__builtin_expect(!!(x), 0)
 
+/*
+ * Route a message around the live progress block when there is one - including
+ * the window between the scan and the dedupe phase, where the block is on
+ * screen with no printer thread animating it (progress_block_live()). Each
+ * invocation is one home/wipe/print/redraw cycle, so pass whole lines: a
+ * message assembled from several calls would redraw the block between the
+ * pieces.
+ */
 #define progress_print(stream, format, ...) do {			\
-	if (is_progress_printer_running())						\
+	if (is_progress_printer_running() || progress_block_live())	\
 		pscan_printf(format, ##__VA_ARGS__);			\
 	else								\
 		fprintf(stream, format, ##__VA_ARGS__);         	\

--- a/src/debug.h
+++ b/src/debug.h
@@ -31,24 +31,13 @@ extern int quiet;
 #define unlikely(x)	__builtin_expect(!!(x), 0)
 
 /*
- * Route a message around the live progress block when there is one - including
- * the window between the scan and the dedupe phase, where the block is on
- * screen with no printer thread animating it (progress_block_live()). Each
- * invocation is one home/wipe/print/redraw cycle, so pass whole lines: a
- * message assembled from several calls would redraw the block between the
- * pieces.
+ * All four print around the live progress block; see progress_printf() in
+ * progress.c for what that costs and why every message must go through it.
  */
-#define progress_print(stream, format, ...) do {			\
-	if (is_progress_printer_running() || progress_block_live())	\
-		pscan_printf(format, ##__VA_ARGS__);			\
-	else								\
-		fprintf(stream, format, ##__VA_ARGS__);         	\
-} while (0)
-
-#define dprintf(format, ...) if (debug) progress_print(stdout, format, ##__VA_ARGS__)
-#define vprintf(format, ...) if (verbose) progress_print(stdout, format, ##__VA_ARGS__)
-#define qprintf(format, ...) if (!quiet) progress_print(stdout, format, ##__VA_ARGS__)
-#define eprintf(format, ...) progress_print(stderr, format, ##__VA_ARGS__)
+#define dprintf(format, ...) if (debug) progress_printf(stdout, format, ##__VA_ARGS__)
+#define vprintf(format, ...) if (verbose) progress_printf(stdout, format, ##__VA_ARGS__)
+#define qprintf(format, ...) if (!quiet) progress_printf(stdout, format, ##__VA_ARGS__)
+#define eprintf(format, ...) progress_printf(stderr, format, ##__VA_ARGS__)
 
 void print_stack_trace(void);/* defined in util.c */
 #define	abort_lineno()	do {						\

--- a/src/oans.c
+++ b/src/oans.c
@@ -1426,7 +1426,9 @@ static void report_scan_stats(void)
 	filescan_get_workq_stats(&pops, &empty_waits);
 	dbfile_get_lock_stats(&lock_total, &lock_contended, &lock_wait_ns);
 
-	fprintf(stderr,
+	/* eprintf, not fprintf: this lands in the window where the scan block is
+	 * still on screen, and an unrouted line strands a row of it (#179). */
+	eprintf(
 		"scan-stats: csum-queue pops=%" PRIu64 " empty-waits=%" PRIu64
 		" (%.1f%% starved); write-lock acquisitions=%" PRIu64
 		" contended=%" PRIu64 " (%.1f%%); lock-wait total=%.2fs"
@@ -1449,7 +1451,7 @@ static void report_scan_stats(void)
 		double over_per_file = (double)over_ns / cal_files;
 		double hash_per_byte = (double)hash_ns / cal_bytes;
 
-		fprintf(stderr,
+		eprintf(
 			"eta-calibration: overhead=%.1fus/file hash=%.2fs/GiB"
 			" -> ideal weight %.0f KiB/file (using %" PRIu64 " KiB)\n",
 			over_per_file / 1e3,
@@ -1467,9 +1469,15 @@ static void report_scan_stats(void)
  * exactly the error a journal must carry. The config-driven buckets are
  * verbose-only - they are the user's own --exclude and --min-filesize doing
  * their job, and 812 of them read as alarming next to the one that matters.
+ *
+ * This lands in the window where the scan has handed its block over to the
+ * dedupe phase, so the whole report is assembled first and printed in one
+ * progress_print() call: printed piecewise, the block would be erased and
+ * redrawn between the pieces (#179).
  */
 static void report_scan_skips(const uint64_t *skips)
 {
+	GString *out = g_string_new(NULL);
 	const char *sep = "";
 	uint64_t errors = 0;
 	unsigned int i;
@@ -1479,15 +1487,17 @@ static void report_scan_skips(const uint64_t *skips)
 			errors += skips[i];
 
 	if (errors) {
-		printf("  %sSkipped%s        ", col_dim, col_reset);
+		g_string_append_printf(out, "  %sSkipped%s        ",
+				       col_dim, col_reset);
 		for (i = 0; i < SCAN_SKIP__COUNT; i++) {
 			if (!skips[i] || !scan_skip_is_error(i))
 				continue;
-			printf("%s%"PRIu64" %s", sep, skips[i],
-			       scan_skip_desc(i));
+			g_string_append_printf(out, "%s%"PRIu64" %s", sep,
+					       skips[i], scan_skip_desc(i));
 			sep = ", ";
 		}
-		printf(" %s(rerun with -v for detail)%s\n", col_dim, col_reset);
+		g_string_append_printf(out, " %s(rerun with -v for detail)%s\n",
+				       col_dim, col_reset);
 	}
 
 	/*
@@ -1497,27 +1507,31 @@ static void report_scan_skips(const uint64_t *skips)
 	 * surprise as the silent --exclude no-op #147 removed (#156).
 	 */
 	if (skips[SCAN_SKIP_READONLY_SUBVOL])
-		printf("  %sSnapshots%s      %"PRIu64" read-only subvolume%s skipped "
-		       "%s(--no-skip-readonly-subvols to include them)%s\n",
-		       col_dim, col_reset, skips[SCAN_SKIP_READONLY_SUBVOL],
-		       skips[SCAN_SKIP_READONLY_SUBVOL] == 1 ? "" : "s",
-		       col_dim, col_reset);
-
-	if (!verbose)
-		return;
+		g_string_append_printf(out,
+			"  %sSnapshots%s      %"PRIu64" read-only subvolume%s skipped "
+			"%s(--no-skip-readonly-subvols to include them)%s\n",
+			col_dim, col_reset, skips[SCAN_SKIP_READONLY_SUBVOL],
+			skips[SCAN_SKIP_READONLY_SUBVOL] == 1 ? "" : "s",
+			col_dim, col_reset);
 
 	sep = "";
-	for (i = 0; i < SCAN_SKIP__COUNT; i++) {
+	for (i = 0; verbose && i < SCAN_SKIP__COUNT; i++) {
 		if (!skips[i] || scan_skip_is_error(i) ||
 		    i == SCAN_SKIP_READONLY_SUBVOL)
 			continue;
 		if (!*sep)
-			printf("  %sNot scanned%s    ", col_dim, col_reset);
-		printf("%s%"PRIu64" %s", sep, skips[i], scan_skip_desc(i));
+			g_string_append_printf(out, "  %sNot scanned%s    ",
+					       col_dim, col_reset);
+		g_string_append_printf(out, "%s%"PRIu64" %s", sep, skips[i],
+				       scan_skip_desc(i));
 		sep = ", ";
 	}
 	if (*sep)
-		printf("\n");
+		g_string_append_c(out, '\n');
+
+	if (out->len)
+		progress_print(stdout, "%s", out->str);
+	g_string_free(out, TRUE);
 }
 
 static int scan_files(char **roots, int nroots, struct dbhandle *db,

--- a/src/oans.c
+++ b/src/oans.c
@@ -1336,7 +1336,7 @@ static void process_duplicates(struct dbhandle *db)
 	 * Start the live dedupe block first, then do the deferred post-scan prep
 	 * under it so the seconds it can take on a big hashfile animate instead of
 	 * freezing the display. With the printer running, qprintf() routes these
-	 * status lines above the block (see progress_print). The prep:
+	 * status lines above the block (see progress_printf). The prep:
 	 *   - drop rows for files deleted from disk since they were scanned, so a
 	 *     stale hashfile does not grow and the dedupe phase does not load
 	 *     phantom groups (must precede the count and the per-pass loads);
@@ -1426,8 +1426,8 @@ static void report_scan_stats(void)
 	filescan_get_workq_stats(&pops, &empty_waits);
 	dbfile_get_lock_stats(&lock_total, &lock_contended, &lock_wait_ns);
 
-	/* eprintf, not fprintf: this lands in the window where the scan block is
-	 * still on screen, and an unrouted line strands a row of it (#179). */
+	/* eprintf, not fprintf: this lands while the scan block is still on
+	 * screen, and an unrouted line strands a row of it (#179). */
 	eprintf(
 		"scan-stats: csum-queue pops=%" PRIu64 " empty-waits=%" PRIu64
 		" (%.1f%% starved); write-lock acquisitions=%" PRIu64
@@ -1470,35 +1470,28 @@ static void report_scan_stats(void)
  * verbose-only - they are the user's own --exclude and --min-filesize doing
  * their job, and 812 of them read as alarming next to the one that matters.
  *
- * This lands in the window where the scan has handed its block over to the
- * dedupe phase, so the whole report is assembled first and printed in one
- * progress_print() call: printed piecewise, the block would be erased and
- * redrawn between the pieces (#179).
+ * Assembled into one string and printed in one call: this lands while the live
+ * block is still on screen, and each print erases and redraws it (#179).
  */
 static void report_scan_skips(const uint64_t *skips)
 {
 	GString *out = g_string_new(NULL);
 	const char *sep = "";
-	uint64_t errors = 0;
 	unsigned int i;
 
-	for (i = 0; i < SCAN_SKIP__COUNT; i++)
-		if (scan_skip_is_error(i))
-			errors += skips[i];
-
-	if (errors) {
-		g_string_append_printf(out, "  %sSkipped%s        ",
-				       col_dim, col_reset);
-		for (i = 0; i < SCAN_SKIP__COUNT; i++) {
-			if (!skips[i] || !scan_skip_is_error(i))
-				continue;
-			g_string_append_printf(out, "%s%"PRIu64" %s", sep,
-					       skips[i], scan_skip_desc(i));
-			sep = ", ";
-		}
+	for (i = 0; i < SCAN_SKIP__COUNT; i++) {
+		if (!skips[i] || !scan_skip_is_error(i))
+			continue;
+		if (!*sep)
+			g_string_append_printf(out, "  %sSkipped%s        ",
+					       col_dim, col_reset);
+		g_string_append_printf(out, "%s%"PRIu64" %s", sep, skips[i],
+				       scan_skip_desc(i));
+		sep = ", ";
+	}
+	if (*sep)
 		g_string_append_printf(out, " %s(rerun with -v for detail)%s\n",
 				       col_dim, col_reset);
-	}
 
 	/*
 	 * Read-only subvolumes are reported by default, not just under -v: this
@@ -1514,23 +1507,25 @@ static void report_scan_skips(const uint64_t *skips)
 			skips[SCAN_SKIP_READONLY_SUBVOL] == 1 ? "" : "s",
 			col_dim, col_reset);
 
-	sep = "";
-	for (i = 0; verbose && i < SCAN_SKIP__COUNT; i++) {
-		if (!skips[i] || scan_skip_is_error(i) ||
-		    i == SCAN_SKIP_READONLY_SUBVOL)
-			continue;
-		if (!*sep)
-			g_string_append_printf(out, "  %sNot scanned%s    ",
-					       col_dim, col_reset);
-		g_string_append_printf(out, "%s%"PRIu64" %s", sep, skips[i],
-				       scan_skip_desc(i));
-		sep = ", ";
+	if (verbose) {
+		sep = "";
+		for (i = 0; i < SCAN_SKIP__COUNT; i++) {
+			if (!skips[i] || scan_skip_is_error(i) ||
+			    i == SCAN_SKIP_READONLY_SUBVOL)
+				continue;
+			if (!*sep)
+				g_string_append_printf(out, "  %sNot scanned%s    ",
+						       col_dim, col_reset);
+			g_string_append_printf(out, "%s%"PRIu64" %s", sep,
+					       skips[i], scan_skip_desc(i));
+			sep = ", ";
+		}
+		if (*sep)
+			g_string_append_c(out, '\n');
 	}
-	if (*sep)
-		g_string_append_c(out, '\n');
 
 	if (out->len)
-		progress_print(stdout, "%s", out->str);
+		progress_printf(stdout, "%s", out->str);
 	g_string_free(out, TRUE);
 }
 

--- a/src/progress.c
+++ b/src/progress.c
@@ -1172,6 +1172,28 @@ bool is_progress_printer_running(void)
 	return printer ? true : false;
 }
 
+/*
+ * A block is on screen and drawn_lines says how far above the cursor it starts.
+ * Every byte written while that holds must go through pscan_printf(), or the
+ * cursor drifts down without drawn_lines following and the next
+ * progress_home() lands *inside* the block, stranding the rows it skipped
+ * (#179).
+ *
+ * Deliberately not the same question as is_progress_printer_running(): the scan
+ * hands its block straight to the dedupe phase (pscan_join(continues=true) ...
+ * pdedupe_begin()) and no printer thread is alive across that gap, yet the
+ * block is very much on screen. One unrouted line printed there - the scan-skip
+ * report, say - stranded one worker row per line.
+ *
+ * Racy in principle (drawn_lines is written by the printer thread under
+ * pscan.mutex) but not in practice: callers test is_progress_printer_running()
+ * first, so this is only reached when no printer thread exists to write it.
+ */
+bool progress_block_live(void)
+{
+	return tty && drawn_lines != 0;
+}
+
 void pscan_printf(char *fmt, ...)
 {
 	va_list args;

--- a/src/progress.c
+++ b/src/progress.c
@@ -114,6 +114,18 @@ void progress_set_json(bool on)
 static unsigned int drawn_lines;
 
 /*
+ * Is a block on screen, with drawn_lines saying how far above the cursor it
+ * starts? Everything written while that holds has to go through
+ * progress_printf(), or the cursor drifts down without drawn_lines following,
+ * the next progress_home() lands *inside* the block, and its erase-below both
+ * strands the rows it skipped and wipes the message that caused it (#179).
+ */
+static bool block_live(void)
+{
+	return tty && drawn_lines != 0;
+}
+
+/*
  * The unified live display walks a run through four monotonic stages. The stage
  * line shows all four at once, each with a spinner (running), a tick (finished)
  * or a dim dot (pending); the progress bar and detail line below it describe
@@ -253,7 +265,7 @@ static uint64_t work_total_clamped(void)
 /* Move the cursor to the top-left of the block drawn in the previous render. */
 static void progress_home(void)
 {
-	if (tty && drawn_lines)
+	if (block_live())
 		printf("\33[%uA\r", drawn_lines);
 }
 
@@ -1167,59 +1179,55 @@ void pscan_slot_waiting(struct pscan_thread *slot, bool waiting)
 	slot->waiting_since = waiting ? g_get_monotonic_time() : 0;
 }
 
-bool is_progress_printer_running(void)
+/* Erase the live block, print where it sat (that row becomes scrollback), then
+ * redraw the block below the message. */
+static void print_above_block(const char *fmt, va_list args)
 {
-	return printer ? true : false;
-}
-
-/*
- * A block is on screen and drawn_lines says how far above the cursor it starts.
- * Every byte written while that holds must go through pscan_printf(), or the
- * cursor drifts down without drawn_lines following and the next
- * progress_home() lands *inside* the block, stranding the rows it skipped
- * (#179).
- *
- * Deliberately not the same question as is_progress_printer_running(): the scan
- * hands its block straight to the dedupe phase (pscan_join(continues=true) ...
- * pdedupe_begin()) and no printer thread is alive across that gap, yet the
- * block is very much on screen. One unrouted line printed there - the scan-skip
- * report, say - stranded one worker row per line.
- *
- * Racy in principle (drawn_lines is written by the printer thread under
- * pscan.mutex) but not in practice: callers test is_progress_printer_running()
- * first, so this is only reached when no printer thread exists to write it.
- */
-bool progress_block_live(void)
-{
-	return tty && drawn_lines != 0;
-}
-
-void pscan_printf(char *fmt, ...)
-{
-	va_list args;
-	va_start(args, fmt);
-
 	/* JSON mode draws no block (and the progress stream is on stderr), so a
 	 * routed message is just a plain stdout print. */
 	if (progress_json) {
 		vfprintf(stdout, fmt, args);
-		va_end(args);
 		return;
 	}
 
 	g_mutex_lock(&pscan.mutex);
 
-	/* Erase the live block, print the message where it sat (it becomes
-	 * scrollback), then redraw the block below it. */
 	progress_home();
 	progress_wipe();
 	drawn_lines = 0;
 
 	vfprintf(stdout, fmt, args);
-	va_end(args);
 
 	print_progress();
 	g_mutex_unlock(&pscan.mutex);
+}
+
+/*
+ * Print a message without disturbing the live block (see block_live()). The
+ * message lands above the block and scrolls away as history; `stream` is used
+ * only when there is no block to work around.
+ *
+ * Two states count as "a block to work around", and missing either one is what
+ * #179 was: a printer thread is animating it, *or* one is simply sitting there
+ * with nobody drawing - the scan hands its block to the dedupe phase
+ * (pscan_join(continues=true) ... pdedupe_begin()) with no printer alive across
+ * the gap. Testing `printer` first also keeps drawn_lines from being read while
+ * a printer thread could be writing it.
+ *
+ * One call is one erase/print/redraw cycle, so callers pass whole lines: a
+ * message assembled from several calls would redraw the block between the
+ * pieces.
+ */
+void progress_printf(FILE *stream, const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	if (printer || block_live())
+		print_above_block(fmt, args);
+	else
+		vfprintf(stream, fmt, args);
+	va_end(args);
 }
 
 /*

--- a/src/progress.h
+++ b/src/progress.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdatomic.h>
+#include <stdio.h>	/* FILE, for progress_printf() */
 
 #include "glib.h"
 
@@ -142,20 +143,14 @@ void pscan_slot_idle(struct pscan_thread *slot);
  */
 void pscan_slot_waiting(struct pscan_thread *slot, bool waiting);
 
-bool is_progress_printer_running(void);
-
 /*
- * True while a drawn block sits at the bottom of the screen, whether or not a
- * printer thread is currently animating it. Anything printed in that state has
- * to go through pscan_printf() - see progress.c.
+ * Print above the live progress block, which owns the bottom of the screen -
+ * the only sanctioned way to write anything while a run is in progress. Use the
+ * dprintf/vprintf/qprintf/eprintf macros in debug.h rather than calling this
+ * directly. One call per whole line; see progress.c for why.
  */
-bool progress_block_live(void);
-
-/*
- * The progress thread overwrites its area.
- * This function is used to write something before that area
- */
-void pscan_printf(char *fmt, ...);
+void progress_printf(FILE *stream, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
 
 /*
  * Dedupe-phase status. Reuses the same reserved screen area, per-thread lines

--- a/src/progress.h
+++ b/src/progress.h
@@ -145,6 +145,13 @@ void pscan_slot_waiting(struct pscan_thread *slot, bool waiting);
 bool is_progress_printer_running(void);
 
 /*
+ * True while a drawn block sits at the bottom of the screen, whether or not a
+ * printer thread is currently animating it. Anything printed in that state has
+ * to go through pscan_printf() - see progress.c.
+ */
+bool progress_block_live(void);
+
+/*
  * The progress thread overwrites its area.
  * This function is used to write something before that area
  */

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -1,0 +1,202 @@
+"""The live progress block must not strand rows in the scrollback (#179).
+
+The block is drawn at the bottom of the screen and redrawn in place by moving
+the cursor up ``drawn_lines`` rows. Anything printed while it is on screen has
+to be routed through ``pscan_printf()``, which erases the block first; a plain
+``printf`` moves the cursor down without ``drawn_lines`` following, so the next
+redraw homes *into* the block and leaves the rows it skipped on screen forever
+-- and erases the message that caused it.
+
+That only happens on a tty, which is why the rest of the suite (pipes) cannot
+see it: these tests run oans under a real pty of a fixed size and replay the
+byte stream through a small ANSI emulator to get the screen a user would see.
+
+The window that regressed is between the scan and the dedupe phase: the scan
+deliberately leaves its block up for the dedupe phase to keep drawing
+(pscan_join(continues=True)) and no printer thread is alive across the gap, so
+routing keyed on "is a printer running" took the raw branch there.
+"""
+
+import os
+import pty
+import re
+import select
+import struct
+import sys
+import termios
+import fcntl
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import DUPEREMOVE, DuperemoveTest, requires_reflink  # noqa: E402
+
+COLS, ROWS = 100, 30
+
+# A worker-slot row: two spaces, the slot number, two spaces, the status word.
+WORKER_ROW = re.compile(r"^ {2}\d+ {2}(idle|hashing|mapping|commit|wait lock|deduping)\b")
+
+_CSI = re.compile(rb"\x1b\[([0-9;?]*)([A-Za-z])")
+
+
+def _run_in_pty(argv, cols=COLS, rows=ROWS):
+    """Run argv on a pty of the given size; return its raw output bytes."""
+    pid, fd = pty.fork()
+    if pid == 0:                                  # child
+        os.execvp(argv[0], argv)
+        os._exit(127)                             # unreachable on success
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    chunks = []
+    while True:
+        if not select.select([fd], [], [], 60)[0]:
+            break                                 # hung; let the assert report
+        try:
+            data = os.read(fd, 65536)
+        except OSError:                           # EIO: the child closed the pty
+            break
+        if not data:
+            break
+        chunks.append(data)
+    os.close(fd)
+    os.waitpid(pid, 0)
+    return b"".join(chunks)
+
+
+def _render(data, cols=COLS, rows=ROWS):
+    """Replay an ANSI stream and return every line the user saw, scrollback first.
+
+    Handles just what the progress block emits: CR, LF, cursor up/down/left/right
+    (ESC[nA..D), column set (ESC[nG), erase-below (ESC[J), erase-in-line (ESC[K)
+    and autowrap. SGR colors and cursor show/hide are consumed and ignored.
+    """
+    grid = [[" "] * cols for _ in range(rows)]
+    scrollback = []
+    cy = cx = 0
+    wrap_pending = False
+
+    def newline():
+        nonlocal cy, wrap_pending
+        wrap_pending = False
+        cy += 1
+        if cy >= rows:
+            scrollback.append("".join(grid[0]).rstrip())
+            grid.pop(0)
+            grid.append([" "] * cols)
+            cy = rows - 1
+
+    i, n = 0, len(data)
+    while i < n:
+        if data[i:i + 1] == b"\x1b":
+            m = _CSI.match(data, i)
+            if not m:
+                i += 1
+                continue
+            nums = [int(x) for x in m.group(1).split(b";") if x.isdigit()]
+            arg = nums[0] if nums else None
+            cmd = m.group(2)
+            if cmd == b"A":
+                cy, wrap_pending = max(0, cy - (arg or 1)), False
+            elif cmd == b"B":
+                cy, wrap_pending = min(rows - 1, cy + (arg or 1)), False
+            elif cmd == b"C":
+                cx = min(cols - 1, cx + (arg or 1))
+            elif cmd == b"D":
+                cx = max(0, cx - (arg or 1))
+            elif cmd == b"G":
+                cx, wrap_pending = (arg or 1) - 1, False
+            elif cmd == b"J" and (arg or 0) == 0:
+                grid[cy][cx:] = [" "] * (cols - cx)
+                for y in range(cy + 1, rows):
+                    grid[y] = [" "] * cols
+            elif cmd == b"K" and (arg or 0) == 0:
+                grid[cy][cx:] = [" "] * (cols - cx)
+            i = m.end()
+            continue
+
+        ch = data[i:i + 1]
+        if ch == b"\r":
+            cx, wrap_pending = 0, False
+            i += 1
+            continue
+        if ch == b"\n":
+            cx = 0
+            newline()
+            i += 1
+            continue
+        if ch == b"\b":
+            cx, wrap_pending = max(0, cx - 1), False
+            i += 1
+            continue
+
+        # One UTF-8 character (the block draws braille and box glyphs).
+        b0 = data[i]
+        width = 1 if b0 < 0x80 else 2 if b0 < 0xE0 else 3 if b0 < 0xF0 else 4
+        try:
+            char = data[i:i + width].decode()
+        except UnicodeDecodeError:
+            char = "?"
+        if wrap_pending:
+            cx = 0
+            newline()
+        grid[cy][cx] = char
+        if cx + 1 >= cols:
+            wrap_pending = True
+        else:
+            cx += 1
+        i += width
+
+    return scrollback + ["".join(row).rstrip() for row in grid]
+
+
+@requires_reflink
+@unittest.skipIf(os.geteuid() == 0,
+                 "running as root defeats the chmod 000 unreadable files")
+class ProgressTtyTest(DuperemoveTest):
+    def build_tree(self):
+        """A tree with duplicates to dedupe and two files the hasher cannot open.
+
+        The unreadable pair is what makes the run print in the scan/dedupe gap:
+        each one fails open() in csum_whole_file and lands in the walk's
+        permission-denied skip bucket, which report_scan_skips() summarises
+        there.
+        """
+        for i in range(8):
+            self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 256 * 1024)
+        for i in range(2):
+            path = self.mkrand(f"tree/locked/{i}.bin", 64 * 1024)
+            os.chmod(path, 0)
+        self.sync()
+        return os.path.join(self.work, "tree")
+
+    def dedupe_in_pty(self):
+        tree = self.build_tree()
+        raw = _run_in_pty([DUPEREMOVE, "-dr", "--hashfile", self.hf, tree])
+        return _render(raw)
+
+    def test_no_worker_rows_survive_the_run(self):
+        """Once the run is over, every worker row must have been erased.
+
+        pdedupe_end() wipes the block and leaves only the ticked stage line, so
+        any surviving "  1  idle" is by definition a row a redraw homed past.
+        """
+        screen = self.dedupe_in_pty()
+        stranded = [ln for ln in screen if WORKER_ROW.match(ln)]
+        self.assertEqual([], stranded,
+                         "worker rows left on screen:\n  " +
+                         "\n  ".join(stranded) + "\n\nfull screen:\n  " +
+                         "\n  ".join(screen))
+
+    def test_scan_skip_report_survives_the_block(self):
+        """The message printed in the gap must still be readable afterwards.
+
+        The same desync ate it: the next redraw homed one row too low and its
+        erase-below wiped the line that had just been printed below the block.
+        """
+        screen = self.dedupe_in_pty()
+        self.assertTrue(
+            any("2 permission denied" in ln for ln in screen),
+            "the scan-skip report was erased by the progress block:\n  " +
+            "\n  ".join(screen))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -1,34 +1,27 @@
 """The live progress block must not strand rows in the scrollback (#179).
 
-The block is drawn at the bottom of the screen and redrawn in place by moving
-the cursor up ``drawn_lines`` rows. Anything printed while it is on screen has
-to be routed through ``pscan_printf()``, which erases the block first; a plain
-``printf`` moves the cursor down without ``drawn_lines`` following, so the next
-redraw homes *into* the block and leaves the rows it skipped on screen forever
--- and erases the message that caused it.
+The block owns the bottom of the screen and is redrawn in place by moving the
+cursor up ``drawn_lines`` rows, so everything else has to be printed through
+``progress_printf()``, which erases the block first. A plain ``printf`` moves
+the cursor down without ``drawn_lines`` following, and the next redraw homes
+*into* the block: the rows above the landing point are stranded on screen and
+the message that caused it is erased.
 
-That only happens on a tty, which is why the rest of the suite (pipes) cannot
-see it: these tests run oans under a real pty of a fixed size and replay the
-byte stream through a small ANSI emulator to get the screen a user would see.
-
-The window that regressed is between the scan and the dedupe phase: the scan
-deliberately leaves its block up for the dedupe phase to keep drawing
-(pscan_join(continues=True)) and no printer thread is alive across the gap, so
-routing keyed on "is a printer running" took the raw branch there.
+Only reproducible on a tty, which is why the rest of the suite (pipes) cannot
+see it. This runs oans under a real pty and replays the byte stream through a
+small ANSI emulator to get the screen a user would actually see.
 """
 
+import fcntl
 import os
 import pty
 import re
 import select
 import struct
-import sys
 import termios
-import fcntl
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from harness import DUPEREMOVE, DuperemoveTest, requires_reflink  # noqa: E402
+from harness import DUPEREMOVE, DuperemoveTest, requires_reflink
 
 COLS, ROWS = 100, 30
 
@@ -38,13 +31,15 @@ WORKER_ROW = re.compile(r"^ {2}\d+ {2}(idle|hashing|mapping|commit|wait lock|ded
 _CSI = re.compile(rb"\x1b\[([0-9;?]*)([A-Za-z])")
 
 
-def _run_in_pty(argv, cols=COLS, rows=ROWS):
-    """Run argv on a pty of the given size; return its raw output bytes."""
+def _run_in_pty(argv):
+    """Run argv on a COLS x ROWS pty; return its raw output bytes."""
     pid, fd = pty.fork()
     if pid == 0:                                  # child
-        os.execvp(argv[0], argv)
-        os._exit(127)                             # unreachable on success
-    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+        try:
+            os.execvp(argv[0], argv)
+        finally:                                  # execvp raises, never returns
+            os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
     chunks = []
     while True:
         if not select.select([fd], [], [], 60)[0]:
@@ -61,27 +56,25 @@ def _run_in_pty(argv, cols=COLS, rows=ROWS):
     return b"".join(chunks)
 
 
-def _render(data, cols=COLS, rows=ROWS):
+def _render(data):
     """Replay an ANSI stream and return every line the user saw, scrollback first.
 
-    Handles just what the progress block emits: CR, LF, cursor up/down/left/right
-    (ESC[nA..D), column set (ESC[nG), erase-below (ESC[J), erase-in-line (ESC[K)
-    and autowrap. SGR colors and cursor show/hide are consumed and ignored.
+    Handles exactly what oans emits: CR, LF, cursor-up (``ESC[nA``),
+    erase-below (``ESC[J``), erase-in-line (``ESC[K``) and line wrapping. Cursor
+    show/hide and SGR colors are matched and ignored, as is any other CSI.
     """
-    grid = [[" "] * cols for _ in range(rows)]
+    grid = [[" "] * COLS for _ in range(ROWS)]
     scrollback = []
     cy = cx = 0
-    wrap_pending = False
 
     def newline():
-        nonlocal cy, wrap_pending
-        wrap_pending = False
+        nonlocal cy
         cy += 1
-        if cy >= rows:
+        if cy >= ROWS:
             scrollback.append("".join(grid[0]).rstrip())
             grid.pop(0)
-            grid.append([" "] * cols)
-            cy = rows - 1
+            grid.append([" "] * COLS)
+            cy = ROWS - 1
 
     i, n = 0, len(data)
     while i < n:
@@ -90,31 +83,21 @@ def _render(data, cols=COLS, rows=ROWS):
             if not m:
                 i += 1
                 continue
-            nums = [int(x) for x in m.group(1).split(b";") if x.isdigit()]
-            arg = nums[0] if nums else None
-            cmd = m.group(2)
+            params, cmd = m.group(1), m.group(2)
+            arg = int(params) if params.isdigit() else 0
             if cmd == b"A":
-                cy, wrap_pending = max(0, cy - (arg or 1)), False
-            elif cmd == b"B":
-                cy, wrap_pending = min(rows - 1, cy + (arg or 1)), False
-            elif cmd == b"C":
-                cx = min(cols - 1, cx + (arg or 1))
-            elif cmd == b"D":
-                cx = max(0, cx - (arg or 1))
-            elif cmd == b"G":
-                cx, wrap_pending = (arg or 1) - 1, False
-            elif cmd == b"J" and (arg or 0) == 0:
-                grid[cy][cx:] = [" "] * (cols - cx)
-                for y in range(cy + 1, rows):
-                    grid[y] = [" "] * cols
-            elif cmd == b"K" and (arg or 0) == 0:
-                grid[cy][cx:] = [" "] * (cols - cx)
+                cy = max(0, cy - max(arg, 1))
+            elif cmd in (b"J", b"K") and arg == 0:
+                grid[cy][cx:] = [" "] * (COLS - cx)
+                if cmd == b"J":
+                    for y in range(cy + 1, ROWS):
+                        grid[y] = [" "] * COLS
             i = m.end()
             continue
 
         ch = data[i:i + 1]
         if ch == b"\r":
-            cx, wrap_pending = 0, False
+            cx = 0
             i += 1
             continue
         if ch == b"\n":
@@ -122,26 +105,22 @@ def _render(data, cols=COLS, rows=ROWS):
             newline()
             i += 1
             continue
-        if ch == b"\b":
-            cx, wrap_pending = max(0, cx - 1), False
-            i += 1
-            continue
 
-        # One UTF-8 character (the block draws braille and box glyphs).
+        # One UTF-8 character (the block draws braille bar cells and ticks).
         b0 = data[i]
         width = 1 if b0 < 0x80 else 2 if b0 < 0xE0 else 3 if b0 < 0xF0 else 4
         try:
             char = data[i:i + width].decode()
         except UnicodeDecodeError:
             char = "?"
-        if wrap_pending:
+        # Wrap on write, not on reaching the edge: a line of exactly COLS
+        # characters followed by a newline occupies one row, as on a real
+        # terminal (the long routed error messages depend on this).
+        if cx >= COLS:
             cx = 0
             newline()
         grid[cy][cx] = char
-        if cx + 1 >= cols:
-            wrap_pending = True
-        else:
-            cx += 1
+        cx += 1
         i += width
 
     return scrollback + ["".join(row).rstrip() for row in grid]
@@ -151,51 +130,36 @@ def _render(data, cols=COLS, rows=ROWS):
 @unittest.skipIf(os.geteuid() == 0,
                  "running as root defeats the chmod 000 unreadable files")
 class ProgressTtyTest(DuperemoveTest):
-    def build_tree(self):
-        """A tree with duplicates to dedupe and two files the hasher cannot open.
+    def test_block_leaves_nothing_behind(self):
+        """Nothing of the block survives the run, and no message is eaten.
 
-        The unreadable pair is what makes the run print in the scan/dedupe gap:
-        each one fails open() in csum_whole_file and lands in the walk's
-        permission-denied skip bucket, which report_scan_skips() summarises
-        there.
+        Two halves of one screen, so one run answers both. ``pdedupe_end()``
+        wipes the block and leaves only the ticked stage line, so any surviving
+        "  1  idle" is by definition a row a redraw homed past -- an invariant
+        that holds for an unrouted print in *any* phase, not just the scan/dedupe
+        gap that regressed. The skip report is the message that gap's desync
+        erased.
         """
+        # The two unreadable files are what makes the run print in the gap:
+        # each fails open() in csum_whole_file and lands in the walk's
+        # permission-denied bucket, which report_scan_skips() summarises there.
         for i in range(8):
             self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 256 * 1024)
         for i in range(2):
-            path = self.mkrand(f"tree/locked/{i}.bin", 64 * 1024)
-            os.chmod(path, 0)
-        self.sync()
-        return os.path.join(self.work, "tree")
+            os.chmod(self.mkrand(f"tree/locked/{i}.bin", 64 * 1024), 0)
+        tree = os.path.join(self.work, "tree")
 
-    def dedupe_in_pty(self):
-        tree = self.build_tree()
-        raw = _run_in_pty([DUPEREMOVE, "-dr", "--hashfile", self.hf, tree])
-        return _render(raw)
+        screen = _render(_run_in_pty(
+            [DUPEREMOVE, "-dr", "--hashfile", self.hf, tree]))
+        shown = "\n  ".join(screen)
 
-    def test_no_worker_rows_survive_the_run(self):
-        """Once the run is over, every worker row must have been erased.
-
-        pdedupe_end() wipes the block and leaves only the ticked stage line, so
-        any surviving "  1  idle" is by definition a row a redraw homed past.
-        """
-        screen = self.dedupe_in_pty()
         stranded = [ln for ln in screen if WORKER_ROW.match(ln)]
         self.assertEqual([], stranded,
-                         "worker rows left on screen:\n  " +
-                         "\n  ".join(stranded) + "\n\nfull screen:\n  " +
-                         "\n  ".join(screen))
-
-    def test_scan_skip_report_survives_the_block(self):
-        """The message printed in the gap must still be readable afterwards.
-
-        The same desync ate it: the next redraw homed one row too low and its
-        erase-below wiped the line that had just been printed below the block.
-        """
-        screen = self.dedupe_in_pty()
+                         f"worker rows left on screen:\n  {chr(10).join(stranded)}"
+                         f"\n\nfull screen:\n  {shown}")
         self.assertTrue(
             any("2 permission denied" in ln for ln in screen),
-            "the scan-skip report was erased by the progress block:\n  " +
-            "\n  ".join(screen))
+            f"the scan-skip report was erased by the block:\n  {shown}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #179.

## What was happening

The live block is redrawn by moving the cursor up `drawn_lines`, so anything printed while it is on screen has to be routed through the block-aware printer (erase → message → redraw). The routing decision was `is_progress_printer_running()`.

But **"a block is on screen" is not the same question as "a printer thread is running."** The scan deliberately leaves its block up for the dedupe phase (`pscan_join(continues=true)` … `pdedupe_begin()`) and no printer is alive across that gap. `report_scan_skips()` prints exactly there, with a plain `printf`.

So the cursor moved down a row, `drawn_lines` did not, and the next `progress_home()` landed one row *inside* the block. Straight from the captured pty stream:

```
<ESC[J>  Skipped   2 permission denied ...<CR><LF>   <- unrouted, drawn_lines still 12
<ESC[?25l><ESC[12A><CR><ESC[J>Hashfile "..." written  <- up 12 from 13 rows below the block top
```

One stranded worker row per unrouted line — which is why a `/home` full of short-lived browser cache files reproduces it: every `csum_whole_file` failure feeds the permission/ENOENT skip buckets, so that report is always non-empty there.

**It was not purely cosmetic.** The erase-below at the too-low landing point also wiped the line that had just been printed, so the `N permission denied` summary was destroyed on every run that had one.

The issue's two ruled-out theories were both right to rule out: line wrapping is not involved, and the routed path was indeed behaving correctly — the desync came from a message that never entered it.

## The fix

Two commits: the fix, then a cleanup pass over it (`/simplify`).

- **`progress_printf(FILE *stream, fmt, ...)`** in `progress.c` is now the single entry point, and it decides on `printer || block_live()` — a file-static predicate rather than two exported ones. `progress.h` exports no state predicates and `drawn_lines` is read only in its own TU. `is_progress_printer_running()` and `pscan_printf()` are gone; each had exactly one caller (the `progress_print` macro), so there was nothing to keep them for. `progress_home()` also stops open-coding `tty && drawn_lines`.
- The `format(printf, 2, 3)` attribute that comes with a real function now type-checks all four of `dprintf`/`vprintf`/`qprintf`/`eprintf`.
- **`report_scan_skips()`** assembles its whole report in a `GString` and emits it in one call — one call is one erase/print/redraw cycle, so a line printed piecewise would redraw the block between the pieces. While rewriting it, the pre-pass that summed the error buckets just to decide whether to print a header is gone (the second loop's lazy-header idiom does it in one pass).
- **`report_scan_stats()`**'s two diagnostics use `eprintf` — same window.

Non-tty output is byte-identical (`block_live()` is gated on `tty`), so `scripts/bench.py`, which pipes, still gets `scan-stats` on stderr — verified.

## Known gap, deliberately not fixed here

A routed `eprintf` lands on **stdout**, because the block lives on stdout and the printer only knows that stream. So an error's destination depends on whether a block happened to be up. That is pre-existing, this PR only makes it visible; fixing it means flushing across two streams mid-redraw and moves every scan-time error from stdout to stderr — a user-visible change that deserves its own issue. Recorded in CLAUDE.md.

## Testing

`tests/integration/test_progress_tty.py` runs oans under a real pty and replays the byte stream through a ~50-line ANSI emulator, per the issue's suggestion. Its invariant is deliberately broader than this call site: **no worker-slot row may survive the end of a run** (`pdedupe_end()` wipes the block, so any surviving `  1  idle` is by definition a row a redraw homed past). It also asserts the skip report is still readable afterwards. It fails on the parent commit with `['  1  idle']`.

Also checked by hand at 80/100/200 columns, with unreadable files scattered through the scan so messages land mid-block as well as in the gap, and across `-r` / `-drv` / `-dr -q` / `--min-filesize`.

`scripts/verify.sh` passes (build clean, 185 tests, valgrind smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)