### PR TITLE
dedupe: converge in one run instead of re-deduping every run (#186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,63 @@ extent passes. Lives in `run_dedupe.c` (`dedupe_phase_begin/end`,
   makes a fast worker win too rarely); producer-vs-worker lifetime rules need
   review, not just the suite.
 
+## Dedupe must converge — the already-shared skip (#186)
+
+**A second `-d` run over an unchanged tree must reclaim 0.** Nothing in the
+output tells you when it doesn't: `FIDEDUPERANGE` returns `bytes_deduped` for a
+range that already shares storage, so a run that frees nothing still reports
+gigabytes. On a 415 GiB home, `oans -dr ~/` claimed **6.6 GiB every single run**
+with a measured free-space change of **0**. Check convergence by *repeating the
+command*, not by reading the summary.
+
+Three separate causes, each worth a fix; the numbers are successive stages on
+that same tree (6.6 GiB → 1.4 GiB → 131 MiB → 21.3 MiB → **0 B**):
+
+- **`clean_deduped()` culls against the target, not pairwise.** It used to
+  collapse a group to one survivor per distinct physical offset. Only that
+  survivor is repointed by the ioctl, so the rest of its class stayed on the old
+  extent and that extent was never freed — one copy moved per run, nothing
+  reclaimed until the last one landed. **Whole-file groups load with `poff = 0`**
+  (`GET_DUPLICATE_FILES` has no fiemap to draw on) so they never hit this, which
+  is why `--dedupe-options=only_whole_files` converged where the default did not.
+  That asymmetry is the diagnostic — if only_whole_files converges, suspect the
+  extent path.
+- **`fiemap_range_shared_with()` compares coverage, not extent records.** The
+  same shared storage is described with different record boundaries in each
+  file: a dedupe stops on a block boundary and splits the destination's tail
+  where the target has one record. Record-for-record equality reads that as "not
+  shared" and resubmits the whole file forever. **Never do `fe_physical + delta`
+  arithmetic** — on a compressed extent `fe_physical` addresses the compressed
+  extent as a whole, so an offset into it is meaningless; compare `fe_physical`
+  for equality only, at points where both sides sit the same distance into their
+  record. Holes count too: fiemap omits them, matching holes on both sides *are*
+  shared (a browser cache is mostly hole), and a hole facing data is not.
+- **Compare whole blocks only.** The kernel rounds a dedupe length down to a
+  filesystem block, so a trailing partial block can never be shared and
+  comparing it makes the check permanently unsatisfiable. Trim with
+  `dedupe_blocksize()` — but **fall back to the untrimmed length below one
+  block**, or the skip is silently disabled for every sub-block file (that alone
+  was the last 21.3 MiB).
+
+Diagnosing this class: **bisect by scope.** Every subdirectory and every *pair*
+of subdirectories converged while their union did not — that pattern means the
+group got bigger, not that some directory is cursed.
+
+Pinned by `tests/integration/test_dedupe_idempotent.py`,
+`test_extent_dedupe.py::test_group_on_two_physical_extents_converges_in_one_run`
+and the `test_fiemap_maps_share` unit test (the map walk is pure and worth
+testing directly — synthetic fiemap records beat coaxing btrfs into a layout).
+
+Two traps when writing tests here, both of which make a test pass while testing
+nothing:
+
+- **coreutils `cp` and `cat` reflink.** They go through `copy_file_range()`,
+  which btrfs implements as a clone — `cp --reflink=never` does *not* give you
+  an independent copy. Use `dd`, or write the bytes from python.
+- **A file below btrfs `max_inline` (2048 by default) is stored inline**, has no
+  physical location, and the kernel declines to dedupe it. Any "reclaimed 0"
+  assertion on such a file holds no matter what the code does.
+
 ## Dedupe progress is byte-weighted (not group-counted)
 
 The dedupe bar tracks the kernel **byte-verify volume**, not a fuzzy group

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdatomic.h>
 #include <sys/vfs.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -165,16 +166,22 @@ static unsigned int get_fs_blocksize(int fd)
  * stays 0 until a request actually comes back EINVAL, and so doubles as "this
  * kernel will not shorten for us" - this is always a real value.
  *
- * Racy by design: concurrent dedupe workers may all query it, but they compute
- * the same value from the same filesystem, so the store is idempotent.
+ * Every dedupe worker reaches this, so the cache is atomic. Relaxed is enough:
+ * racing threads all store the same value (one filesystem, one fstatfs answer),
+ * and the only ordering that matters is that a reader sees either 0 or that
+ * value. A plain int here is a genuine data race, not a benign one - TSan flags
+ * it, and the compiler is entitled to reload it.
  */
 static unsigned int cached_blocksize(int fd)
 {
-	static unsigned int cached;
+	static _Atomic unsigned int cached;
+	unsigned int bs = atomic_load_explicit(&cached, memory_order_relaxed);
 
-	if (!cached)
-		cached = get_fs_blocksize(fd);
-	return cached;
+	if (!bs) {
+		bs = get_fs_blocksize(fd);
+		atomic_store_explicit(&cached, bs, memory_order_relaxed);
+	}
+	return bs;
 }
 
 uint64_t dedupe_shareable_len(int fd, uint64_t len)

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -161,21 +161,29 @@ static unsigned int get_fs_blocksize(int fd)
 }
 
 /*
- * Block size the kernel will align a dedupe request to, cached after the first
- * query. Unlike fs_blocksize above - which stays 0 until a request actually
- * comes back EINVAL - this is always a real value, because callers need it
- * before they submit anything.
+ * The filesystem's block size, queried once. Unlike fs_blocksize above - which
+ * stays 0 until a request actually comes back EINVAL, and so doubles as "this
+ * kernel will not shorten for us" - this is always a real value.
  *
  * Racy by design: concurrent dedupe workers may all query it, but they compute
  * the same value from the same filesystem, so the store is idempotent.
  */
-unsigned int dedupe_blocksize(int fd)
+static unsigned int cached_blocksize(int fd)
 {
 	static unsigned int cached;
 
 	if (!cached)
 		cached = get_fs_blocksize(fd);
 	return cached;
+}
+
+uint64_t dedupe_shareable_len(int fd, uint64_t len)
+{
+	unsigned int bs = cached_blocksize(fd);
+
+	/* Under a block there is nothing to round down to - the kernel takes
+	 * such a range whole or not at all. */
+	return len < bs ? len : len & ~((uint64_t)bs - 1);
 }
 
 struct dedupe_ctxt *new_dedupe_ctxt(unsigned int max_extents, uint64_t loff,
@@ -269,8 +277,11 @@ static void set_aligned_same_length(struct dedupe_ctxt *ctxt,
 	same->src_length = ctxt->len;
 	if (same->src_length > DEDUPE_ROUND_LEN)
 		same->src_length = DEDUPE_ROUND_LEN;
-	if (fs_blocksize != 0 && same->src_length > fs_blocksize)
-		same->src_length &= ~((uint64_t)fs_blocksize - 1);
+	/* Only once we know this kernel returns EINVAL rather than shortening
+	 * for us; the rounding rule itself is dedupe_shareable_len's. */
+	if (fs_blocksize != 0)
+		same->src_length = dedupe_shareable_len(ctxt->ioctl_file->fd,
+							same->src_length);
 }
 
 static void populate_dedupe_request(struct dedupe_ctxt *ctxt,
@@ -459,7 +470,7 @@ retry:
 			print_btrfs_same_info(ctxt);
 
 		if (ctxt->same->info[0].status == -EINVAL && !fs_blocksize) {
-			fs_blocksize = get_fs_blocksize(ctxt->ioctl_file->fd);
+			fs_blocksize = cached_blocksize(ctxt->ioctl_file->fd);
 			set_aligned_same_length(ctxt, ctxt->same);
 			goto retry;
 		}

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -160,6 +160,24 @@ static unsigned int get_fs_blocksize(int fd)
 	return fs.f_bsize;
 }
 
+/*
+ * Block size the kernel will align a dedupe request to, cached after the first
+ * query. Unlike fs_blocksize above - which stays 0 until a request actually
+ * comes back EINVAL - this is always a real value, because callers need it
+ * before they submit anything.
+ *
+ * Racy by design: concurrent dedupe workers may all query it, but they compute
+ * the same value from the same filesystem, so the store is idempotent.
+ */
+unsigned int dedupe_blocksize(int fd)
+{
+	static unsigned int cached;
+
+	if (!cached)
+		cached = get_fs_blocksize(fd);
+	return cached;
+}
+
 struct dedupe_ctxt *new_dedupe_ctxt(unsigned int max_extents, uint64_t loff,
 				    uint64_t elen, struct filerec *ioctl_file)
 {

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -70,6 +70,14 @@ struct dedupe_ctxt *new_dedupe_ctxt(unsigned int max_extents, uint64_t loff,
 void free_dedupe_ctxt(struct dedupe_ctxt *ctxt);
 
 /*
+ * Block size a dedupe request gets aligned to. The kernel rounds the length
+ * down to a multiple of it (generic_remap_check_len()), so the trailing
+ * partial block of a file whose size is not a multiple can never be shared.
+ * Callers that reason about what the kernel *would* share need this.
+ */
+unsigned int dedupe_blocksize(int fd);
+
+/*
  * add_extent_to_dedupe returns:
  *  < 0: error
  * == 0: no more extents after this one

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -70,12 +70,16 @@ struct dedupe_ctxt *new_dedupe_ctxt(unsigned int max_extents, uint64_t loff,
 void free_dedupe_ctxt(struct dedupe_ctxt *ctxt);
 
 /*
- * Block size a dedupe request gets aligned to. The kernel rounds the length
- * down to a multiple of it (generic_remap_check_len()), so the trailing
- * partial block of a file whose size is not a multiple can never be shared.
- * Callers that reason about what the kernel *would* share need this.
+ * How much of a `len`-byte dedupe request the kernel would actually share:
+ * it rounds the length down to a whole filesystem block
+ * (generic_remap_check_len()), so a trailing partial block never gets shared.
+ * A range under one block is returned unchanged - there is nothing to round
+ * down to, and the kernel takes it whole or not at all.
+ *
+ * The one rule, for both the code that submits requests and the code that
+ * reasons about what a request would achieve.
  */
-unsigned int dedupe_blocksize(int fd);
+uint64_t dedupe_shareable_len(int fd, uint64_t len);
 
 /*
  * add_extent_to_dedupe returns:

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -218,32 +218,40 @@ int fiemap_count_shared(int fd, size_t start_off, size_t end_off, uint64_t *shar
 			FIEMAP_EXTENT_DATA_INLINE)
 
 /*
+ * Unallocated bytes at `off`: fiemap omits holes, so a gap before the record -
+ * or having run out of records - is one. `rest` is what remains of the range.
+ */
+static uint64_t gap_at(const struct fiemap_extent *e, uint64_t off, uint64_t rest)
+{
+	if (!e)
+		return rest;
+	return e->fe_logical > off ? e->fe_logical - off : 0;
+}
+
+/*
  * Do the two ranges already resolve to the same stored extents, so that
  * deduping the destination against the target would change nothing?
  *
- * `len` must already be trimmed to what the kernel would actually dedupe (see
- * dedupe_blocksize()); a range's trailing partial block can never be shared,
- * so comparing it would make this permanently unsatisfiable.
+ * `len` must already be what the kernel would actually dedupe (see
+ * dedupe_shareable_len()); see fiemap.h.
  *
- * The walk covers the range rather than comparing extent records one for one.
- * The same shared storage can be described with different record boundaries in
- * each file - a dedupe that stopped on a block boundary leaves the destination
- * with a split tail where the target has one record - and record-for-record
- * equality reads that as "not shared", so the whole file gets resubmitted to
- * the kernel on every run (#186).
+ * This walks the range instead of comparing extent records one for one,
+ * because the same storage gets described with different record boundaries in
+ * each file - the split tail a dedupe leaves behind is enough - and treating
+ * that as "not shared" resubmits the whole file to the kernel on every run
+ * (#186). Holes count as shared when both sides have one.
  *
  * fe_physical is only ever compared for equality, never with an offset added:
  * on a compressed extent it addresses the compressed extent as a whole, so
- * physical + logical_delta is meaningless. Records that begin before the range
- * are handled by requiring both sides to start the same distance into the same
- * stored extent. Extents with no real physical location (delalloc, unknown,
- * inline) all report fe_physical 0 and must never count as shared.
+ * physical + logical_delta is meaningless. Extents with no real physical
+ * location (delalloc, unknown, inline) all report fe_physical 0 and must never
+ * count as shared.
  */
 static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 			      const struct fiemap *dm, uint64_t dest_off,
 			      uint64_t len)
 {
-	unsigned int ia = 0, ib = 0;
+	unsigned int i = 0;	/* both maps advance together, or we bail */
 	uint64_t pos = 0;	/* bytes of the range proven shared so far */
 
 	if (len == 0 || !tgt || !dm || tgt->fm_mapped_extents == 0)
@@ -253,29 +261,18 @@ static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 		const struct fiemap_extent *ea, *eb;
 		uint64_t pa, pb;	/* range position, relative to the record */
 		uint64_t ha, hb;	/* unallocated bytes at this position */
-		uint64_t ra, rb, step;
+		uint64_t ra, rb;
 
-		ea = ia < tgt->fm_mapped_extents ? &tgt->fm_extents[ia] : NULL;
-		eb = ib < dm->fm_mapped_extents ? &dm->fm_extents[ib] : NULL;
+		ea = i < tgt->fm_mapped_extents ? &tgt->fm_extents[i] : NULL;
+		eb = i < dm->fm_mapped_extents ? &dm->fm_extents[i] : NULL;
 
-		/*
-		 * fiemap omits holes, so a gap before the next record - or
-		 * running out of records - means unallocated space. Sparse
-		 * files are common (a browser cache is mostly hole), and two
-		 * files with the same hole layout share it just fine; only a
-		 * hole facing data on the other side is a real difference.
-		 */
-		ha = !ea ? len - pos :
-			(ea->fe_logical > tgt_off + pos ?
-			 ea->fe_logical - (tgt_off + pos) : 0);
-		hb = !eb ? len - pos :
-			(eb->fe_logical > dest_off + pos ?
-			 eb->fe_logical - (dest_off + pos) : 0);
+		ha = gap_at(ea, tgt_off + pos, len - pos);
+		hb = gap_at(eb, dest_off + pos, len - pos);
 		if (ha || hb) {
-			if (!ha || !hb)
+			/* A hole facing data is a real difference. */
+			if (ha != hb)
 				return false;
-			step = ha < hb ? ha : hb;
-			pos += step > len - pos ? len - pos : step;
+			pos += ha;
 			continue;
 		}
 
@@ -294,10 +291,8 @@ static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 
 		ra = ea->fe_length - pa;
 		rb = eb->fe_length - pb;
-		step = ra < rb ? ra : rb;
-		pos += step > len - pos ? len - pos : step;
-		ia++;
-		ib++;
+		pos += ra < rb ? ra : rb;
+		i++;
 
 		/*
 		 * Same storage, different record boundaries. The shorter side
@@ -312,12 +307,13 @@ static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 	return true;
 }
 
-/* Map the destination range and compare it with the target's map. */
 bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
 			      int dest_fd, uint64_t dest_off, uint64_t len)
 {
 	_cleanup_(freep) struct fiemap *dm = NULL;
 
+	/* Cheap reject before paying for the destination's map: a target we
+	 * could not map is nothing to compare against. */
 	if (len == 0 || !tgt || tgt->fm_mapped_extents == 0)
 		return false;
 

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -217,6 +217,102 @@ int fiemap_count_shared(int fd, size_t start_off, size_t end_off, uint64_t *shar
 #define FIEMAP_NO_PHYS (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_DELALLOC | \
 			FIEMAP_EXTENT_DATA_INLINE)
 
+/*
+ * Do the two ranges already resolve to the same stored extents, so that
+ * deduping the destination against the target would change nothing?
+ *
+ * `len` must already be trimmed to what the kernel would actually dedupe (see
+ * dedupe_blocksize()); a range's trailing partial block can never be shared,
+ * so comparing it would make this permanently unsatisfiable.
+ *
+ * The walk covers the range rather than comparing extent records one for one.
+ * The same shared storage can be described with different record boundaries in
+ * each file - a dedupe that stopped on a block boundary leaves the destination
+ * with a split tail where the target has one record - and record-for-record
+ * equality reads that as "not shared", so the whole file gets resubmitted to
+ * the kernel on every run (#186).
+ *
+ * fe_physical is only ever compared for equality, never with an offset added:
+ * on a compressed extent it addresses the compressed extent as a whole, so
+ * physical + logical_delta is meaningless. Records that begin before the range
+ * are handled by requiring both sides to start the same distance into the same
+ * stored extent. Extents with no real physical location (delalloc, unknown,
+ * inline) all report fe_physical 0 and must never count as shared.
+ */
+static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
+			      const struct fiemap *dm, uint64_t dest_off,
+			      uint64_t len)
+{
+	unsigned int ia = 0, ib = 0;
+	uint64_t pos = 0;	/* bytes of the range proven shared so far */
+
+	if (len == 0 || !tgt || !dm || tgt->fm_mapped_extents == 0)
+		return false;
+
+	while (pos < len) {
+		const struct fiemap_extent *ea, *eb;
+		uint64_t pa, pb;	/* range position, relative to the record */
+		uint64_t ha, hb;	/* unallocated bytes at this position */
+		uint64_t ra, rb, step;
+
+		ea = ia < tgt->fm_mapped_extents ? &tgt->fm_extents[ia] : NULL;
+		eb = ib < dm->fm_mapped_extents ? &dm->fm_extents[ib] : NULL;
+
+		/*
+		 * fiemap omits holes, so a gap before the next record - or
+		 * running out of records - means unallocated space. Sparse
+		 * files are common (a browser cache is mostly hole), and two
+		 * files with the same hole layout share it just fine; only a
+		 * hole facing data on the other side is a real difference.
+		 */
+		ha = !ea ? len - pos :
+			(ea->fe_logical > tgt_off + pos ?
+			 ea->fe_logical - (tgt_off + pos) : 0);
+		hb = !eb ? len - pos :
+			(eb->fe_logical > dest_off + pos ?
+			 eb->fe_logical - (dest_off + pos) : 0);
+		if (ha || hb) {
+			if (!ha || !hb)
+				return false;
+			step = ha < hb ? ha : hb;
+			pos += step > len - pos ? len - pos : step;
+			continue;
+		}
+
+		if ((ea->fe_flags | eb->fe_flags) & FIEMAP_NO_PHYS)
+			return false;
+
+		/*
+		 * Both sides must be on the same stored extent at the same
+		 * offset into it. pa/pb are nonzero only for a first record
+		 * that begins before the range.
+		 */
+		pa = tgt_off + pos - ea->fe_logical;
+		pb = dest_off + pos - eb->fe_logical;
+		if (pa != pb || ea->fe_physical != eb->fe_physical)
+			return false;
+
+		ra = ea->fe_length - pa;
+		rb = eb->fe_length - pb;
+		step = ra < rb ? ra : rb;
+		pos += step > len - pos ? len - pos : step;
+		ia++;
+		ib++;
+
+		/*
+		 * Same storage, different record boundaries. The shorter side
+		 * continues in its next record, but lining the maps back up
+		 * would need the offset arithmetic ruled out above - so accept
+		 * it only when the range is already covered, which is the split
+		 * tail this walk exists for.
+		 */
+		if (ra != rb && pos < len)
+			return false;
+	}
+	return true;
+}
+
+/* Map the destination range and compare it with the target's map. */
 bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
 			      int dest_fd, uint64_t dest_off, uint64_t len)
 {
@@ -225,30 +321,8 @@ bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
 	if (len == 0 || !tgt || tgt->fm_mapped_extents == 0)
 		return false;
 
+	/* NULL means an error or a hole-only range: not known shared. */
 	dm = do_fiemap_range(dest_fd, dest_off, len);
-	/* NULL means an error or a hole-only range; treat as "not known shared". */
-	if (!dm || dm->fm_mapped_extents != tgt->fm_mapped_extents)
-		return false;
 
-	/*
-	 * The ranges share all storage iff their extent maps are identical:
-	 * same count, and every extent at the same position in the range points
-	 * at the same physical offset for the same length. On btrfs a physical
-	 * offset uniquely identifies a stored extent, so equal fe_physical means
-	 * the same on-disk data - deduping would change nothing. Extents with no
-	 * real physical location (delalloc/unknown/inline) all report
-	 * fe_physical 0, so they must never be treated as "shared".
-	 */
-	for (unsigned int i = 0; i < tgt->fm_mapped_extents; i++) {
-		const struct fiemap_extent *ea = &tgt->fm_extents[i];
-		const struct fiemap_extent *eb = &dm->fm_extents[i];
-
-		if ((ea->fe_flags | eb->fe_flags) & FIEMAP_NO_PHYS)
-			return false;
-		if (ea->fe_physical != eb->fe_physical ||
-		    ea->fe_length != eb->fe_length ||
-		    (ea->fe_logical - tgt_off) != (eb->fe_logical - dest_off))
-			return false;
-	}
-	return true;
+	return fiemap_maps_share(tgt, tgt_off, dm, dest_off, len);
 }

--- a/src/fiemap.h
+++ b/src/fiemap.h
@@ -46,15 +46,23 @@ int fiemap_first_extent_poff(int fd, uint64_t start, uint64_t length,
 int fiemap_count_shared(int fd, size_t start_off, size_t end_off, uint64_t *shared);
 
 /*
- * True if [dest_off, dest_off+len) on dest_fd already maps to the exact same
- * physical extents as the precomputed target map `tgt` (which describes
+ * True if [dest_off, dest_off+len) on dest_fd already resolves to the same
+ * stored extents as the precomputed target map `tgt` (which describes
  * [tgt_off, tgt_off+len)) - i.e. the two ranges share all their storage, so
  * deduping them would be a byte-for-byte no-op. The target is passed as an
  * already-fetched map so a caller comparing one target against many
- * destinations fiemaps the target only once. Conservative: returns false on
- * any fiemap failure, any difference, or any extent without a real physical
- * location, so a caller only ever skips a genuine no-op, never a real dedupe.
- * Get `tgt` from do_fiemap_range(tgt_fd, tgt_off, len).
+ * destinations fiemaps the target only once; get it from
+ * do_fiemap_range(tgt_fd, tgt_off, len).
+ *
+ * Compares coverage, not extent records: the same storage may be described
+ * with different record boundaries in each file. Matching holes count as
+ * shared. Conservative otherwise - returns false on any fiemap failure, any
+ * difference it cannot prove away, or any extent without a real physical
+ * location - so a caller only ever skips a genuine no-op, never a real dedupe.
+ *
+ * `len` must be what the kernel would actually dedupe, i.e. run it through
+ * dedupe_shareable_len() first. A trailing partial block is never shared, so
+ * including one makes this permanently false for every unaligned file.
  */
 bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
 			      int dest_fd, uint64_t dest_off, uint64_t len);

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -293,38 +293,26 @@ static int disk_extent_grew(struct dupe_extents *dext, struct extent *extent)
 }
 
 /*
- * Drop the members that already share the target's storage: deduping them
- * would be a no-op. We err on the side of more deduping here.
+ * Drop the members that already share `target`'s storage: deduping them would
+ * be a no-op. Cheap pre-filter over the poffs the scan already stored, so it
+ * saves the exact fiemap_range_shared_with() call the loop would otherwise make
+ * per destination.
  *
- * The comparison is against *the target*, deliberately - not pairwise between
- * members. Collapsing the group to one survivor per distinct physical offset
- * looks equivalent, since same-poff members really are already shared with
- * each other, but it is not: only the survivor is repointed by the ioctl, so
- * every other member of its class stays on the old extent and that extent is
- * never freed. A group with N copies sitting on the wrong extent then needs N
- * runs to converge, moving one copy per run and freeing nothing until the last
- * one lands - which on a large tree it never does (#186).
+ * The two tiers only coexist safely under one rule: **this must never cull
+ * anything fiemap_range_shared_with() would not also skip.** Both are therefore
+ * relative to the target. Culling pairwise instead - one survivor per distinct
+ * poff - is what broke that and made dedupe non-convergent; see CLAUDE.md for
+ * why (#186).
  *
- * Only the extent pass gets past the target check below. Whole-file groups are
- * loaded with poff 0 (GET_DUPLICATE_FILES has no fiemap to draw on), so they
- * keep every member and rely on the per-destination
- * fiemap_range_shared_with() skip in dedupe_extent_list() - which compares
- * against the target too, and is why whole-file dedupe never had this bug.
+ * Whole-file groups load with poff 0 (GET_DUPLICATE_FILES has no fiemap to draw
+ * on), so they bail below and lean entirely on the exact check.
  */
 static void clean_deduped(struct dupe_extents **ret_dext,
-			  struct results_tree *res)
+			  struct results_tree *res, struct extent *target)
 {
 	struct dupe_extents *dext = *ret_dext;
-	struct extent *target, *extent;
-	struct rb_node *node, *next;
-	uint64_t tgt_poff;
-
-	if (!dext || dext->de_num_dupes == 0)
-		return;
-
-	/* dedupe_extent_list() dedupes against the first list entry. */
-	target = list_first_entry(&dext->de_extents, struct extent, e_list);
-	tgt_poff = extent_poff(target);
+	struct extent *extent, *tmp;
+	uint64_t tgt_poff = extent_poff(target);
 
 	/*
 	 * A poff of 0 means fiemap failed or was never run, so we cannot tell
@@ -334,9 +322,8 @@ static void clean_deduped(struct dupe_extents **ret_dext,
 	if (tgt_poff == 0 || disk_extent_grew(dext, target))
 		return;
 
-	for (node = rb_first(&dext->de_extents_root); node; node = next) {
-		extent = rb_entry(node, struct extent, e_node);
-		next = rb_next(node);
+	list_for_each_entry_safe(extent, tmp, &dext->de_extents, e_list) {
+		unsigned int left;
 
 		if (extent == target || extent_poff(extent) != tgt_poff ||
 		    disk_extent_grew(dext, extent))
@@ -348,12 +335,13 @@ static void clean_deduped(struct dupe_extents **ret_dext,
 
 		g_mutex_lock(&mutex);
 		/* Cascades to a full free once fewer than two members remain. */
-		if (remove_extent(res, extent) == 0) {
-			g_mutex_unlock(&mutex);
+		left = remove_extent(res, extent);
+		g_mutex_unlock(&mutex);
+
+		if (left == 0) {
 			*ret_dext = NULL;
 			return;
 		}
-		g_mutex_unlock(&mutex);
 	}
 }
 
@@ -466,11 +454,13 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	struct dedupe_ctxt *ctxt = NULL;
 	struct pscan_thread *slot = gp->slot;
 	uint64_t len = dext->de_len;
-	/* Target's extent map, fetched once and reused to skip already-shared
-	 * destinations (see the shared-check below), plus the length that check
-	 * runs over: `len` trimmed to whole filesystem blocks, since that is all
-	 * the kernel would dedupe. Zero until the target is known. */
+	/* Target's extent map, used to skip already-shared destinations (see the
+	 * shared-check below). Fetched on the first destination, once the target
+	 * is open; tgt_mapped says the attempt was made, so a target we cannot
+	 * fiemap is not retried for every remaining member. */
 	_cleanup_(freep) struct fiemap *tgt_map = NULL;
+	bool tgt_mapped = false;
+	/* What that check compares: all of `len` the kernel would dedupe. */
 	uint64_t cmp_len = 0;
 	OPEN_ONCE(open_files);
 	struct extent *tgt_extent = NULL;
@@ -490,13 +480,29 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	}
 
 	shared_prev = shared_post = 0ULL;
+
+	/*
+	 * Settle the target first: it is the head of the list, and everything
+	 * below is relative to it. Ordering matters - clean_deduped() culls
+	 * against the target, so a later reorder would leave it having culled
+	 * against the wrong one.
+	 *
+	 * Only for whole files, and only when the group has no anchor from an
+	 * earlier pass - an anchored group must keep its anchor (loaded first)
+	 * as target so every pass converges the copies onto the same physical
+	 * extent. See pick_dedupe_target() for how the target is chosen.
+	 */
+	if (whole_file_dedup && !dext->de_anchored)
+		pick_dedupe_target(dext);
+
 	/*
 	 * Remove any extents which have already been deduped. This
 	 * will free dext for us if the number of available extents
 	 * goes below 2. If that happens, we return a special value so
 	 * the caller knows not to reference dext any more.
 	 */
-	clean_deduped(&dext, res);
+	clean_deduped(&dext, res,
+		      list_first_entry(&dext->de_extents, struct extent, e_list));
 	if (!dext) {
 		vprintf("[%p] Skipping - extents are already deduped.\n",
 		       g_thread_self());
@@ -509,15 +515,6 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	 */
 	if (report_net_shared)
 		add_shared_extents(dext, &shared_prev);
-
-	/*
-	 * Only for whole files, and only when the group has no anchor from an
-	 * earlier pass - an anchored group must keep its anchor (loaded first)
-	 * as target so every pass converges the copies onto the same physical
-	 * extent. See pick_dedupe_target() for how the target is chosen.
-	 */
-	if (whole_file_dedup && !dext->de_anchored)
-		pick_dedupe_target(dext);
 
 	/* clean_deduped/target selection may have changed the group; show the
 	 * real target and remaining work on this thread's status line. */
@@ -648,19 +645,13 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		 * for every destination; it never skips a real dedupe (see
 		 * fiemap_range_shared_with()).
 		 */
-		if (!tgt_map) {
-			unsigned int bs = dedupe_blocksize(tgt_extent->e_file->fd);
-
-			/*
-			 * Trim to whole blocks, since the kernel will not share
-			 * a trailing partial one. A range shorter than a block
-			 * is all tail: trimming would leave nothing to compare
-			 * and disable the skip entirely, so compare it whole -
-			 * it is a single record on each side either way.
-			 */
-			cmp_len = len & ~(uint64_t)(bs - 1);
-			if (!cmp_len)
-				cmp_len = len;
+		if (!tgt_mapped) {
+			tgt_mapped = true;
+			/* Compare only what a dedupe would actually share, or
+			 * the trailing partial block of an unaligned file - which
+			 * the kernel never shares - makes the check unsatisfiable
+			 * and every such file is resubmitted on every run. */
+			cmp_len = dedupe_shareable_len(tgt_extent->e_file->fd, len);
 			tgt_map = do_fiemap_range(tgt_extent->e_file->fd,
 						  tgt_extent->e_loff, cmp_len);
 		}

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -293,82 +293,67 @@ static int disk_extent_grew(struct dupe_extents *dext, struct extent *extent)
 }
 
 /*
- * Removes extents which it believes have already been deduped. We err
- * on the side of more deduping here.
+ * Drop the members that already share the target's storage: deduping them
+ * would be a no-op. We err on the side of more deduping here.
+ *
+ * The comparison is against *the target*, deliberately - not pairwise between
+ * members. Collapsing the group to one survivor per distinct physical offset
+ * looks equivalent, since same-poff members really are already shared with
+ * each other, but it is not: only the survivor is repointed by the ioctl, so
+ * every other member of its class stays on the old extent and that extent is
+ * never freed. A group with N copies sitting on the wrong extent then needs N
+ * runs to converge, moving one copy per run and freeing nothing until the last
+ * one lands - which on a large tree it never does (#186).
+ *
+ * Only the extent pass gets past the target check below. Whole-file groups are
+ * loaded with poff 0 (GET_DUPLICATE_FILES has no fiemap to draw on), so they
+ * keep every member and rely on the per-destination
+ * fiemap_range_shared_with() skip in dedupe_extent_list() - which compares
+ * against the target too, and is why whole-file dedupe never had this bug.
  */
 static void clean_deduped(struct dupe_extents **ret_dext,
 			  struct results_tree *res)
 {
-	int left;
-	int extents_kept = 0;
-	int first = 1;
 	struct dupe_extents *dext = *ret_dext;
-	struct rb_node *inner, *outer;
-	struct extent *inner_extent, *outer_extent;
+	struct extent *target, *extent;
+	struct rb_node *node, *next;
+	uint64_t tgt_poff;
 
 	if (!dext || dext->de_num_dupes == 0)
 		return;
 
-	outer = rb_first(&dext->de_extents_root);
-	while (outer) {
-		outer_extent = rb_entry(outer, struct extent, e_node);
+	/* dedupe_extent_list() dedupes against the first list entry. */
+	target = list_first_entry(&dext->de_extents, struct extent, e_list);
+	tgt_poff = extent_poff(target);
 
-		/*
-		 * First extent will not be considered for removal
-		 * below, which is fine as remove_extent() handles the
-		 * case of only 1 extent left on the dext for us.
-		 *
-		 * Replicate the checks though and count it as kept if
-		 * we don't want it deleted. That will trigger the
-		 * logic below to save the dext if we should wind up
-		 * throwing everything else out.
-		 */
-		if (first &&
-		    (extent_poff(outer_extent) == 0 ||
-		     disk_extent_grew(dext, outer_extent)))
-			extents_kept++;
-		first = 0;
+	/*
+	 * A poff of 0 means fiemap failed or was never run, so we cannot tell
+	 * what is shared; disk_extent_grew() means the target's physical extent
+	 * is shorter than the duplicate range. Either way, keep everything.
+	 */
+	if (tgt_poff == 0 || disk_extent_grew(dext, target))
+		return;
 
-		inner = rb_next(outer);
-		while (inner) {
-			inner_extent = rb_entry(inner, struct extent, e_node);
-			inner = rb_next(inner);
+	for (node = rb_first(&dext->de_extents_root); node; node = next) {
+		extent = rb_entry(node, struct extent, e_node);
+		next = rb_next(node);
 
-			/*
-			 * Track if any extents have survived the
-			 * culling. If we're down to the last two and
-			 * at least one of them was deemed worthy,
-			 * exit here so that he may be deduped.
-			 */
-			if (dext->de_num_dupes == 2 && extents_kept)
-				return;
+		if (extent == target || extent_poff(extent) != tgt_poff ||
+		    disk_extent_grew(dext, extent))
+			continue;
 
-			/*
-			 * e_poff could be zero if fiemap from
-			 * add_shared_extents fails. In that case,
-			 * skip the extent (it might want to be
-			 * deduped).
-			 */
-			if (extent_poff(inner_extent)
-			    && extent_poff(outer_extent) == extent_poff(inner_extent)
-			    && !disk_extent_grew(dext, inner_extent)) {
-				dprintf("Remove extent "
-					"(\"%s\", %"PRIu64", %"PRIu64")\n",
-					inner_extent->e_file->filename,
-					extent_poff(inner_extent),
-					extent_plen(inner_extent));
+		dprintf("Remove extent (\"%s\", %"PRIu64", %"PRIu64")\n",
+			extent->e_file->filename, extent_poff(extent),
+			extent_plen(extent));
 
-				g_mutex_lock(&mutex);
-				left = remove_extent(res, inner_extent);
-				g_mutex_unlock(&mutex);
-				if (left == 0) {
-					*ret_dext = dext = NULL;
-					return;
-				}
-			} else
-				extents_kept++;
+		g_mutex_lock(&mutex);
+		/* Cascades to a full free once fewer than two members remain. */
+		if (remove_extent(res, extent) == 0) {
+			g_mutex_unlock(&mutex);
+			*ret_dext = NULL;
+			return;
 		}
-		outer = rb_next(outer);
+		g_mutex_unlock(&mutex);
 	}
 }
 
@@ -482,8 +467,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	struct pscan_thread *slot = gp->slot;
 	uint64_t len = dext->de_len;
 	/* Target's extent map, fetched once and reused to skip already-shared
-	 * destinations (see the shared-check below). */
+	 * destinations (see the shared-check below), plus the length that check
+	 * runs over: `len` trimmed to whole filesystem blocks, since that is all
+	 * the kernel would dedupe. Zero until the target is known. */
 	_cleanup_(freep) struct fiemap *tgt_map = NULL;
+	uint64_t cmp_len = 0;
 	OPEN_ONCE(open_files);
 	struct extent *tgt_extent = NULL;
 
@@ -660,12 +648,25 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		 * for every destination; it never skips a real dedupe (see
 		 * fiemap_range_shared_with()).
 		 */
-		if (!tgt_map)
+		if (!tgt_map) {
+			unsigned int bs = dedupe_blocksize(tgt_extent->e_file->fd);
+
+			/*
+			 * Trim to whole blocks, since the kernel will not share
+			 * a trailing partial one. A range shorter than a block
+			 * is all tail: trimming would leave nothing to compare
+			 * and disable the skip entirely, so compare it whole -
+			 * it is a single record on each side either way.
+			 */
+			cmp_len = len & ~(uint64_t)(bs - 1);
+			if (!cmp_len)
+				cmp_len = len;
 			tgt_map = do_fiemap_range(tgt_extent->e_file->fd,
-						  tgt_extent->e_loff, len);
+						  tgt_extent->e_loff, cmp_len);
+		}
 		if (fiemap_range_shared_with(tgt_map, tgt_extent->e_loff,
 					     extent->e_file->fd, extent->e_loff,
-					     len)) {
+					     cmp_len)) {
 			atomic_fetch_add(&dedupe_dest_already_shared, 1);
 			group_tick(gp, len);	/* skipped, but credit its work */
 			vprintf("[%p] %s already shares the target's extents; "

--- a/src/tests.c
+++ b/src/tests.c
@@ -132,17 +132,31 @@ MU_TEST(test_seen_inode) {
 	seen_inodes_free();
 }
 
-MU_TEST(test_get_extent) {
-	/* Three data extents with holes between them:
-	 * [0, 4k)   hole   [8k, 12k)   hole   [16k, 20k) */
-	unsigned int n = 3;
+/* One fiemap record: {logical, physical, length, flags}. */
+struct fm_rec { uint64_t log, phys, len; uint32_t flags; };
+
+static struct fiemap *mkmap(const struct fm_rec *recs, unsigned int n)
+{
 	struct fiemap *fm = calloc(1, sizeof(*fm) +
 				   n * sizeof(struct fiemap_extent));
 
 	fm->fm_mapped_extents = n;
-	fm->fm_extents[0].fe_logical = 0;     fm->fm_extents[0].fe_length = 4096;
-	fm->fm_extents[1].fe_logical = 8192;  fm->fm_extents[1].fe_length = 4096;
-	fm->fm_extents[2].fe_logical = 16384; fm->fm_extents[2].fe_length = 4096;
+	for (unsigned int i = 0; i < n; i++) {
+		fm->fm_extents[i].fe_logical = recs[i].log;
+		fm->fm_extents[i].fe_physical = recs[i].phys;
+		fm->fm_extents[i].fe_length = recs[i].len;
+		fm->fm_extents[i].fe_flags = recs[i].flags;
+	}
+	return fm;
+}
+
+MU_TEST(test_get_extent) {
+	/* Three data extents with holes between them:
+	 * [0, 4k)   hole   [8k, 12k)   hole   [16k, 20k) */
+	struct fm_rec recs[] = {
+		{0, 0, 4096, 0}, {8192, 0, 4096, 0}, {16384, 0, 4096, 0}
+	};
+	struct fiemap *fm = mkmap(recs, ARRAY_SIZE(recs));
 
 	/* Plain lookups (no cursor). */
 	mu_check(get_extent(fm, 0, NULL) == &fm->fm_extents[0]);
@@ -177,22 +191,23 @@ MU_TEST(test_get_extent) {
 	free(fm);
 }
 
-/* One fiemap record: {logical, physical, length, flags}. */
-struct fm_rec { uint64_t log, phys, len; uint32_t flags; };
-
-static struct fiemap *mkmap(const struct fm_rec *recs, unsigned int n)
+/*
+ * fiemap_maps_share() decides whether deduping one range against another would
+ * be a no-op. It has to answer "yes" for storage that is genuinely shared but
+ * described with different record boundaries, or the same file is resubmitted
+ * to the kernel on every run (#186) - and "no" whenever it cannot prove it.
+ */
+/* Build both maps, compare, free. Keeps each case below to its records. */
+static bool share(const struct fm_rec *ra, unsigned int na, uint64_t off_a,
+		  const struct fm_rec *rb, unsigned int nb, uint64_t off_b,
+		  uint64_t len)
 {
-	struct fiemap *fm = calloc(1, sizeof(*fm) +
-				   n * sizeof(struct fiemap_extent));
+	struct fiemap *a = mkmap(ra, na), *b = mkmap(rb, nb);
+	bool shared = fiemap_maps_share(a, off_a, b, off_b, len);
 
-	fm->fm_mapped_extents = n;
-	for (unsigned int i = 0; i < n; i++) {
-		fm->fm_extents[i].fe_logical = recs[i].log;
-		fm->fm_extents[i].fe_physical = recs[i].phys;
-		fm->fm_extents[i].fe_length = recs[i].len;
-		fm->fm_extents[i].fe_flags = recs[i].flags;
-	}
-	return fm;
+	free(a);
+	free(b);
+	return shared;
 }
 
 /*
@@ -204,107 +219,70 @@ static struct fiemap *mkmap(const struct fm_rec *recs, unsigned int n)
 MU_TEST(test_fiemap_maps_share) {
 	const uint32_t SH = FIEMAP_EXTENT_SHARED;
 	const uint32_t ENC = FIEMAP_EXTENT_ENCODED;
-	struct fiemap *a, *b;
 
 	/* Identical single records over the whole range. */
-	{
-		struct fm_rec r[] = {{0, 4096, 8192, SH}};
+	struct fm_rec one[] = {{0, 4096, 8192, SH}};
 
-		a = mkmap(r, 1); b = mkmap(r, 1);
-		mu_check(fiemap_maps_share(a, 0, b, 0, 8192));
-		free(a); free(b);
-	}
+	mu_check(share(one, 1, 0, one, 1, 0, 8192));
 
 	/* Different stored extent: not shared. */
-	{
-		struct fm_rec ra[] = {{0, 4096, 8192, SH}};
-		struct fm_rec rb[] = {{0, 8192, 8192, SH}};
+	struct fm_rec elsewhere[] = {{0, 8192, 8192, SH}};
 
-		a = mkmap(ra, 1); b = mkmap(rb, 1);
-		mu_check(!fiemap_maps_share(a, 0, b, 0, 8192));
-		free(a); free(b);
-	}
+	mu_check(!share(one, 1, 0, elsewhere, 1, 0, 8192));
 
-	/* The regression: same storage, but the destination's tail is split at
-	 * the block boundary a previous dedupe stopped on. Shared over the
-	 * range the caller asked about. */
-	{
-		struct fm_rec ra[] = {{0, 4096, 12288, SH | ENC}};
-		struct fm_rec rb[] = {{0, 4096, 8192, SH | ENC},
-				      {8192, 99999, 4096, ENC}};
+	/*
+	 * The regression: same storage, but the destination's tail is split at
+	 * the block boundary a previous dedupe stopped on.
+	 */
+	struct fm_rec whole[] = {{0, 4096, 12288, SH | ENC}};
+	struct fm_rec split[] = {{0, 4096, 8192, SH | ENC},
+				 {8192, 99999, 4096, ENC}};
 
-		a = mkmap(ra, 1); b = mkmap(rb, 2);
-		mu_check(fiemap_maps_share(a, 0, b, 0, 8192));
-		/* ... but not once the range reaches into the split-off part. */
-		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
-		free(a); free(b);
-	}
+	mu_check(share(whole, 1, 0, split, 2, 0, 8192));
+	/* ... but not once the range reaches into the split-off part. */
+	mu_check(!share(whole, 1, 0, split, 2, 0, 12288));
 
-	/* Matching holes are shared: a sparse cache file is mostly hole, and
-	 * the map simply stops before the end of the range. */
-	{
-		struct fm_rec r[] = {{0, 4096, 8192, SH}};
-
-		a = mkmap(r, 1); b = mkmap(r, 1);
-		mu_check(fiemap_maps_share(a, 0, b, 0, 262144));
-		free(a); free(b);
-	}
+	/*
+	 * Matching holes are shared: a sparse cache file is mostly hole, so the
+	 * map simply stops before the end of the range.
+	 */
+	mu_check(share(one, 1, 0, one, 1, 0, 262144));
 
 	/* A hole facing data is a real difference. */
-	{
-		struct fm_rec ra[] = {{0, 4096, 8192, SH}};
-		struct fm_rec rb[] = {{0, 4096, 8192, SH}, {8192, 8192, 4096, 0}};
+	struct fm_rec then_data[] = {{0, 4096, 8192, SH}, {8192, 8192, 4096, 0}};
 
-		a = mkmap(ra, 1); b = mkmap(rb, 2);
-		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
-		free(a); free(b);
-	}
+	mu_check(!share(one, 1, 0, then_data, 2, 0, 12288));
 
 	/* Interior holes must line up on both sides. */
-	{
-		struct fm_rec ra[] = {{0, 4096, 4096, SH}, {8192, 8192, 4096, SH}};
-		struct fm_rec rb[] = {{0, 4096, 4096, SH}, {4096, 8192, 4096, SH}};
+	struct fm_rec gapped[] = {{0, 4096, 4096, SH}, {8192, 8192, 4096, SH}};
+	struct fm_rec packed[] = {{0, 4096, 4096, SH}, {4096, 8192, 4096, SH}};
 
-		a = mkmap(ra, 2); b = mkmap(rb, 2);
-		mu_check(fiemap_maps_share(a, 0, a, 0, 12288));
-		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
-		free(a); free(b);
-	}
+	mu_check(share(gapped, 2, 0, gapped, 2, 0, 12288));
+	mu_check(!share(gapped, 2, 0, packed, 2, 0, 12288));
 
-	/* No stable physical location: never "shared", whatever the offsets say. */
-	{
-		struct fm_rec r[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
+	/* No stable physical location: never shared, whatever the offsets say. */
+	struct fm_rec delalloc[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
 
-		a = mkmap(r, 1); b = mkmap(r, 1);
-		mu_check(!fiemap_maps_share(a, 0, b, 0, 8192));
-		free(a); free(b);
-	}
+	mu_check(!share(delalloc, 1, 0, delalloc, 1, 0, 8192));
 
-	/* Ranges at different logical offsets, on the same stored extent at the
-	 * same offset into it (the extent pass compares mid-file ranges). */
-	{
-		struct fm_rec ra[] = {{65536, 4096, 8192, SH}};
-		struct fm_rec rb[] = {{131072, 4096, 8192, SH}};
+	/*
+	 * Ranges at different logical offsets, on the same stored extent at the
+	 * same offset into it (the extent pass compares mid-file ranges).
+	 */
+	struct fm_rec at64k[] = {{65536, 4096, 8192, SH}};
+	struct fm_rec at128k[] = {{131072, 4096, 8192, SH}};
 
-		a = mkmap(ra, 1); b = mkmap(rb, 1);
-		mu_check(fiemap_maps_share(a, 65536, b, 131072, 8192));
-		free(a); free(b);
-	}
+	mu_check(share(at64k, 1, 65536, at128k, 1, 131072, 8192));
 
-	/* A record that begins before the range: shared only when both sides
-	 * start the same distance into the same stored extent. */
-	{
-		struct fm_rec ra[] = {{0, 4096, 16384, SH}};
-		struct fm_rec rb[] = {{0, 4096, 16384, SH}};
-		struct fm_rec rc[] = {{4096, 4096, 12288, SH}};
+	/*
+	 * A record that begins before the range: shared only when both sides
+	 * start the same distance into the same stored extent.
+	 */
+	struct fm_rec big[] = {{0, 4096, 16384, SH}};
+	struct fm_rec offset[] = {{4096, 4096, 12288, SH}};
 
-		a = mkmap(ra, 1); b = mkmap(rb, 1);
-		mu_check(fiemap_maps_share(a, 8192, b, 8192, 8192));
-		free(b);
-		b = mkmap(rc, 1);
-		mu_check(!fiemap_maps_share(a, 8192, b, 8192, 4096));
-		free(a); free(b);
-	}
+	mu_check(share(big, 1, 8192, big, 1, 8192, 8192));
+	mu_check(!share(big, 1, 8192, offset, 1, 8192, 4096));
 }
 
 MU_TEST(test_sanitize_ctrl) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -177,6 +177,136 @@ MU_TEST(test_get_extent) {
 	free(fm);
 }
 
+/* One fiemap record: {logical, physical, length, flags}. */
+struct fm_rec { uint64_t log, phys, len; uint32_t flags; };
+
+static struct fiemap *mkmap(const struct fm_rec *recs, unsigned int n)
+{
+	struct fiemap *fm = calloc(1, sizeof(*fm) +
+				   n * sizeof(struct fiemap_extent));
+
+	fm->fm_mapped_extents = n;
+	for (unsigned int i = 0; i < n; i++) {
+		fm->fm_extents[i].fe_logical = recs[i].log;
+		fm->fm_extents[i].fe_physical = recs[i].phys;
+		fm->fm_extents[i].fe_length = recs[i].len;
+		fm->fm_extents[i].fe_flags = recs[i].flags;
+	}
+	return fm;
+}
+
+/*
+ * fiemap_maps_share() decides whether deduping one range against another would
+ * be a no-op. It has to answer "yes" for storage that is genuinely shared but
+ * described with different record boundaries, or the same file is resubmitted
+ * to the kernel on every run (#186) - and "no" whenever it cannot prove it.
+ */
+MU_TEST(test_fiemap_maps_share) {
+	const uint32_t SH = FIEMAP_EXTENT_SHARED;
+	const uint32_t ENC = FIEMAP_EXTENT_ENCODED;
+	struct fiemap *a, *b;
+
+	/* Identical single records over the whole range. */
+	{
+		struct fm_rec r[] = {{0, 4096, 8192, SH}};
+
+		a = mkmap(r, 1); b = mkmap(r, 1);
+		mu_check(fiemap_maps_share(a, 0, b, 0, 8192));
+		free(a); free(b);
+	}
+
+	/* Different stored extent: not shared. */
+	{
+		struct fm_rec ra[] = {{0, 4096, 8192, SH}};
+		struct fm_rec rb[] = {{0, 8192, 8192, SH}};
+
+		a = mkmap(ra, 1); b = mkmap(rb, 1);
+		mu_check(!fiemap_maps_share(a, 0, b, 0, 8192));
+		free(a); free(b);
+	}
+
+	/* The regression: same storage, but the destination's tail is split at
+	 * the block boundary a previous dedupe stopped on. Shared over the
+	 * range the caller asked about. */
+	{
+		struct fm_rec ra[] = {{0, 4096, 12288, SH | ENC}};
+		struct fm_rec rb[] = {{0, 4096, 8192, SH | ENC},
+				      {8192, 99999, 4096, ENC}};
+
+		a = mkmap(ra, 1); b = mkmap(rb, 2);
+		mu_check(fiemap_maps_share(a, 0, b, 0, 8192));
+		/* ... but not once the range reaches into the split-off part. */
+		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
+		free(a); free(b);
+	}
+
+	/* Matching holes are shared: a sparse cache file is mostly hole, and
+	 * the map simply stops before the end of the range. */
+	{
+		struct fm_rec r[] = {{0, 4096, 8192, SH}};
+
+		a = mkmap(r, 1); b = mkmap(r, 1);
+		mu_check(fiemap_maps_share(a, 0, b, 0, 262144));
+		free(a); free(b);
+	}
+
+	/* A hole facing data is a real difference. */
+	{
+		struct fm_rec ra[] = {{0, 4096, 8192, SH}};
+		struct fm_rec rb[] = {{0, 4096, 8192, SH}, {8192, 8192, 4096, 0}};
+
+		a = mkmap(ra, 1); b = mkmap(rb, 2);
+		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
+		free(a); free(b);
+	}
+
+	/* Interior holes must line up on both sides. */
+	{
+		struct fm_rec ra[] = {{0, 4096, 4096, SH}, {8192, 8192, 4096, SH}};
+		struct fm_rec rb[] = {{0, 4096, 4096, SH}, {4096, 8192, 4096, SH}};
+
+		a = mkmap(ra, 2); b = mkmap(rb, 2);
+		mu_check(fiemap_maps_share(a, 0, a, 0, 12288));
+		mu_check(!fiemap_maps_share(a, 0, b, 0, 12288));
+		free(a); free(b);
+	}
+
+	/* No stable physical location: never "shared", whatever the offsets say. */
+	{
+		struct fm_rec r[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
+
+		a = mkmap(r, 1); b = mkmap(r, 1);
+		mu_check(!fiemap_maps_share(a, 0, b, 0, 8192));
+		free(a); free(b);
+	}
+
+	/* Ranges at different logical offsets, on the same stored extent at the
+	 * same offset into it (the extent pass compares mid-file ranges). */
+	{
+		struct fm_rec ra[] = {{65536, 4096, 8192, SH}};
+		struct fm_rec rb[] = {{131072, 4096, 8192, SH}};
+
+		a = mkmap(ra, 1); b = mkmap(rb, 1);
+		mu_check(fiemap_maps_share(a, 65536, b, 131072, 8192));
+		free(a); free(b);
+	}
+
+	/* A record that begins before the range: shared only when both sides
+	 * start the same distance into the same stored extent. */
+	{
+		struct fm_rec ra[] = {{0, 4096, 16384, SH}};
+		struct fm_rec rb[] = {{0, 4096, 16384, SH}};
+		struct fm_rec rc[] = {{4096, 4096, 12288, SH}};
+
+		a = mkmap(ra, 1); b = mkmap(rb, 1);
+		mu_check(fiemap_maps_share(a, 8192, b, 8192, 8192));
+		free(b);
+		b = mkmap(rc, 1);
+		mu_check(!fiemap_maps_share(a, 8192, b, 8192, 4096));
+		free(a); free(b);
+	}
+}
+
 MU_TEST(test_sanitize_ctrl) {
 	char out[64];
 
@@ -814,6 +944,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_file_renamed);
 	MU_RUN_TEST(test_seen_inode);
 	MU_RUN_TEST(test_get_extent);
+	MU_RUN_TEST(test_fiemap_maps_share);
 	MU_RUN_TEST(test_sanitize_ctrl);
 	MU_RUN_TEST(test_progress_copy_path);
 	MU_RUN_TEST(test_progress_path_two_stage_render);

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -51,6 +51,7 @@ _NET_CHANGE_RE = re.compile(r"net change in shared extents of:\s*(\d+)")
 # The size is human_size()-rendered ("1.0 MiB", "512 B"), so assert on the
 # rendered string; for exact bytes use --json's reclaimed_total_bytes instead.
 _RECLAIMED_RE = re.compile(r"Reclaimed\s+([\d.]+ [A-Za-z]+)\s+across\s+(\d+)\s+group")
+_ALREADY_SHARED_RE = re.compile(r"Already shared (\d+) file")
 
 
 # --------------------------------------------------------------------------
@@ -323,6 +324,22 @@ class DuperemoveTest(unittest.TestCase):
     def assertReclaimed(self, size_str, groups, msg=None):
         """Assert the summary reported `size_str` reclaimed across `groups`."""
         self.assertEqual((size_str, groups), self.reclaimed_summary(), msg)
+
+    def assertReclaimedNothing(self, msg=None):
+        """The last run freed nothing: '0 B', or no Reclaimed line at all."""
+        summary = self.reclaimed_summary()
+        self.assertTrue(summary is None or summary[0] == "0 B",
+                        (msg or "expected nothing to be reclaimed") +
+                        f", got {summary}")
+
+    def already_shared(self):
+        """Count from the 'Already shared N files skipped' summary line.
+
+        Zero when the line is absent, which is also what oans prints when no
+        destination was skipped.
+        """
+        m = _ALREADY_SHARED_RE.search(self.out)
+        return int(m.group(1)) if m else 0
 
     # -- hashfile (SQLite) inspection --------------------------------------
 

--- a/tests/integration/test_dedupe_idempotent.py
+++ b/tests/integration/test_dedupe_idempotent.py
@@ -1,0 +1,126 @@
+"""A second dedupe of an unchanged tree must be a no-op.
+
+Every destination oans hands the kernel a second time is a full byte-compare of
+the range for nothing, and the kernel reports those bytes as deduped, so a run
+that frees no space can still claim to have reclaimed gigabytes (#186). What
+keeps that from happening is the already-shared skip, which has to recognise
+the layouts dedupe itself leaves behind: a tail split on a block boundary, a
+file smaller than one block, a sparse file whose extent map stops well before
+the end of the range.
+
+These run without a hashfile so each invocation reconsiders the whole tree.
+With one, the incremental dedupe_seq watermark would skip the unchanged groups
+and every second run would pass for the wrong reason.
+"""
+
+import os
+import re
+from harness import DuperemoveTest, requires_reflink
+
+KiB = 1 << 10
+
+_ALREADY_SHARED_RE = re.compile(r"Already shared (\d+) file")
+
+
+@requires_reflink
+class DedupeIdempotentTest(DuperemoveTest):
+    def already_shared(self):
+        """Destinations the last run skipped as already sharing the target."""
+        m = _ALREADY_SHARED_RE.search(self.out)
+        return int(m.group(1)) if m else 0
+
+    def assertSecondRunIsNoop(self, tree, expect_skips=True):
+        """Dedupe twice; the second run must reclaim nothing."""
+        self.dm("-rd", tree, hashfile=False)
+        self.assertDmOk("first dedupe")
+        self.sync()
+
+        self.dm("-rd", tree, hashfile=False, quiet=False)
+        self.assertDmOk("second dedupe")
+        summary = self.reclaimed_summary()
+        self.assertTrue(summary is None or summary[0] == "0 B",
+                        f"second run reclaimed {summary}, expected nothing")
+        if expect_skips:
+            # Distinguishes "recognised as shared" from "no group at all".
+            self.assertGreater(self.already_shared(), 0,
+                               "expected the already-shared skip to fire")
+
+    def test_block_aligned_files(self):
+        self.mkdup("tree/a", "tree/b", 64 * KiB)
+        self.sync()
+        self.assertSecondRunIsNoop(self.path("tree"))
+
+    def test_unaligned_tail(self):
+        """A size that is not a whole number of blocks.
+
+        The kernel will not share the trailing partial block, so the copy keeps
+        its own tail record forever. Comparing that tail makes the skip
+        unsatisfiable and the whole file is resubmitted on every run.
+        """
+        self.mkdup("tree/a", "tree/b", 64 * KiB + 1234)
+        self.sync()
+        self.assertSecondRunIsNoop(self.path("tree"))
+
+    def test_file_smaller_than_a_block(self):
+        """The whole file is one partial block: there is no aligned part to
+        compare, so the skip has to fall back to comparing it whole.
+
+        Sized above btrfs's max_inline (2048 by default) on purpose: an inline
+        extent has no physical location, the kernel declines to dedupe it, and
+        the run comes out at zero however the skip behaves - which would make
+        this pass without testing anything.
+        """
+        self.mkdup("tree/a", "tree/b", 4 * KiB - 96)
+        self.sync()
+        self.assertSecondRunIsNoop(self.path("tree"))
+
+    def test_tail_block_split_off(self):
+        """Every full block shared, the trailing partial block not.
+
+        This is the layout dedupe leaves on a file whose size is not a whole
+        number of blocks, because the kernel rounds the length down and never
+        shares that last block. If the already-shared check insists on it, the
+        file can never pass and its whole length is byte-compared again on
+        every run - which is where most of #186's phantom "reclaimed" came
+        from. Built by hand here (reflink, then rewrite the tail with the same
+        bytes so copy-on-write splits it off) rather than by deduping, so the
+        test does not depend on how the kernel treats an unaligned tail.
+
+        Asserted on the *first* run: there is nothing here left to share, and
+        recognising that without byte-comparing the whole file is the point.
+        """
+        aligned = 128 * KiB
+        data = os.urandom(aligned + 2000)
+        self.write("tree/a", data)
+        self.sync()
+        b = self.reflink("tree/a", "tree/b")
+        with open(b, "r+b") as f:
+            f.seek(aligned)
+            f.write(data[aligned:])
+        self.sync()
+
+        self.dm("-rd", self.path("tree"), hashfile=False, quiet=False)
+        self.assertDmOk()
+        summary = self.reclaimed_summary()
+        self.assertTrue(summary is None or summary[0] == "0 B",
+                        f"nothing here is shareable, but it reclaimed {summary}")
+        self.assertGreater(self.already_shared(), 0,
+                           "expected the already-shared skip to fire")
+
+    def test_sparse_twins(self):
+        """fiemap omits holes, so the map stops short of the range end. Two
+        files with the same hole layout share it; that must not read as a
+        difference."""
+        head, tail = os.urandom(8 * KiB), os.urandom(8 * KiB)
+        self.make_sparse("tree/a", head, 256 * KiB, tail)
+        self.make_sparse("tree/b", head, 256 * KiB, tail)
+        self.sync()
+        self.assertSecondRunIsNoop(self.path("tree"))
+
+    def test_trailing_hole(self):
+        """Same, with the hole at the end - the map simply runs out."""
+        data = os.urandom(8 * KiB)
+        self.make_trailing_hole("tree/a", data, 256 * KiB)
+        self.make_trailing_hole("tree/b", data, 256 * KiB)
+        self.sync()
+        self.assertSecondRunIsNoop(self.path("tree"))

--- a/tests/integration/test_dedupe_idempotent.py
+++ b/tests/integration/test_dedupe_idempotent.py
@@ -21,14 +21,24 @@ KiB = 1 << 10
 
 @requires_reflink
 class DedupeIdempotentTest(DuperemoveTest):
+    # Every case here turns on the physical layout dedupe leaves behind - a
+    # split tail, a hole map, a sub-block extent - so it belongs in the
+    # one-at-a-time pass. See DuperemoveTest.serial: concurrent I/O perturbs
+    # btrfs writeback, and CI caught exactly that (a valgrind shard failed
+    # test_tail_block_split_off while the plain btrfs legs passed).
+    serial = True
+
     def assertRunFindsNothingToDo(self, tree, why):
         """One dedupe over `tree` that must free nothing and say why."""
         self.dm("-rd", tree, hashfile=False, quiet=False)
         self.assertDmOk()
         self.assertReclaimedNothing(why)
-        # Distinguishes "recognised as shared" from "no group at all".
+        # Distinguishes "recognised as shared" from "no group at all" - the
+        # latter would make every assertion above pass without testing
+        # anything. On failure the run's own summary says which it was.
         self.assertGreater(self.already_shared(), 0,
-                           "expected the already-shared skip to fire")
+                           "expected the already-shared skip to fire; oans said:"
+                           f"\n{self.out.strip()}")
 
     def assertSecondRunIsNoop(self, tree):
         """Dedupe twice; the second run must reclaim nothing."""

--- a/tests/integration/test_dedupe_idempotent.py
+++ b/tests/integration/test_dedupe_idempotent.py
@@ -14,36 +14,28 @@ and every second run would pass for the wrong reason.
 """
 
 import os
-import re
 from harness import DuperemoveTest, requires_reflink
 
 KiB = 1 << 10
 
-_ALREADY_SHARED_RE = re.compile(r"Already shared (\d+) file")
-
 
 @requires_reflink
 class DedupeIdempotentTest(DuperemoveTest):
-    def already_shared(self):
-        """Destinations the last run skipped as already sharing the target."""
-        m = _ALREADY_SHARED_RE.search(self.out)
-        return int(m.group(1)) if m else 0
+    def assertRunFindsNothingToDo(self, tree, why):
+        """One dedupe over `tree` that must free nothing and say why."""
+        self.dm("-rd", tree, hashfile=False, quiet=False)
+        self.assertDmOk()
+        self.assertReclaimedNothing(why)
+        # Distinguishes "recognised as shared" from "no group at all".
+        self.assertGreater(self.already_shared(), 0,
+                           "expected the already-shared skip to fire")
 
-    def assertSecondRunIsNoop(self, tree, expect_skips=True):
+    def assertSecondRunIsNoop(self, tree):
         """Dedupe twice; the second run must reclaim nothing."""
         self.dm("-rd", tree, hashfile=False)
         self.assertDmOk("first dedupe")
         self.sync()
-
-        self.dm("-rd", tree, hashfile=False, quiet=False)
-        self.assertDmOk("second dedupe")
-        summary = self.reclaimed_summary()
-        self.assertTrue(summary is None or summary[0] == "0 B",
-                        f"second run reclaimed {summary}, expected nothing")
-        if expect_skips:
-            # Distinguishes "recognised as shared" from "no group at all".
-            self.assertGreater(self.already_shared(), 0,
-                               "expected the already-shared skip to fire")
+        self.assertRunFindsNothingToDo(tree, "the tree is already deduped")
 
     def test_block_aligned_files(self):
         self.mkdup("tree/a", "tree/b", 64 * KiB)
@@ -99,13 +91,8 @@ class DedupeIdempotentTest(DuperemoveTest):
             f.write(data[aligned:])
         self.sync()
 
-        self.dm("-rd", self.path("tree"), hashfile=False, quiet=False)
-        self.assertDmOk()
-        summary = self.reclaimed_summary()
-        self.assertTrue(summary is None or summary[0] == "0 B",
-                        f"nothing here is shareable, but it reclaimed {summary}")
-        self.assertGreater(self.already_shared(), 0,
-                           "expected the already-shared skip to fire")
+        self.assertRunFindsNothingToDo(self.path("tree"),
+                                       "nothing here is left to share")
 
     def test_sparse_twins(self):
         """fiemap omits holes, so the map stops short of the range end. Two

--- a/tests/integration/test_extent_dedupe.py
+++ b/tests/integration/test_extent_dedupe.py
@@ -36,6 +36,24 @@ class ExtentDedupeTest(DuperemoveTest):
             f.write(tail)
         return p
 
+    def _reflink_new_head(self, src_rel, dst_rel, head_len):
+        """Reflink src, then rewrite its head in place.
+
+        Copy-on-write replaces only the head blocks, so the copy keeps the
+        seed's tail extents byte for byte - a physical class of two that does
+        not depend on how writeback laid anything out.
+        """
+        p = self.reflink(src_rel, dst_rel)
+        with open(p, "r+b") as f:
+            f.write(os.urandom(head_len))
+        return p
+
+    def _layout(self, **files):
+        """Physical extents per file, for a failure message worth reading."""
+        from harness import phys_extents
+        return "\n  " + "\n  ".join(
+            f"{name}: {sorted(phys_extents(p))}" for name, p in files.items())
+
     def test_shared_tail_is_deduped(self):
         # Distinct heads, identical tail -> not whole-file dupes, so only the
         # extent pass can share the tail.
@@ -72,22 +90,27 @@ class ExtentDedupeTest(DuperemoveTest):
         Runs without a hashfile so each invocation reconsiders the whole tree:
         with one, the incremental dedupe_seq watermark would skip the unchanged
         groups and the second run would be a no-op for the wrong reason.
+
+        The two classes are built with reflinks rather than by deduping the
+        subtrees first. A reflink copies the extent map exactly, so each pair
+        provably lands in one group; writing four files independently and
+        hoping writeback splits all four tails the same way does not survive a
+        different allocator (it failed on CI's fresh 2 GiB image while passing
+        on a large aged filesystem). Only a1-vs-b1 still relies on two
+        head+fsync+tail writes matching, which test_shared_tail_is_deduped
+        above already depends on.
         """
+        head = 64 * 1024        # block-aligned, so rewriting it spares the tail
         tail = os.urandom(4 * MiB)
-        # Distinct head sizes keep these four out of the whole-file pass.
-        a1 = self._mkfile("tree/a/1", os.urandom(64 * 1024), tail)
-        a2 = self._mkfile("tree/a/2", os.urandom(96 * 1024), tail)
-        b1 = self._mkfile("tree/b/1", os.urandom(128 * 1024), tail)
-        b2 = self._mkfile("tree/b/2", os.urandom(160 * 1024), tail)
+        a1 = self._mkfile("tree/a/1", os.urandom(head), tail)
+        b1 = self._mkfile("tree/b/1", os.urandom(head), tail)
+        self.sync()
+        # Same tail extents as the seed, different head - so same size but a
+        # different file, which keeps all four out of the whole-file pass.
+        a2 = self._reflink_new_head("tree/a/1", "tree/a/2", head)
+        b2 = self._reflink_new_head("tree/b/1", "tree/b/2", head)
         self.sync()
 
-        # Two independent physical copies of `tail`, two members each: dedupe
-        # the subtrees separately so a/* land on one extent and b/* the other.
-        self.dm("-rd", self.path("tree/a"), hashfile=False)
-        self.assertDmOk()
-        self.dm("-rd", self.path("tree/b"), hashfile=False)
-        self.assertDmOk()
-        self.sync()
         self.assertShared(a1, a2, "a/* share one physical copy of the tail")
         self.assertShared(b1, b2, "b/* share the other")
         self.assertNotShared(a1, b1, "the two copies are still independent")
@@ -102,7 +125,8 @@ class ExtentDedupeTest(DuperemoveTest):
         # behind, so check every member against the same reference.
         for other, name in ((a2, "a/2"), (b1, "b/1"), (b2, "b/2")):
             self.assertShared(a1, other,
-                              f"{name} still on its old extent after one run")
+                              f"{name} still on its old extent after one run"
+                              + self._layout(a1=a1, a2=a2, b1=b1, b2=b2))
         self.assertEqual(before, self.tree_digest(self.path("tree")),
                          "dedupe preserved file contents")
 

--- a/tests/integration/test_extent_dedupe.py
+++ b/tests/integration/test_extent_dedupe.py
@@ -110,6 +110,4 @@ class ExtentDedupeTest(DuperemoveTest):
         self.dm("-rd", self.path("tree"), hashfile=False)
         self.assertDmOk()
         self.assertNoNewSharing()
-        summary = self.reclaimed_summary()
-        self.assertTrue(summary is None or summary[0] == "0 B",
-                        f"second run should reclaim nothing, got {summary}")
+        self.assertReclaimedNothing("second run should find the group settled")

--- a/tests/integration/test_extent_dedupe.py
+++ b/tests/integration/test_extent_dedupe.py
@@ -59,3 +59,57 @@ class ExtentDedupeTest(DuperemoveTest):
         self.dedupe(self.path("tree"))
         self.assertDmOk()
         self.assertNoNewSharing()
+
+    def test_group_on_two_physical_extents_converges_in_one_run(self):
+        """Every member lands on the target, not just one per physical extent.
+
+        clean_deduped() used to cull pairwise, keeping one survivor per distinct
+        physical offset. Only that survivor is repointed by the ioctl, so the
+        rest of its class stayed on the old extent, which was therefore never
+        freed - one copy moved per run, nothing reclaimed until the last one
+        landed, which on a large tree never happened (#186).
+
+        Runs without a hashfile so each invocation reconsiders the whole tree:
+        with one, the incremental dedupe_seq watermark would skip the unchanged
+        groups and the second run would be a no-op for the wrong reason.
+        """
+        tail = os.urandom(4 * MiB)
+        # Distinct head sizes keep these four out of the whole-file pass.
+        a1 = self._mkfile("tree/a/1", os.urandom(64 * 1024), tail)
+        a2 = self._mkfile("tree/a/2", os.urandom(96 * 1024), tail)
+        b1 = self._mkfile("tree/b/1", os.urandom(128 * 1024), tail)
+        b2 = self._mkfile("tree/b/2", os.urandom(160 * 1024), tail)
+        self.sync()
+
+        # Two independent physical copies of `tail`, two members each: dedupe
+        # the subtrees separately so a/* land on one extent and b/* the other.
+        self.dm("-rd", self.path("tree/a"), hashfile=False)
+        self.assertDmOk()
+        self.dm("-rd", self.path("tree/b"), hashfile=False)
+        self.assertDmOk()
+        self.sync()
+        self.assertShared(a1, a2, "a/* share one physical copy of the tail")
+        self.assertShared(b1, b2, "b/* share the other")
+        self.assertNotShared(a1, b1, "the two copies are still independent")
+
+        before = self.tree_digest(self.path("tree"))
+        self.dm("-rd", self.path("tree"), hashfile=False)
+        self.assertDmOk()
+        self.sync()
+
+        # One run has to collapse all four onto one extent. Whichever class the
+        # target comes from, the old cull left the other class's non-survivor
+        # behind, so check every member against the same reference.
+        for other, name in ((a2, "a/2"), (b1, "b/1"), (b2, "b/2")):
+            self.assertShared(a1, other,
+                              f"{name} still on its old extent after one run")
+        self.assertEqual(before, self.tree_digest(self.path("tree")),
+                         "dedupe preserved file contents")
+
+        # ... so there is nothing left for a second run to do.
+        self.dm("-rd", self.path("tree"), hashfile=False)
+        self.assertDmOk()
+        self.assertNoNewSharing()
+        summary = self.reclaimed_summary()
+        self.assertTrue(summary is None or summary[0] == "0 B",
+                        f"second run should reclaim nothing, got {summary}")


### PR DESCRIPTION
Fixes #186. Also removes most of what #187 reports, though the accounting question there stands on its own.

## The symptom

`oans -dr ~/` on a 415 GiB home reported **6.6 GiB reclaimed on every run**, forever. Free space measured before and after: **+192 KB**. The summary can't reveal this on its own — `FIDEDUPERANGE` returns `bytes_deduped` for a range that already shares storage, so a run that frees nothing still reports gigabytes. The only reliable check is to run the same command twice.

## Diagnosis

Bisecting by scope was the useful move: every subdirectory of `~/.local`, and every *pair* of them, converged on the second run, while `~/.local` as a whole re-reclaimed 3.7 GiB indefinitely. That pattern says the group got bigger, not that some directory is cursed.

The minimal reproducer turned out to be three files: one 128 KiB extent digest occurring at 39 offsets across them, spread over exactly two physical extents. Each run moved exactly one occurrence and reported 128 KiB.

## Three causes

**1. `clean_deduped()` culled pairwise.** It collapsed a group to one survivor per distinct physical offset. Same-poff members really are shared *with each other*, so this looks equivalent — but only the survivor is repointed by the ioctl, so the rest of its class stays on the old extent and that extent is never freed. N copies on the wrong extent needed N runs, freeing nothing until the last one landed. Now culls against the target.

Whole-file groups load with `poff = 0` (`GET_DUPLICATE_FILES` has no fiemap to draw on) so they never reached this code, which is exactly why `--dedupe-options=only_whole_files` converged where the default did not. That asymmetry was the tell.

**2. `fiemap_range_shared_with()` required record-for-record equality.** The same shared storage gets described with different record boundaries in each file — a dedupe stops on a block boundary and splits the destination's tail where the target has one record. Two files sharing all 88 MB read as "not shared" and got resubmitted in full every run. It now walks the range and compares coverage, holes included (fiemap omits holes, and a browser cache is mostly hole; matching holes are shared, a hole facing data is not).

`fe_physical` is only ever compared for equality, never with a delta added — on a compressed extent it addresses the compressed extent as a whole, so an offset into it means nothing.

**3. The comparison has to stop at the last whole block.** The kernel rounds a dedupe length down (`generic_remap_check_len()`), so a trailing partial block can never be shared and comparing it makes the check permanently unsatisfiable. New `dedupe_blocksize()` for that — with a fallback to the untrimmed length below one block, or the skip is silently disabled for every sub-block file.

## Result

Same tree, stage by stage:

| | reclaimed per run | already-shared skips |
|---|---|---|
| before | 6.6 GiB | 22 653 files |
| target-relative cull | 1.4 GiB | 90 437 |
| + block trim | 130.8 MiB | 116 091 |
| + hole handling | 21.3 MiB | 116 653 |
| + sub-block fallback | **0 B** | 124 306 |

No change in wall-clock on an already-converged tree (`~/.local`: 11.1 s either way, interleaved A/B). The saving is the byte-compares that no longer happen while a tree is converging.

The `content mismatch` count rises, as expected: destinations that used to be masked by a redundant re-dedupe now reach the kernel and are correctly reported. Spot-checked — they are live caches (mesa shader cache, plasma `.kcache`, ccache) rewritten between hash and dedupe.

## Tests

Each part is pinned by a test that fails without it — verified by reverting them one at a time:

- `tests/integration/test_dedupe_idempotent.py` (new): unaligned tail, split-off tail block, sub-block file, sparse twins, trailing hole.
- `test_extent_dedupe.py::test_group_on_two_physical_extents_converges_in_one_run`: a group spread over two physical extents must collapse onto the target in one run.
- `test_fiemap_maps_share` unit test over synthetic fiemap records — the map walk is pure, and this is far more robust than coaxing btrfs into a particular layout.

`scripts/verify.sh` passes, 194 tests, and `make integration-valgrind` reports no findings. Suite run three times in parallel with no flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)