### PR TITLE
dedupe: report bytes freed, not bytes the kernel compared (#187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -658,3 +658,16 @@ check unlinks and recreates (it's only a cache).
   `-q` "net change in shared extents" line is a separate fiemap diagnostic
   (counts the surviving copy too, ~2× for pairs); `--json`
   `reclaimable_logical_bytes` is a logical upper bound.
+- **Never credit the kernel's `bytes_deduped` as space freed (#187).**
+  `FIDEDUPERANGE` reports the whole compared length whether or not the range
+  already shared the target's storage, so summing it counted work as savings: a
+  destination half of which was already shared credited twice what it freed, and
+  before #186 a run that freed *nothing* claimed 6.6 GiB. Each destination is
+  measured before submission — `fiemap_unshared_bytes()` over the target's
+  sorted physical addresses — and only that part is credited, capped by what the
+  kernel got through and only for destinations it accepted. Approximate by at
+  most one extent either way (a partial reference at a different offset into an
+  uncompressed extent reads as unshared; any part of a compressed extent reads
+  as shared), which is why it must never gate a *decision*, only the figure.
+  Pinned by `test_reclaimed_excludes_what_was_already_shared` and the
+  `test_fiemap_unshared_bytes` unit test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,7 +487,7 @@ that same tree (6.6 GiB → 1.4 GiB → 131 MiB → 21.3 MiB → **0 B**):
   is why `--dedupe-options=only_whole_files` converged where the default did not.
   That asymmetry is the diagnostic — if only_whole_files converges, suspect the
   extent path.
-- **`fiemap_range_shared_with()` compares coverage, not extent records.** The
+- **`fiemap_maps_share()` compares coverage, not extent records.** The
   same shared storage is described with different record boundaries in each
   file: a dedupe stops on a block boundary and splits the destination's tail
   where the target has one record. Record-for-record equality reads that as "not

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -503,8 +503,12 @@ Summary
 \f[I]N\f[R] identical copies, \f[CR]oans\f[R] keeps one physical copy
 and frees the other \f[I]N\f[R]−1, so this is the honest bytes\-freed
 figure, not an inflated count.
-\f[B]Already shared\f[R] counts files skipped because their storage was
-already shared.
+Only data that was still duplicated counts towards it \(em a copy
+already sharing part of the target\(cqs storage contributes just the
+remainder, so a run over an already\-deduplicated tree reports
+\f[CR]0 B\f[R] rather than the volume it re\-examined.
+\f[B]Already shared\f[R] counts files skipped entirely because their
+storage was already shared.
 If some destinations could not be deduped (their data changed since the
 scan, or the kernel refused), a \f[B]Not deduped\f[R] line reports the
 counts; re\-run with \f[B]\-v\f[R] for detail.

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -421,10 +421,14 @@ Summary
 
 **Reclaimed** is the disk space actually freed: for a group of *N* identical
 copies, `oans` keeps one physical copy and frees the other *N*−1, so this is the
-honest bytes-freed figure, not an inflated count. **Already shared** counts
-files skipped because their storage was already shared. If some destinations
-could not be deduped (their data changed since the scan, or the kernel refused),
-a **Not deduped** line reports the counts; re-run with **-v** for detail.
+honest bytes-freed figure, not an inflated count. Only data that was still
+duplicated counts towards it — a copy already sharing part of the target's
+storage contributes just the remainder, so a run over an already-deduplicated
+tree reports `0 B` rather than the volume it re-examined. **Already shared**
+counts files skipped entirely because their storage was already shared. If some
+destinations could not be deduped (their data changed since the scan, or the
+kernel refused), a **Not deduped** line reports the counts; re-run with **-v**
+for detail.
 
 When standard output is not a terminal, or under **-q**, `oans` also prints a
 stable machine-readable line:

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -45,11 +45,13 @@ struct dedupe_req {
 
 	uint64_t		req_loff;
 	uint64_t		req_total; /* total bytes processed by kernel */
+	uint64_t		req_unshared; /* of which was not already shared */
 	int			req_status;
 	int			req_idx; /* index into same->info */
 };
 
-static struct dedupe_req *new_dedupe_req(struct filerec *file, uint64_t loff)
+static struct dedupe_req *new_dedupe_req(struct filerec *file, uint64_t loff,
+					 uint64_t unshared)
 {
 	struct dedupe_req *req = calloc(1, sizeof(*req));
 
@@ -57,6 +59,7 @@ static struct dedupe_req *new_dedupe_req(struct filerec *file, uint64_t loff)
 		INIT_LIST_HEAD(&req->req_list);
 		req->req_file = file;
 		req->req_loff = loff;
+		req->req_unshared = unshared;
 	}
 	return req;
 }
@@ -233,9 +236,9 @@ struct dedupe_ctxt *new_dedupe_ctxt(unsigned int max_extents, uint64_t loff,
 }
 
 int add_extent_to_dedupe(struct dedupe_ctxt *ctxt, uint64_t loff,
-			 struct filerec *file)
+			 struct filerec *file, uint64_t unshared)
 {
-	struct dedupe_req *req = new_dedupe_req(file, loff);
+	struct dedupe_req *req = new_dedupe_req(file, loff, unshared);
 
 	abort_on(ctxt->num_queued >= ctxt->max_queable);
 
@@ -515,7 +518,7 @@ retry:
  */
 int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 			  uint64_t *off, uint64_t *bytes_deduped,
-			  struct filerec **file)
+			  uint64_t *bytes_freed, struct filerec **file)
 {
 	struct dedupe_req *req;
 
@@ -531,6 +534,11 @@ int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 	*status = req->req_status;
 	*off = req->req_loff - req->req_total;
 	*bytes_deduped = req->req_total;
+	/* Capped: the kernel may have got through less than the whole range
+	 * (a short round, a clamped length), and it cannot free more of the
+	 * duplication than it actually processed. */
+	*bytes_freed = req->req_unshared < req->req_total ?
+		req->req_unshared : req->req_total;
 	*file = req->req_file;
 
 	free_dedupe_req(req);

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -517,7 +517,6 @@ retry:
  * Returns 1 when we have no more items.
  */
 int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
-			  uint64_t *off, uint64_t *bytes_deduped,
 			  uint64_t *bytes_freed, struct filerec **file)
 {
 	struct dedupe_req *req;
@@ -532,13 +531,10 @@ int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 	list_del_init(&req->req_list);
 
 	*status = req->req_status;
-	*off = req->req_loff - req->req_total;
-	*bytes_deduped = req->req_total;
-	/* Capped: the kernel may have got through less than the whole range
-	 * (a short round, a clamped length), and it cannot free more of the
-	 * duplication than it actually processed. */
-	*bytes_freed = req->req_unshared < req->req_total ?
-		req->req_unshared : req->req_total;
+	/* Zero unless the kernel took it, and never more than it processed. */
+	*bytes_freed = req->req_status ? 0 :
+		(req->req_unshared < req->req_total ?
+		 req->req_unshared : req->req_total);
 	*file = req->req_file;
 
 	free_dedupe_req(req);

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -84,9 +84,11 @@ uint64_t dedupe_shareable_len(int fd, uint64_t len);
 /*
  * Queue one destination. `unshared` is how many of its bytes are not already
  * on the target's storage - what this dedupe would actually stop duplicating,
- * handed back by pop_one_dedupe_result() so the caller can report space freed
- * rather than bytes the kernel compared (#187). Callers that cannot tell pass
- * the full length.
+ * handed back by pop_one_dedupe_result() so the caller reports space freed
+ * rather than bytes the kernel compared (#187). It must be measured against
+ * the target (fiemap_unshared_bytes()); passing the full length credits the
+ * whole range, which is that over-count, and is only right when the target
+ * could not be mapped at all.
  *
  * Returns:
  *  < 0: error
@@ -97,11 +99,11 @@ int add_extent_to_dedupe(struct dedupe_ctxt *ctxt, uint64_t loff,
 			 struct filerec *file, uint64_t unshared);
 int dedupe_extents(struct dedupe_ctxt *ctxt);
 /*
- * `bytes_deduped` is what the kernel reported comparing and sharing;
- * `bytes_freed` is the part of that which was not already shared.
+ * `bytes_freed` is the destination's `unshared` bytes, capped at what the
+ * kernel actually processed and zero unless it accepted the request - i.e.
+ * space this dedupe stopped duplicating, not length it compared.
  */
 int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
-			  uint64_t *off, uint64_t *bytes_deduped,
 			  uint64_t *bytes_freed, struct filerec **file);
 
 #endif	/* __DEDUPE_H__ */

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -82,16 +82,26 @@ void free_dedupe_ctxt(struct dedupe_ctxt *ctxt);
 uint64_t dedupe_shareable_len(int fd, uint64_t len);
 
 /*
- * add_extent_to_dedupe returns:
+ * Queue one destination. `unshared` is how many of its bytes are not already
+ * on the target's storage - what this dedupe would actually stop duplicating,
+ * handed back by pop_one_dedupe_result() so the caller can report space freed
+ * rather than bytes the kernel compared (#187). Callers that cannot tell pass
+ * the full length.
+ *
+ * Returns:
  *  < 0: error
  * == 0: no more extents after this one
  *  > 0: ok, can accept more extents
  */
 int add_extent_to_dedupe(struct dedupe_ctxt *ctxt, uint64_t loff,
-			 struct filerec *file);
+			 struct filerec *file, uint64_t unshared);
 int dedupe_extents(struct dedupe_ctxt *ctxt);
+/*
+ * `bytes_deduped` is what the kernel reported comparing and sharing;
+ * `bytes_freed` is the part of that which was not already shared.
+ */
 int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 			  uint64_t *off, uint64_t *bytes_deduped,
-			  struct filerec **file);
+			  uint64_t *bytes_freed, struct filerec **file);
 
 #endif	/* __DEDUPE_H__ */

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -247,9 +247,9 @@ static uint64_t gap_at(const struct fiemap_extent *e, uint64_t off, uint64_t res
  * location (delalloc, unknown, inline) all report fe_physical 0 and must never
  * count as shared.
  */
-static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
-			      const struct fiemap *dm, uint64_t dest_off,
-			      uint64_t len)
+bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
+		       const struct fiemap *dm, uint64_t dest_off,
+		       uint64_t len)
 {
 	unsigned int i = 0;	/* both maps advance together, or we bail */
 	uint64_t pos = 0;	/* bytes of the range proven shared so far */
@@ -307,18 +307,78 @@ static bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 	return true;
 }
 
-bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
-			      int dest_fd, uint64_t dest_off, uint64_t len)
+static int cmp_u64(const void *a, const void *b)
 {
-	_cleanup_(freep) struct fiemap *dm = NULL;
+	uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
 
-	/* Cheap reject before paying for the destination's map: a target we
-	 * could not map is nothing to compare against. */
-	if (len == 0 || !tgt || tgt->fm_mapped_extents == 0)
-		return false;
+	return (x > y) - (x < y);
+}
 
-	/* NULL means an error or a hole-only range: not known shared. */
-	dm = do_fiemap_range(dest_fd, dest_off, len);
+uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count)
+{
+	uint64_t *v;
+	unsigned int n = 0;
 
-	return fiemap_maps_share(tgt, tgt_off, dm, dest_off, len);
+	*count = 0;
+	if (!fm || fm->fm_mapped_extents == 0)
+		return NULL;
+
+	v = malloc(fm->fm_mapped_extents * sizeof(*v));
+	if (!v)
+		return NULL;
+
+	for (unsigned int i = 0; i < fm->fm_mapped_extents; i++) {
+		if (fm->fm_extents[i].fe_flags & FIEMAP_NO_PHYS)
+			continue;	/* no stable address to match against */
+		v[n++] = fm->fm_extents[i].fe_physical;
+	}
+	qsort(v, n, sizeof(*v), cmp_u64);
+	*count = n;
+	return v;
+}
+
+/*
+ * How many bytes of [dest_off, dest_off+len) are NOT already on storage the
+ * target references - i.e. how much a dedupe would actually stop duplicating.
+ *
+ * Membership is by physical address: two records with the same fe_physical are
+ * the same stored bytes, so a destination record already sitting on one of the
+ * target's extents frees nothing, and where in the range it sits is irrelevant
+ * to that. Holes contribute nothing, having nothing to free.
+ *
+ * Approximate at the edges, by at most one extent either way: a partial
+ * reference at a different offset into the same uncompressed extent reports a
+ * different fe_physical and is counted as unshared, while a compressed extent
+ * reports one address for the whole extent so any part of it counts as shared.
+ * This only feeds the reported figure, never a decision to skip work.
+ */
+uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
+			       const struct fiemap *dm, uint64_t dest_off,
+			       uint64_t len)
+{
+	uint64_t unshared = 0;
+
+	/* No destination map means we could not tell: assume nothing is shared,
+	 * which is what the figure said before it could tell at all. */
+	if (!dm)
+		return len;
+
+	for (unsigned int i = 0; i < dm->fm_mapped_extents; i++) {
+		const struct fiemap_extent *e = &dm->fm_extents[i];
+		uint64_t start = e->fe_logical > dest_off ? e->fe_logical : dest_off;
+		uint64_t end = e->fe_logical + e->fe_length;
+
+		if (end > dest_off + len)
+			end = dest_off + len;
+		if (end <= start)
+			continue;
+
+		if (!(e->fe_flags & FIEMAP_NO_PHYS) && tgt_phys &&
+		    bsearch(&e->fe_physical, tgt_phys, tgt_n, sizeof(*tgt_phys),
+			    cmp_u64))
+			continue;	/* already on the target's storage */
+
+		unshared += end - start;
+	}
+	return unshared;
 }

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -307,13 +307,6 @@ bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 	return true;
 }
 
-static int cmp_u64(const void *a, const void *b)
-{
-	uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
-
-	return (x > y) - (x < y);
-}
-
 uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count)
 {
 	uint64_t *v;
@@ -333,6 +326,19 @@ uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count)
 		v[n++] = fm->fm_extents[i].fe_physical;
 	}
 	qsort(v, n, sizeof(*v), cmp_u64);
+
+	/* Collapse duplicates: a compressed extent reports one address for every
+	 * record referencing it, and a fragmented file can repeat one many times.
+	 * Shrinking the array shortens every later search. */
+	if (n > 1) {
+		unsigned int uniq = 1;
+
+		for (unsigned int i = 1; i < n; i++)
+			if (v[i] != v[uniq - 1])
+				v[uniq++] = v[i];
+		n = uniq;
+	}
+
 	*count = n;
 	return v;
 }
@@ -356,6 +362,7 @@ uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
 			       const struct fiemap *dm, uint64_t dest_off,
 			       uint64_t len)
 {
+	const uint64_t dest_end = dest_off + len;
 	uint64_t unshared = 0;
 
 	/* No destination map means we could not tell: assume nothing is shared,
@@ -368,12 +375,12 @@ uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
 		uint64_t start = e->fe_logical > dest_off ? e->fe_logical : dest_off;
 		uint64_t end = e->fe_logical + e->fe_length;
 
-		if (end > dest_off + len)
-			end = dest_off + len;
+		if (end > dest_end)
+			end = dest_end;
 		if (end <= start)
 			continue;
 
-		if (!(e->fe_flags & FIEMAP_NO_PHYS) && tgt_phys &&
+		if (!(e->fe_flags & FIEMAP_NO_PHYS) && tgt_n &&
 		    bsearch(&e->fe_physical, tgt_phys, tgt_n, sizeof(*tgt_phys),
 			    cmp_u64))
 			continue;	/* already on the target's storage */

--- a/src/fiemap.h
+++ b/src/fiemap.h
@@ -46,17 +46,15 @@ int fiemap_first_extent_poff(int fd, uint64_t start, uint64_t length,
 int fiemap_count_shared(int fd, size_t start_off, size_t end_off, uint64_t *shared);
 
 /*
- * True if [dest_off, dest_off+len) on dest_fd already resolves to the same
- * stored extents as the precomputed target map `tgt` (which describes
- * [tgt_off, tgt_off+len)) - i.e. the two ranges share all their storage, so
- * deduping them would be a byte-for-byte no-op. The target is passed as an
- * already-fetched map so a caller comparing one target against many
- * destinations fiemaps the target only once; get it from
- * do_fiemap_range(tgt_fd, tgt_off, len).
+ * True if [dest_off, dest_off+len) described by `dm` already resolves to the
+ * same stored extents as [tgt_off, tgt_off+len) described by `tgt` - i.e. the
+ * two ranges share all their storage, so deduping them would be a byte-for-byte
+ * no-op. Both maps come from do_fiemap_range(); a caller comparing one target
+ * against many destinations fetches the target's once.
  *
  * Compares coverage, not extent records: the same storage may be described
  * with different record boundaries in each file. Matching holes count as
- * shared. Conservative otherwise - returns false on any fiemap failure, any
+ * shared. Conservative otherwise - returns false on any missing map, any
  * difference it cannot prove away, or any extent without a real physical
  * location - so a caller only ever skips a genuine no-op, never a real dedupe.
  *
@@ -64,8 +62,26 @@ int fiemap_count_shared(int fd, size_t start_off, size_t end_off, uint64_t *shar
  * dedupe_shareable_len() first. A trailing partial block is never shared, so
  * including one makes this permanently false for every unaligned file.
  */
-bool fiemap_range_shared_with(const struct fiemap *tgt, uint64_t tgt_off,
-			      int dest_fd, uint64_t dest_off, uint64_t len);
+bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
+		       const struct fiemap *dm, uint64_t dest_off, uint64_t len);
+
+/*
+ * The physical addresses `fm` references, sorted, for fiemap_unshared_bytes()
+ * to look up. Built once per target and reused across its destinations.
+ * Returns NULL (count 0) for an empty map or on allocation failure; the caller
+ * frees it.
+ */
+uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count);
+
+/*
+ * Bytes of [dest_off, dest_off+len) that are not already on storage `tgt_phys`
+ * references - what deduping the destination would actually stop duplicating,
+ * as opposed to what the kernel reports having compared. See the definition for
+ * where it approximates.
+ */
+uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
+			       const struct fiemap *dm, uint64_t dest_off,
+			       uint64_t len);
 
 /*
  * Number of physical extents overlapping [start, start+length), via a single

--- a/src/oans.c
+++ b/src/oans.c
@@ -87,13 +87,6 @@ static void print_file(char *filename, char *ino, char *subvol)
 		printf("%s\n", filename);
 }
 
-static int cmp_u64(const void *a, const void *b)
-{
-	uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
-
-	return x < y ? -1 : x > y ? 1 : 0;
-}
-
 /* Human duration for the timing lines: ms under a second, else seconds. */
 static const char *fmt_dur(char *buf, size_t n, double s)
 {

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -191,7 +191,7 @@ static _Atomic uint64_t dedupe_dest_changed;
 static _Atomic uint64_t dedupe_dest_differs;
 static _Atomic uint64_t dedupe_dest_errors;
 /* Destinations skipped because they already shared all storage with the
- * target (deduping them would have been a no-op). See fiemap_ranges_shared(). */
+ * target (deduping them would have been a no-op). See fiemap_maps_share(). */
 static _Atomic uint64_t dedupe_dest_already_shared;
 
 static void process_dedupe_results(struct dedupe_ctxt *ctxt,
@@ -199,20 +199,15 @@ static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 {
 	int done = 0;
 	int target_status;
-	uint64_t target_loff, target_bytes, target_freed;
+	uint64_t target_freed;
 	struct filerec *f;
 	const char *status_str = "[unknown status]";
 
 	while (!done) {
-		done = pop_one_dedupe_result(ctxt, &target_status, &target_loff,
-					     &target_bytes, &target_freed, &f);
-		/*
-		 * Credit what stopped being duplicated, not what the kernel
-		 * compared: FIDEDUPERANGE reports the full length even when the
-		 * range already shared the target's storage, so counting that
-		 * let a run which freed nothing claim gigabytes (#187).
-		 */
-		if (freed_bytes && target_status == 0)
+		done = pop_one_dedupe_result(ctxt, &target_status,
+					     &target_freed, &f);
+		/* Space freed, not length compared (#187). */
+		if (freed_bytes)
 			*freed_bytes += target_freed;
 
 		/*
@@ -301,11 +296,11 @@ static int disk_extent_grew(struct dupe_extents *dext, struct extent *extent)
 /*
  * Drop the members that already share `target`'s storage: deduping them would
  * be a no-op. Cheap pre-filter over the poffs the scan already stored, so it
- * saves the exact fiemap_range_shared_with() call the loop would otherwise make
+ * saves the exact fiemap_maps_share() call the loop would otherwise make
  * per destination.
  *
  * The two tiers only coexist safely under one rule: **this must never cull
- * anything fiemap_range_shared_with() would not also skip.** Both are therefore
+ * anything fiemap_maps_share() would not also skip.** Both are therefore
  * relative to the target. Culling pairwise instead - one survivor per distinct
  * poff - is what broke that and made dedupe non-convergent; see CLAUDE.md for
  * why (#186).
@@ -472,9 +467,6 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	bool tgt_mapped = false;
 	/* What that check compares: all of `len` the kernel would dedupe. */
 	uint64_t cmp_len = 0;
-	/* Per-destination scratch, freed as soon as it has been read. */
-	struct fiemap *dest_map = NULL;
-	uint64_t unshared;
 	OPEN_ONCE(open_files);
 	struct extent *tgt_extent = NULL;
 
@@ -534,6 +526,9 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	slot_show_group(slot, dext);
 
 	list_for_each_entry(extent, &dext->de_extents, e_list) {
+		/* Declared before the gotos below jump forward past it. */
+		uint64_t unshared;
+
 		if (list_is_last(&extent->e_list, &dext->de_extents))
 			last = 1;
 
@@ -649,17 +644,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		}
 
 		/*
-		 * Map this destination once and get two things from it: whether
-		 * it already maps to the same physical extents as the target -
-		 * deduping it would be a byte-for-byte no-op, but the kernel
-		 * still reads and compares the whole range, the dominant cost on
-		 * already-shared trees like repeated snapshots (upstream #331) -
-		 * and, if not, how much of it is genuinely duplicated, which is
-		 * what the run gets to claim it freed (#187).
-		 *
-		 * The target's map and its sorted addresses are built once (a
-		 * couple of cheap metadata ioctls) and reused for every
-		 * destination.
+		 * One map of this destination answers both questions: is it
+		 * already on the target's extents, so deduping it would be a
+		 * byte-for-byte no-op the kernel would still read and compare in
+		 * full (upstream #331), and if not, how much of it is genuinely
+		 * duplicated - which is all the run may claim it freed (#187).
 		 */
 		if (!tgt_mapped) {
 			tgt_mapped = true;
@@ -670,27 +659,45 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			cmp_len = dedupe_shareable_len(tgt_extent->e_file->fd, len);
 			tgt_map = do_fiemap_range(tgt_extent->e_file->fd,
 						  tgt_extent->e_loff, cmp_len);
-			tgt_phys = fiemap_phys_sorted(tgt_map, &tgt_phys_n);
 		}
-		dest_map = do_fiemap_range(extent->e_file->fd, extent->e_loff,
-					   cmp_len);
-		if (fiemap_maps_share(tgt_map, tgt_extent->e_loff, dest_map,
-				      extent->e_loff, cmp_len)) {
+		/* Nothing to measure against: credit the whole range, as the
+		 * figure did before it could measure at all. */
+		unshared = cmp_len;
+		if (tgt_map) {
+			/* Measure while the map is in hand, free it once, then
+			 * act on the verdict. */
+			struct fiemap *dest_map =
+				do_fiemap_range(extent->e_file->fd,
+						extent->e_loff, cmp_len);
+			bool shared = fiemap_maps_share(tgt_map,
+							tgt_extent->e_loff,
+							dest_map,
+							extent->e_loff, cmp_len);
+
+			if (!shared) {
+				/* Built on first real use: a run over an
+				 * already-shared tree never needs it. */
+				if (!tgt_phys)
+					tgt_phys = fiemap_phys_sorted(tgt_map,
+								      &tgt_phys_n);
+				unshared = fiemap_unshared_bytes(tgt_phys,
+								 tgt_phys_n,
+								 dest_map,
+								 extent->e_loff,
+								 cmp_len);
+			}
 			free(dest_map);
-			dest_map = NULL;
-			atomic_fetch_add(&dedupe_dest_already_shared, 1);
-			group_tick(gp, len);	/* skipped, but credit its work */
-			vprintf("[%p] %s already shares the target's extents; "
-				"skipping.\n", g_thread_self(),
-				extent->e_file->filename);
-			if (ctxt && last)
-				goto run_dedupe;
-			continue;
+			if (shared) {
+				atomic_fetch_add(&dedupe_dest_already_shared, 1);
+				group_tick(gp, len); /* skipped, but credit its work */
+				vprintf("[%p] %s already shares the target's "
+					"extents; skipping.\n", g_thread_self(),
+					extent->e_file->filename);
+				if (ctxt && last)
+					goto run_dedupe;
+				continue;
+			}
 		}
-		unshared = fiemap_unshared_bytes(tgt_phys, tgt_phys_n, dest_map,
-						 extent->e_loff, cmp_len);
-		free(dest_map);
-		dest_map = NULL;
 
 		rc = add_extent_to_dedupe(ctxt, extent->e_loff, extent->e_file,
 					  unshared);

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -195,19 +195,25 @@ static _Atomic uint64_t dedupe_dest_errors;
 static _Atomic uint64_t dedupe_dest_already_shared;
 
 static void process_dedupe_results(struct dedupe_ctxt *ctxt,
-				   uint64_t *kern_bytes)
+				   uint64_t *freed_bytes)
 {
 	int done = 0;
 	int target_status;
-	uint64_t target_loff, target_bytes;
+	uint64_t target_loff, target_bytes, target_freed;
 	struct filerec *f;
 	const char *status_str = "[unknown status]";
 
 	while (!done) {
 		done = pop_one_dedupe_result(ctxt, &target_status, &target_loff,
-					     &target_bytes, &f);
-		if (kern_bytes)
-			*kern_bytes += target_bytes;
+					     &target_bytes, &target_freed, &f);
+		/*
+		 * Credit what stopped being duplicated, not what the kernel
+		 * compared: FIDEDUPERANGE reports the full length even when the
+		 * range already shared the target's storage, so counting that
+		 * let a run which freed nothing claim gigabytes (#187).
+		 */
+		if (freed_bytes && target_status == 0)
+			*freed_bytes += target_freed;
 
 		/*
 		 * Only report errors.
@@ -443,7 +449,7 @@ static void group_tick(void *arg, uint64_t bytes)
 static int dedupe_extent_list(struct dupe_extents *dext,
 			      struct group_progress *gp, bool whole_file_dedup,
 			      struct results_tree *res,
-			      uint64_t *fiemap_bytes, uint64_t *kern_bytes,
+			      uint64_t *fiemap_bytes, uint64_t *freed_bytes,
 			      unsigned long long passno)
 {
 	int ret = 0;
@@ -459,9 +465,16 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	 * is open; tgt_mapped says the attempt was made, so a target we cannot
 	 * fiemap is not retried for every remaining member. */
 	_cleanup_(freep) struct fiemap *tgt_map = NULL;
+	/* The target's physical addresses, for measuring how much of a
+	 * destination is genuinely duplicated rather than already shared. */
+	_cleanup_(freep) uint64_t *tgt_phys = NULL;
+	unsigned int tgt_phys_n = 0;
 	bool tgt_mapped = false;
 	/* What that check compares: all of `len` the kernel would dedupe. */
 	uint64_t cmp_len = 0;
+	/* Per-destination scratch, freed as soon as it has been read. */
+	struct fiemap *dest_map = NULL;
+	uint64_t unshared;
 	OPEN_ONCE(open_files);
 	struct extent *tgt_extent = NULL;
 
@@ -636,14 +649,17 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		}
 
 		/*
-		 * Skip a destination that already maps to the exact same
-		 * physical extents as the target: deduping it would be a
-		 * byte-for-byte no-op, but the kernel still reads and compares
-		 * the whole range, which is the dominant cost on already-shared
-		 * trees like repeated snapshots (upstream #331). The target map
-		 * is fetched once (a couple of cheap metadata ioctls) and reused
-		 * for every destination; it never skips a real dedupe (see
-		 * fiemap_range_shared_with()).
+		 * Map this destination once and get two things from it: whether
+		 * it already maps to the same physical extents as the target -
+		 * deduping it would be a byte-for-byte no-op, but the kernel
+		 * still reads and compares the whole range, the dominant cost on
+		 * already-shared trees like repeated snapshots (upstream #331) -
+		 * and, if not, how much of it is genuinely duplicated, which is
+		 * what the run gets to claim it freed (#187).
+		 *
+		 * The target's map and its sorted addresses are built once (a
+		 * couple of cheap metadata ioctls) and reused for every
+		 * destination.
 		 */
 		if (!tgt_mapped) {
 			tgt_mapped = true;
@@ -654,10 +670,14 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			cmp_len = dedupe_shareable_len(tgt_extent->e_file->fd, len);
 			tgt_map = do_fiemap_range(tgt_extent->e_file->fd,
 						  tgt_extent->e_loff, cmp_len);
+			tgt_phys = fiemap_phys_sorted(tgt_map, &tgt_phys_n);
 		}
-		if (fiemap_range_shared_with(tgt_map, tgt_extent->e_loff,
-					     extent->e_file->fd, extent->e_loff,
-					     cmp_len)) {
+		dest_map = do_fiemap_range(extent->e_file->fd, extent->e_loff,
+					   cmp_len);
+		if (fiemap_maps_share(tgt_map, tgt_extent->e_loff, dest_map,
+				      extent->e_loff, cmp_len)) {
+			free(dest_map);
+			dest_map = NULL;
 			atomic_fetch_add(&dedupe_dest_already_shared, 1);
 			group_tick(gp, len);	/* skipped, but credit its work */
 			vprintf("[%p] %s already shares the target's extents; "
@@ -667,8 +687,13 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 				goto run_dedupe;
 			continue;
 		}
+		unshared = fiemap_unshared_bytes(tgt_phys, tgt_phys_n, dest_map,
+						 extent->e_loff, cmp_len);
+		free(dest_map);
+		dest_map = NULL;
 
-		rc = add_extent_to_dedupe(ctxt, extent->e_loff, extent->e_file);
+		rc = add_extent_to_dedupe(ctxt, extent->e_loff, extent->e_file,
+					  unshared);
 		if (rc) {
 			if (rc < 0) {
 				/* This can only be ENOMEM. */
@@ -704,7 +729,7 @@ run_dedupe:
 
 			ret = dedupe_extents(ctxt);
 			if (ret == 0) {
-				process_dedupe_results(ctxt, kern_bytes);
+				process_dedupe_results(ctxt, freed_bytes);
 			} else {
 				ret = errno;
 				eprintf("FAILURE: Dedupe ioctl returns %d: %s\n",
@@ -765,7 +790,7 @@ out:
 static int extent_dedupe_worker(struct dupe_extents *dext,
 				struct group_progress *gp, bool whole_file_dedup,
 				struct results_tree *res,
-				uint64_t *fiemap_bytes, uint64_t *kern_bytes)
+				uint64_t *fiemap_bytes, uint64_t *freed_bytes)
 {
 	int ret;
 	unsigned long long passno = __atomic_add_fetch(&curr_dedupe_pass, 1, __ATOMIC_SEQ_CST);
@@ -775,7 +800,7 @@ static int extent_dedupe_worker(struct dupe_extents *dext,
 	struct dbhandle *db = dbfile_get_handle();
 
 	ret = dedupe_extent_list(dext, gp, whole_file_dedup, res, fiemap_bytes,
-				 kern_bytes, passno);
+				 freed_bytes, passno);
 	if (ret) {
 		if (ret == DEDUPE_EXTENTS_CLEANED)
 			return 0;
@@ -834,7 +859,7 @@ static void batch_maybe_complete_locked(struct dedupe_batch *batch)
 static void dedupe_worker_body(void *priv)
 {
 	uint64_t fiemap_bytes = 0ULL;
-	uint64_t kern_bytes = 0ULL;
+	uint64_t freed_bytes = 0ULL;
 	struct dedupe_work_item *item = priv;
 	struct dupe_extents *dext = item->dext;
 	struct dedupe_batch *batch = item->batch;
@@ -862,7 +887,7 @@ static void dedupe_worker_body(void *priv)
 	slot_show_group(slot, dext);
 
 	extent_dedupe_worker(dext, &gp, whole_file, res, &fiemap_bytes,
-			     &kern_bytes);
+			     &freed_bytes);
 
 	/*
 	 * Settle up the byte bar: credit whatever work never reached the kernel
@@ -881,7 +906,7 @@ static void dedupe_worker_body(void *priv)
 	 * too (~2x for pairs), so it is reported only as the "net change in
 	 * shared extents" diagnostic, not as space reclaimed.
 	 */
-	pdedupe_group_done(kern_bytes, fiemap_bytes);
+	pdedupe_group_done(freed_bytes, fiemap_bytes);
 
 	/* Last one out of this batch wakes the producer to reap it. */
 	g_mutex_lock(&producer_mutex);

--- a/src/tests.c
+++ b/src/tests.c
@@ -191,12 +191,6 @@ MU_TEST(test_get_extent) {
 	free(fm);
 }
 
-/*
- * fiemap_maps_share() decides whether deduping one range against another would
- * be a no-op. It has to answer "yes" for storage that is genuinely shared but
- * described with different record boundaries, or the same file is resubmitted
- * to the kernel on every run (#186) - and "no" whenever it cannot prove it.
- */
 /* Build both maps, compare, free. Keeps each case below to its records. */
 static bool share(const struct fm_rec *ra, unsigned int na, uint64_t off_a,
 		  const struct fm_rec *rb, unsigned int nb, uint64_t off_b,
@@ -283,6 +277,76 @@ MU_TEST(test_fiemap_maps_share) {
 
 	mu_check(share(big, 1, 8192, big, 1, 8192, 8192));
 	mu_check(!share(big, 1, 8192, offset, 1, 8192, 4096));
+}
+
+/* Sort the target's addresses, measure the destination against them, free. */
+static uint64_t unshared(const struct fm_rec *rt, unsigned int nt,
+			 const struct fm_rec *rd, unsigned int nd,
+			 uint64_t dest_off, uint64_t len)
+{
+	struct fiemap *t = mkmap(rt, nt), *d = nd ? mkmap(rd, nd) : NULL;
+	unsigned int n = 0;
+	uint64_t *phys = fiemap_phys_sorted(t, &n);
+	uint64_t bytes = fiemap_unshared_bytes(phys, n, d, dest_off, len);
+
+	free(phys);
+	free(t);
+	free(d);
+	return bytes;
+}
+
+/*
+ * fiemap_unshared_bytes() answers "how much would deduping this destination
+ * actually stop duplicating" - the figure a run reports as reclaimed. The
+ * kernel's own byte count cannot answer it: FIDEDUPERANGE reports the whole
+ * compared length even for a range that already shared the target's storage
+ * (#187).
+ */
+MU_TEST(test_fiemap_unshared_bytes) {
+	const uint32_t SH = FIEMAP_EXTENT_SHARED;
+	struct fm_rec tgt[] = {{0, 4096, 8192, SH}};
+
+	/* Already on the target's extent: nothing would be freed. */
+	mu_check(unshared(tgt, 1, tgt, 1, 0, 8192) == 0);
+
+	/* A copy of its own: all of it. */
+	struct fm_rec other[] = {{0, 99999, 8192, 0}};
+
+	mu_check(unshared(tgt, 1, other, 1, 0, 8192) == 8192);
+
+	/*
+	 * The case the reported figure got wrong: half the destination already
+	 * sits on the target's extent, so only the other half is duplicated.
+	 */
+	struct fm_rec half[] = {{0, 4096, 4096, SH}, {4096, 99999, 4096, 0}};
+
+	mu_check(unshared(tgt, 1, half, 2, 0, 4096 * 2) == 4096);
+
+	/* Position is irrelevant: the same stored extent frees nothing wherever
+	 * the destination references it. */
+	struct fm_rec elsewhere[] = {{0, 4096, 4096, SH}};
+
+	mu_check(unshared(tgt, 1, elsewhere, 1, 0, 4096) == 0);
+
+	/* Records are clipped to the range, not counted whole. */
+	struct fm_rec wide[] = {{0, 99999, 1 << 20, 0}};
+
+	mu_check(unshared(tgt, 1, wide, 1, 0, 8192) == 8192);
+
+	/* A hole frees nothing - there is nothing there to stop duplicating. */
+	struct fm_rec late[] = {{65536, 99999, 4096, 0}};
+
+	mu_check(unshared(tgt, 1, late, 1, 0, 8192) == 0);
+
+	/* No usable address on either side: cannot prove anything is shared, so
+	 * report it all as duplicated rather than over-claiming a saving. */
+	struct fm_rec delalloc[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
+
+	mu_check(unshared(tgt, 1, delalloc, 1, 0, 8192) == 8192);
+	mu_check(unshared(delalloc, 1, tgt, 1, 0, 8192) == 8192);
+
+	/* No destination map at all (fiemap failed): same fallback. */
+	mu_check(unshared(tgt, 1, NULL, 0, 0, 8192) == 8192);
 }
 
 MU_TEST(test_sanitize_ctrl) {
@@ -923,6 +987,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_seen_inode);
 	MU_RUN_TEST(test_get_extent);
 	MU_RUN_TEST(test_fiemap_maps_share);
+	MU_RUN_TEST(test_fiemap_unshared_bytes);
 	MU_RUN_TEST(test_sanitize_ctrl);
 	MU_RUN_TEST(test_progress_copy_path);
 	MU_RUN_TEST(test_progress_path_two_stage_render);

--- a/src/tests.c
+++ b/src/tests.c
@@ -347,6 +347,24 @@ MU_TEST(test_fiemap_unshared_bytes) {
 
 	/* No destination map at all (fiemap failed): same fallback. */
 	mu_check(unshared(tgt, 1, NULL, 0, 0, 8192) == 8192);
+
+	/*
+	 * The two measures gate different things - one a skip, one a number -
+	 * but they must agree at the boundary: anything fiemap_maps_share()
+	 * calls fully shared has nothing left to free. Shared fixtures, so a
+	 * future relaxation of one cannot silently drift from the other.
+	 */
+	struct fm_rec tail[] = {{0, 4096, 8192, SH}, {8192, 99999, 4096, 0}};
+
+	/* Identical maps. */
+	mu_check(share(tgt, 1, 0, tgt, 1, 0, 8192));
+	mu_check(unshared(tgt, 1, tgt, 1, 0, 8192) == 0);
+	/* A tail split off past the compared range. */
+	mu_check(share(tgt, 1, 0, tail, 2, 0, 8192));
+	mu_check(unshared(tgt, 1, tail, 2, 0, 8192) == 0);
+	/* Matching holes to the end of the range. */
+	mu_check(share(tgt, 1, 0, tgt, 1, 0, 262144));
+	mu_check(unshared(tgt, 1, tgt, 1, 0, 262144) == 0);
 }
 
 MU_TEST(test_sanitize_ctrl) {

--- a/src/util.h
+++ b/src/util.h
@@ -93,6 +93,14 @@ unsigned int get_num_cpus(void);
 /* Bump up maximum open file limit. */
 int increase_limits(void);
 
+/* qsort/bsearch over a plain uint64_t array. */
+static inline int cmp_u64(const void *a, const void *b)
+{
+	uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
+
+	return (x > y) - (x < y);
+}
+
 #define _cleanup_(x) __attribute__((cleanup(x)))
 static inline void freep(void *p)
 {

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -18,6 +18,7 @@ Configuration via environment:
 import ctypes
 import fcntl
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -49,7 +50,7 @@ _ERROR_RE = re.compile(
 _NET_CHANGE_RE = re.compile(r"net change in shared extents of:\s*(\d+)")
 # The human summary line, e.g. "  Reclaimed      1.0 MiB across 1 group".
 # The size is human_size()-rendered ("1.0 MiB", "512 B"), so assert on the
-# rendered string; for exact bytes use --json's reclaimed_total_bytes instead.
+# rendered string; for exact bytes use reclaimed_bytes() below.
 _RECLAIMED_RE = re.compile(r"Reclaimed\s+([\d.]+ [A-Za-z]+)\s+across\s+(\d+)\s+group")
 _ALREADY_SHARED_RE = re.compile(r"Already shared (\d+) file")
 
@@ -315,11 +316,18 @@ class DuperemoveTest(unittest.TestCase):
         size_str is the rendered human figure (e.g. '1.0 MiB') — the honest
         disk-freed amount, one physical copy kept per group. Matches both the
         full Summary block and the -q one-liner (#148); returns None when there
-        was nothing to dedupe. For exact byte assertions use the --json
-        `reclaimed_total_bytes` field.
+        was nothing to dedupe. For exact byte assertions use reclaimed_bytes().
         """
         m = _RECLAIMED_RE.search(self.out)
         return (m.group(1), int(m.group(2))) if m else None
+
+    def reclaimed_bytes(self):
+        """Exact bytes freed, from the hashfile's --json metrics.
+
+        The human summary rounds ('1.0 MiB'); this is the figure to assert on.
+        Runs oans again, so it needs a hashfile the previous run wrote to.
+        """
+        return json.loads(self.dm("--json"))["reclaimed_total_bytes"]
 
     def assertReclaimed(self, size_str, groups, msg=None):
         """Assert the summary reported `size_str` reclaimed across `groups`."""

--- a/tests/integration/test_dedupe.py
+++ b/tests/integration/test_dedupe.py
@@ -1,14 +1,19 @@
 """Dedupe phase: identical files share storage, data is preserved, second run
 is a no-op. Requires a reflink-capable filesystem."""
 
+import json
 import os
-from harness import DuperemoveTest, requires_reflink
+from harness import DuperemoveTest, phys_extents, requires_reflink
 
 MiB = 1 << 20
 
 
 @requires_reflink
 class DedupeTest(DuperemoveTest):
+    # test_reclaimed_excludes_what_was_already_shared turns on the physical
+    # layout a reflink-plus-rewrite leaves behind; see DuperemoveTest.serial.
+    serial = True
+
     def test_shares_identical_files(self):
         a, b = self.mkdup("tree/a", "tree/b", MiB)
         self.sync()
@@ -39,6 +44,40 @@ class DedupeTest(DuperemoveTest):
         self.dm("-rd", self.path("tree"), quiet=False)  # full Summary block
         self.assertDmOk()
         self.assertReclaimed("1.0 MiB", 1)
+
+    def test_reclaimed_excludes_what_was_already_shared(self):
+        """Half the copy already sits on the target's extents: half is freed.
+
+        FIDEDUPERANGE reports the whole compared length as deduped whether or
+        not the range already shared that storage, so crediting the kernel's
+        figure counted the shared half as freed too - and a run that freed
+        nothing could still claim gigabytes (#187).
+
+        Built by reflinking and then rewriting the second half, so exactly
+        1 MiB of the 2 MiB copy is duplicated. Layout-sensitive, hence serial;
+        the precondition is checked rather than assumed.
+        """
+        data = os.urandom(2 * MiB)
+        a = self.write("tree/a", data)
+        self.sync()
+        b = self.reflink("tree/a", "tree/b")
+        with open(b, "r+b") as f:
+            f.seek(MiB)
+            f.write(data[MiB:])
+        self.sync()
+
+        pa, pb = phys_extents(a), phys_extents(b)
+        if not (pa & pb) or not (pb - pa):
+            self.skipTest(f"no half-shared layout here: a={sorted(pa)} "
+                          f"b={sorted(pb)}")
+
+        # a is the least fragmented, so pick_dedupe_target() makes it the
+        # target and b the destination whose unshared half gets counted.
+        self.dedupe(self.path("tree"))
+        self.assertDmOk()
+        self.assertEqual(MiB,
+                         json.loads(self.dm("--json"))["reclaimed_total_bytes"],
+                         "only the half that was still duplicated was freed")
 
     def test_is_idempotent(self):
         a, b = self.mkdup("tree/a", "tree/b", MiB)

--- a/tests/integration/test_dedupe.py
+++ b/tests/integration/test_dedupe.py
@@ -1,7 +1,6 @@
 """Dedupe phase: identical files share storage, data is preserved, second run
 is a no-op. Requires a reflink-capable filesystem."""
 
-import json
 import os
 from harness import DuperemoveTest, phys_extents, requires_reflink
 
@@ -75,8 +74,7 @@ class DedupeTest(DuperemoveTest):
         # target and b the destination whose unshared half gets counted.
         self.dedupe(self.path("tree"))
         self.assertDmOk()
-        self.assertEqual(MiB,
-                         json.loads(self.dm("--json"))["reclaimed_total_bytes"],
+        self.assertEqual(MiB, self.reclaimed_bytes(),
                          "only the half that was still duplicated was freed")
 
     def test_is_idempotent(self):


### PR DESCRIPTION
Fixes #187.

## The problem

`Reclaimed` summed the kernel's `bytes_deduped`. `FIDEDUPERANGE` returns the whole compared length whether or not the range already shared the target's storage, so the figure measured *work done*, not *space saved*.

Measured on master with a deliberately half-shared pair — a 2 MiB file, reflinked, then its second half rewritten so exactly 1 MiB is still duplicated:

```
exclusive before: 1048576      <- btrfs filesystem du -s
 Reclaimed 2.0 MiB across 1 group
exclusive after:  0            <- 1 MiB actually freed
```

Double the truth. Before #186 the same defect let a run that freed **nothing** report 6.6 GiB, which is what made that bug invisible for so long.

## The fix

Measure each destination before submitting it. The already-shared check already fetches the destination's extent map; keep it and ask how many of its bytes are *not* on storage the target references.

Membership is by physical address — two records with the same `fe_physical` are the same stored bytes, so a destination already sitting on one of the target's extents frees nothing, and where in the range it sits is irrelevant to that. The target's addresses are sorted once per group and binary-searched per destination, so a fragmented whole-file group stays O(n log n) instead of O(n·m).

The figure rides along on the dedupe request and comes back with the result, so it is credited **per destination**, capped by what the kernel actually got through, and only for destinations the kernel accepted. The variable carrying it is no longer called `kern_bytes`, which is what it stopped being.

Same pair after:

```
exclusive before: 1048576
 Reclaimed 1.0 MiB across 1 group
exclusive after:  0
--- second run:
 Reclaimed 0 B across 1 group
 Already shared 1 file skipped (no work needed)
```

## Where it approximates

By at most one extent either way, and the direction is documented at the definition:

- a partial reference at a different offset into an *uncompressed* extent reports a different `fe_physical` and reads as unshared (over-counts freed);
- a *compressed* extent reports one address for the whole extent, so any part of it reads as shared (under-counts freed).

It only ever feeds the reported number — never a decision to skip work — so neither can cost a real dedupe. A physically exact figure needs `BTRFS_IOC_LOGICAL_INO` and therefore root, which is why `Reclaimed` stays a logical figure; that caveat is unchanged and still documented.

## Tests

- `test_reclaimed_excludes_what_was_already_shared` — the half-shared pair, asserting exact bytes via `--json`. Fails `2097152 != 1048576` without the change. Layout-sensitive, so the class is serial and the precondition is checked rather than assumed.
- `test_fiemap_unshared_bytes` — unit test over synthetic maps: fully shared, fully independent, half shared, position-independence, clipping to the range, holes, no-physical-address records, and a missing map.
- `test_reports_honest_reclaimed` (existing) still passes unchanged: an ordinary 1 MiB pair of independent copies still reports 1.0 MiB.

`scripts/verify.sh`, `make integration-valgrind` (no findings) and the ThreadSanitizer leg all pass locally. A full `oans -dr ~/` reports 19.7 MiB then 0 B on the second run.

Docs updated: the man page's OUTPUT section, and CLAUDE.md gains the rule — never credit `bytes_deduped` as space freed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)