### PR TITLE
tests: assert convergence and honesty against the kernel, not against oans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,3 +671,20 @@ check unlinks and recreates (it's only a cache).
   as shared), which is why it must never gate a *decision*, only the figure.
   Pinned by `test_reclaimed_excludes_what_was_already_shared` and the
   `test_fiemap_unshared_bytes` unit test.
+- **Check a reported figure against `physical_footprint()`, not against
+  sharing.** `tests/integration/test_convergence.py` asserts the two properties
+  a summary cannot show — a second run frees nothing, and the reported figure
+  equals the drop in distinct physical storage the tree references (summed from
+  fiemap in the harness, independently of anything oans computes). #186 and
+  #187 both shipped because the suite checked what oans *said* and which
+  extents it *shared*, and never either of these. Its layout zoo lives in one
+  tree on purpose: #186 only reproduced at that scale.
+  - **A whole-file group is not a substitute for an extent group.** Whole-file
+    groups load with `poff = 0` and skip `clean_deduped()` entirely, so only an
+    extent-pass layout (same tail, different heads) reproduces #186 — a
+    four-identical-file version of the same physical shape does not.
+  - **Known over-count (#191), deliberately excluded from that test:** two members of
+    one group sitting on a *single* extent are each credited in full, while
+    releasing that extent frees its length once — 2.0 MiB reported against
+    1 MiB freed. The per-destination measure has no notion of destinations
+    sharing storage with *each other*. Convergence is unaffected.

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -133,6 +133,42 @@ def files_share(a, b, dir_fd=None):
     return bool(phys_extents(a, dir_fd) & phys_extents(b, dir_fd))
 
 
+def physical_footprint(directory):
+    """Bytes of distinct physical storage the files under `directory` reference.
+
+    The union of [physical, physical+length) over every regular file's real
+    extents, so storage that several files share is counted once. Reducing this
+    number is dedupe's entire job, which makes the drop across a run the ground
+    truth to check a reported "Reclaimed" against - arrived at from the kernel's
+    extent maps, independently of anything oans computes.
+
+    Only meaningful for incompressible data: on a compressed filesystem
+    fe_length is the *logical* length while fe_physical is a disk address, so
+    the ranges are not real disk ranges. Callers write os.urandom(), which btrfs
+    detects as incompressible and stores raw even under compress=zstd.
+    """
+    ranges = []
+    for root, _dirs, names in os.walk(directory):
+        for name in names:
+            p = os.path.join(root, name)
+            if os.path.islink(p) or not os.path.isfile(p):
+                continue
+            ranges.extend((phys, phys + length)
+                          for _log, phys, length, flags in fiemap_extents(p)
+                          if not (flags & _NO_PHYS))
+
+    total = 0
+    start = end = None
+    for lo, hi in sorted(ranges):
+        if end is not None and lo <= end:
+            end = max(end, hi)
+            continue
+        if end is not None:
+            total += end - start
+        start, end = lo, hi
+    return total + (end - start if end is not None else 0)
+
+
 # --------------------------------------------------------------------------
 # Reflink support probe
 # --------------------------------------------------------------------------

--- a/tests/integration/test_convergence.py
+++ b/tests/integration/test_convergence.py
@@ -1,0 +1,237 @@
+"""The two properties a dedupe run's summary cannot show you.
+
+Both #186 and #187 shipped for months because the suite checked what oans
+*said* and which extents it *shared*, but never whether a run finished the job
+or whether the space it claimed to free was freed. The two bugs concealed each
+other: the inflated figure made a run that freed nothing look like one that
+worked.
+
+So this file asserts against ground truth read back from the kernel:
+
+  - convergence - a second run over an unchanged tree must free nothing, over
+    every layout dedupe has to cope with, all sharing one run. #186 only
+    reproduced at that scale: every subdirectory converged on its own while
+    their union did not.
+  - honesty - the reported figure against the drop in physical storage the
+    tree references, measured from fiemap rather than restated from anything
+    oans computed.
+"""
+
+import os
+from harness import (DuperemoveTest, phys_extents, physical_footprint,
+                     requires_reflink)
+
+KiB = 1 << 10
+MiB = 1 << 20
+
+
+@requires_reflink
+class ConvergenceTest(DuperemoveTest):
+    # Every layout here is built for its physical shape; see
+    # DuperemoveTest.serial.
+    serial = True
+
+    # -- layout builders ---------------------------------------------------
+    #
+    # Each makes one duplicate group of a different shape. Data is always
+    # os.urandom(): incompressible, so physical_footprint() measures real disk
+    # ranges and a compressed extent's single address cannot blur the result.
+
+    def _independent(self, d, copies=2, size=MiB):
+        """The ordinary case: N copies, each with its own storage."""
+        data = os.urandom(size)
+        for i in range(copies):
+            self.write(f"{d}/f{i}", data)
+
+    def _three_way(self, d):
+        self._independent(d, copies=3)
+
+    def _unaligned(self, d):
+        """A size that is not a whole number of blocks."""
+        self._independent(d, size=64 * KiB + 1234)
+
+    def _sub_block(self, d):
+        """Smaller than one block, but over btrfs's max_inline (2048): an
+        inline extent has no address and cannot be deduplicated at all."""
+        self._independent(d, size=4 * KiB - 96)
+
+    def _sparse(self, d):
+        """fiemap omits holes, so the map stops short of the range end."""
+        head, tail = os.urandom(8 * KiB), os.urandom(8 * KiB)
+        for name in ("a", "b"):
+            self.make_sparse(f"{d}/{name}", head, 256 * KiB, tail)
+
+    def _trailing_hole(self, d):
+        """Same, with the map simply running out before the range does."""
+        data = os.urandom(8 * KiB)
+        for name in ("a", "b"):
+            self.make_trailing_hole(f"{d}/{name}", data, 256 * KiB)
+
+    def _split_tail(self, d):
+        """Every full block shared, the trailing partial block not - what a
+        dedupe of an unaligned file leaves behind."""
+        aligned = 128 * KiB
+        data = os.urandom(aligned + 2000)
+        self.write(f"{d}/a", data)
+        self.sync()
+        b = self.reflink(f"{d}/a", f"{d}/b")
+        with open(b, "r+b") as f:
+            f.seek(aligned)
+            f.write(data[aligned:])
+
+    def _half_shared(self, d):
+        """Half the copy already sits on the target's extents (#187)."""
+        data = os.urandom(2 * MiB)
+        self.write(f"{d}/a", data)
+        self.sync()
+        b = self.reflink(f"{d}/a", f"{d}/b")
+        with open(b, "r+b") as f:
+            f.seek(MiB)
+            f.write(data[MiB:])
+
+    def _two_physical_classes(self, d):
+        """One group over two extents, two members each - the shape that needed
+        N runs to converge before #186."""
+        data = os.urandom(MiB)
+        self.write(f"{d}/a1", data)
+        self.write(f"{d}/b1", data)
+        self.sync()
+        self.reflink(f"{d}/a1", f"{d}/a2")
+        self.reflink(f"{d}/b1", f"{d}/b2")
+
+    def _two_extent_classes(self, d):
+        """The same two-class shape, but reached through the *extent* pass:
+        one shared tail behind four different heads, so the whole-file pass
+        cannot claim these. That distinction matters - whole-file groups load
+        with no physical offsets and skip the cheap cull entirely, so only this
+        version exercises it, and only this version reproduces #186.
+        """
+        head = 64 * KiB
+        tail = os.urandom(4 * MiB)
+        for seed in ("a", "b"):
+            with open(self.path(f"{d}/{seed}1"), "wb") as f:
+                f.write(os.urandom(head))
+                f.flush()
+                os.fsync(f.fileno())     # force an extent boundary
+                f.write(tail)
+        self.sync()
+        for seed in ("a", "b"):
+            copy = self.reflink(f"{d}/{seed}1", f"{d}/{seed}2")
+            with open(copy, "r+b") as f:
+                f.write(os.urandom(head))
+
+    # Every layout, for the convergence property.
+    ALL = ("independent", "three_way", "unaligned", "sub_block", "sparse",
+           "trailing_hole", "split_tail", "half_shared",
+           "two_physical_classes", "two_extent_classes")
+    # Layouts where the reported figure is exactly the storage freed.
+    EXACT = ("independent", "three_way", "sparse", "trailing_hole",
+             "half_shared")
+    # Already as shared as the kernel can make them, so a run must free nothing
+    # and say so - the case an over-reporting figure used to hide.
+    NOTHING_TO_FREE = ("split_tail",)
+    # Layouts that free whole blocks while the figure counts logical bytes, so
+    # it understates by up to one block - the harmless direction, and inherent
+    # to Reclaimed being a logical figure.
+    BLOCK_ROUNDED = ("unaligned", "sub_block")
+
+    def _build(self, names, root):
+        """Build each named layout under its own directory in `root`."""
+        for name in names:
+            getattr(self, "_" + name)(f"{root}/{name}")
+        self.sync()
+        return self.path(root)
+
+    # -- the properties ----------------------------------------------------
+
+    def test_second_run_over_every_layout_is_a_noop(self):
+        """Convergence, over all the layouts at once.
+
+        Without a hashfile, so each invocation reconsiders the whole tree: the
+        incremental watermark would otherwise make the second run a no-op for
+        the wrong reason.
+        """
+        tree = self._build(self.ALL, "tree")
+        digest = self.tree_digest(tree)
+
+        self.dm("-rd", tree, hashfile=False)
+        self.assertDmOk("first dedupe")
+        self.sync()
+        settled = physical_footprint(tree)
+
+        self.dm("-rd", tree, hashfile=False, quiet=False)
+        self.assertDmOk("second dedupe")
+        self.sync()
+
+        self.assertReclaimedNothing("one run has to finish the job")
+        self.assertEqual(settled, physical_footprint(tree),
+                         "second run moved storage around for nothing")
+        self.assertEqual(digest, self.tree_digest(tree),
+                         "dedupe preserved file contents")
+
+    def test_reclaimed_matches_storage_freed(self):
+        """The reported figure against the storage that stopped being used.
+
+        Measured from fiemap, so it is ground truth rather than a restatement
+        of what oans computed - the check neither #186 nor #187 had, which is
+        why both could ship. Per layout, so a failure names the shape.
+
+        The two-class layouts are left out: two members of one group sitting
+        on a single extent are each credited in full, while releasing that
+        extent frees its length once (2.0 MiB reported against 1 MiB freed). A
+        real over-count (#191); convergence is unaffected and the test above
+        covers both layouts.
+        """
+        seen = 0
+        for name in self.EXACT + self.BLOCK_ROUNDED + self.NOTHING_TO_FREE:
+            with self.subTest(layout=name):
+                # Its own root, so each run scans only this layout.
+                tree = self._build([name], f"t_{name}")
+                digest = self.tree_digest(tree)
+                before = physical_footprint(tree)
+
+                self.dedupe(tree)       # a hashfile, so --json can be read
+                self.assertDmOk()
+                self.sync()
+
+                freed = before - physical_footprint(tree)
+                total = self.reclaimed_bytes()
+                reported, seen = total - seen, total
+
+                if name in self.NOTHING_TO_FREE:
+                    self.assertEqual(0, freed, "expected nothing to free")
+                    self.assertEqual(0, reported, "claimed a saving it did not make")
+                elif name in self.EXACT:
+                    self.assertGreater(freed, 0, "nothing was deduplicated")
+                    self.assertEqual(freed, reported,
+                                     "reported Reclaimed is not what was freed")
+                else:
+                    self.assertGreater(freed, 0, "nothing was deduplicated")
+                    # Over-claiming is #187; understating by block rounding is
+                    # inherent to reporting logical bytes.
+                    self.assertLessEqual(reported, freed, "over-claimed")
+                    self.assertLess(freed - reported, 64 * KiB,
+                                    "shortfall exceeds block rounding")
+                self.assertEqual(digest, self.tree_digest(tree),
+                                 "dedupe preserved file contents")
+
+    def test_footprint_helper_sees_sharing(self):
+        """Guard the measurement itself: a reflink must not add footprint and
+        an independent copy must, or a broken helper would make the assertions
+        above pass by measuring nothing."""
+        data = os.urandom(MiB)
+        a = self.write("t/a", data)
+        self.sync()
+        base = physical_footprint(self.path("t"))
+        self.assertGreaterEqual(base, MiB)
+
+        self.reflink("t/a", "t/shared")
+        self.sync()
+        self.assertEqual(base, physical_footprint(self.path("t")),
+                         "a reflink references the same storage")
+
+        b = self.write("t/independent", data)
+        self.sync()
+        self.assertEqual(base * 2, physical_footprint(self.path("t")),
+                         "an independent copy doubles the storage referenced")
+        self.assertFalse(phys_extents(a) & phys_extents(b))


### PR DESCRIPTION
The two properties a dedupe run's summary cannot show you, asserted against ground truth.

## Why

#186 and #187 both shipped for months, and the suite could not have caught either. It checks what oans *says* and which extents it *shares* — never whether a run finished the job, nor whether the space it claimed to free was freed. The two bugs concealed each other: the inflated figure made a run that freed nothing look like one that worked. Establishing that "2.0 MiB" was really 1 MiB meant reaching for `btrfs filesystem du` by hand.

## What

`harness.physical_footprint()` — the union of `[physical, physical+length)` over a tree's real extents, so storage several files share counts once. Reducing that number is dedupe's entire job, which makes its drop across a run the ground truth for a reported figure. Read from fiemap, independent of anything oans computes. Only sound for incompressible data, so every layout writes `os.urandom()`.

Ten layouts: independent, three-way, unaligned, sub-block, sparse, trailing hole, split tail, half-shared, and two-physical-class groups reached through **both** the whole-file and the extent pass.

- **`test_second_run_over_every_layout_is_a_noop`** — convergence, all layouts sharing one run. That combination is deliberate: #186 only reproduced at that scale, since every subdirectory converged on its own while their union did not.
- **`test_reclaimed_matches_storage_freed`** — reported equals storage freed, per layout so a failure names the shape.
- **`test_footprint_helper_sees_sharing`** — guards the measurement itself, so a broken helper cannot make the other two pass by measuring nothing.

## Verified to catch the originals

Reintroducing each bug and re-running:

| reinstated bug | result |
| --- | --- |
| pairwise cull (#186) | convergence fails — `one run has to finish the job, got ('4.0 MiB', 10)` |
| credit `bytes_deduped` (#187) | honesty fails on three layouts |

## Two findings from writing it

**A whole-file group is not a substitute for an extent group.** My first two-class layout used four identical files — and it did *not* catch #186, because whole-file groups load with `poff = 0` and skip `clean_deduped()` entirely. Only the extent-pass shape (one shared tail behind four different heads) reproduces it. Both are now in the zoo, and the distinction is in CLAUDE.md.

**The honesty check found a real remaining over-count — [#191](https://github.com/martinus/oans/issues/191).** Two members of one group sitting on a *single* extent are each credited in full, while releasing that extent frees its length once: 2.0 MiB reported against 1 MiB freed. The per-destination measure has no notion of destinations sharing storage with *each other*. Excluded from the honesty assertion with a pointer to the issue rather than weakened silently; convergence is unaffected, and the layout is still covered by the convergence test.

Per-layout numbers that fell out, which are worth having on record:

| layout | reported | freed | |
| --- | --- | --- | --- |
| independent / three-way / sparse / trailing hole / half-shared / split tail | — | — | exact |
| unaligned | 65536 | 69632 | −4096, block rounding |
| sub-block | 4000 | 4096 | −96, block rounding |
| two physical classes | 2097152 | 1048576 | **+1048576 (#191)** |

The two block-rounding layouts assert the safe direction instead — never claim more than was freed, and understate by less than a block. That gap is inherent to `Reclaimed` being a logical figure while the disk frees whole blocks.

Tests only; no production code changes. `scripts/verify.sh` passes, 198 tests, suite run twice in parallel with no flakes. The class is serial, since every layout is built for its physical shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)