### PR TITLE
dedupe: count storage two destinations already share once (#191)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -683,8 +683,11 @@ check unlinks and recreates (it's only a cache).
     groups load with `poff = 0` and skip `clean_deduped()` entirely, so only an
     extent-pass layout (same tail, different heads) reproduces #186 — a
     four-identical-file version of the same physical shape does not.
-  - **Known over-count (#191), deliberately excluded from that test:** two members of
-    one group sitting on a *single* extent are each credited in full, while
-    releasing that extent frees its length once — 2.0 MiB reported against
-    1 MiB freed. The per-destination measure has no notion of destinations
-    sharing storage with *each other*. Convergence is unaffected.
+  - **The accounted-for set accumulates across a group's destinations (#191).**
+    Seeded from the target, then grown by `fiemap_unshared_bytes()` as each
+    destination is measured — because two destinations can already share an
+    extent with *each other*, and crediting both in full claimed twice what
+    releasing that one extent frees. Merged per destination, never inserted per
+    address: the fragmented whole-file groups the sorted array exists for make
+    the latter hopeless. Still counts one address repeated *within* a single
+    destination twice; bounded, and noted at the definition.

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -307,62 +307,130 @@ bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 	return true;
 }
 
-uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count)
+/* Sorted-unique in place; returns the surviving count. */
+static unsigned int sort_uniq(uint64_t *v, unsigned int n)
 {
-	uint64_t *v;
+	unsigned int w = 1;
+
+	if (n < 2)
+		return n;
+	qsort(v, n, sizeof(*v), cmp_u64);
+	for (unsigned int i = 1; i < n; i++)
+		if (v[i] != v[w - 1])
+			v[w++] = v[i];
+	return w;
+}
+
+void fiemap_phys_set_init(struct fiemap_phys_set *set, const struct fiemap *fm)
+{
 	unsigned int n = 0;
 
-	*count = 0;
+	set->v = NULL;
+	set->n = set->cap = 0;
 	if (!fm || fm->fm_mapped_extents == 0)
-		return NULL;
+		return;
 
-	v = malloc(fm->fm_mapped_extents * sizeof(*v));
-	if (!v)
-		return NULL;
+	set->v = malloc(fm->fm_mapped_extents * sizeof(*set->v));
+	if (!set->v)
+		return;
+	set->cap = fm->fm_mapped_extents;
 
 	for (unsigned int i = 0; i < fm->fm_mapped_extents; i++) {
 		if (fm->fm_extents[i].fe_flags & FIEMAP_NO_PHYS)
 			continue;	/* no stable address to match against */
-		v[n++] = fm->fm_extents[i].fe_physical;
+		set->v[n++] = fm->fm_extents[i].fe_physical;
 	}
-	qsort(v, n, sizeof(*v), cmp_u64);
+	/* Duplicates are common - a compressed extent reports one address for
+	 * every record referencing it - and collapsing them shortens every
+	 * later search. */
+	set->n = sort_uniq(set->v, n);
+}
 
-	/* Collapse duplicates: a compressed extent reports one address for every
-	 * record referencing it, and a fragmented file can repeat one many times.
-	 * Shrinking the array shortens every later search. */
-	if (n > 1) {
-		unsigned int uniq = 1;
-
-		for (unsigned int i = 1; i < n; i++)
-			if (v[i] != v[uniq - 1])
-				v[uniq++] = v[i];
-		n = uniq;
-	}
-
-	*count = n;
-	return v;
+void fiemap_phys_set_free(struct fiemap_phys_set *set)
+{
+	free(set->v);
+	set->v = NULL;
+	set->n = set->cap = 0;
 }
 
 /*
- * How many bytes of [dest_off, dest_off+len) are NOT already on storage the
- * target references - i.e. how much a dedupe would actually stop duplicating.
+ * Merge `add` (sorted, unique) into the set. Merging per destination rather
+ * than inserting per address keeps this O(n) per destination instead of O(n)
+ * per element - the difference between usable and hopeless on the fragmented
+ * whole-file groups the sorted array exists for.
+ *
+ * On allocation failure the set is left as it was: the reported figure loses
+ * accuracy for the rest of the group, which is all this feeds.
+ */
+static void phys_set_merge(struct fiemap_phys_set *set, const uint64_t *add,
+			   unsigned int n_add)
+{
+	unsigned int i, j, k, w;
+
+	if (!n_add)
+		return;
+
+	if (set->n + n_add > set->cap) {
+		unsigned int cap = set->cap ? set->cap : 16;
+		uint64_t *grown;
+
+		while (cap < set->n + n_add)
+			cap *= 2;
+		grown = realloc(set->v, cap * sizeof(*grown));
+		if (!grown)
+			return;
+		set->v = grown;
+		set->cap = cap;
+	}
+
+	/* Backwards, so the merge can run in place. */
+	i = set->n;
+	j = n_add;
+	k = set->n + n_add;
+	while (j > 0) {
+		if (i > 0 && set->v[i - 1] > add[j - 1])
+			set->v[--k] = set->v[--i];
+		else
+			set->v[--k] = add[--j];
+	}
+	set->n += n_add;
+
+	w = 1;
+	for (i = 1; i < set->n; i++)
+		if (set->v[i] != set->v[w - 1])
+			set->v[w++] = set->v[i];
+	set->n = w;
+}
+
+/*
+ * How many bytes of [dest_off, dest_off+len) are NOT already on storage that
+ * `seen` accounts for - i.e. how much deduplicating this destination would
+ * actually stop duplicating - after which its addresses join the set.
+ *
+ * The set accumulating is the point. It starts as the target's addresses, but
+ * two destinations of one group can already share an extent with *each other*;
+ * crediting both in full claimed twice what releasing that one extent frees
+ * (#191). Whoever is measured first pays for it, and the rest are free.
  *
  * Membership is by physical address: two records with the same fe_physical are
- * the same stored bytes, so a destination record already sitting on one of the
- * target's extents frees nothing, and where in the range it sits is irrelevant
- * to that. Holes contribute nothing, having nothing to free.
+ * the same stored bytes, so a destination already sitting on accounted-for
+ * storage frees nothing, and where in the range it sits is irrelevant to that.
+ * Holes contribute nothing, having nothing to free.
  *
  * Approximate at the edges, by at most one extent either way: a partial
  * reference at a different offset into the same uncompressed extent reports a
  * different fe_physical and is counted as unshared, while a compressed extent
  * reports one address for the whole extent so any part of it counts as shared.
- * This only feeds the reported figure, never a decision to skip work.
+ * One address repeated *within* a single destination is also still counted
+ * twice. This only feeds the reported figure, never a decision to skip work.
  */
-uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
+uint64_t fiemap_unshared_bytes(struct fiemap_phys_set *seen,
 			       const struct fiemap *dm, uint64_t dest_off,
 			       uint64_t len)
 {
 	const uint64_t dest_end = dest_off + len;
+	_cleanup_(freep) uint64_t *fresh = NULL;
+	unsigned int n_fresh = 0;
 	uint64_t unshared = 0;
 
 	/* No destination map means we could not tell: assume nothing is shared,
@@ -370,22 +438,30 @@ uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
 	if (!dm)
 		return len;
 
+	fresh = malloc(dm->fm_mapped_extents * sizeof(*fresh));
+
 	for (unsigned int i = 0; i < dm->fm_mapped_extents; i++) {
 		const struct fiemap_extent *e = &dm->fm_extents[i];
 		uint64_t start = e->fe_logical > dest_off ? e->fe_logical : dest_off;
 		uint64_t end = e->fe_logical + e->fe_length;
+		bool addressable = !(e->fe_flags & FIEMAP_NO_PHYS);
 
 		if (end > dest_end)
 			end = dest_end;
 		if (end <= start)
 			continue;
 
-		if (!(e->fe_flags & FIEMAP_NO_PHYS) && tgt_n &&
-		    bsearch(&e->fe_physical, tgt_phys, tgt_n, sizeof(*tgt_phys),
+		if (addressable && seen->n &&
+		    bsearch(&e->fe_physical, seen->v, seen->n, sizeof(*seen->v),
 			    cmp_u64))
-			continue;	/* already on the target's storage */
+			continue;	/* already accounted for */
 
 		unshared += end - start;
+		if (addressable && fresh)
+			fresh[n_fresh++] = e->fe_physical;
 	}
+
+	if (fresh)
+		phys_set_merge(seen, fresh, sort_uniq(fresh, n_fresh));
 	return unshared;
 }

--- a/src/fiemap.h
+++ b/src/fiemap.h
@@ -66,20 +66,29 @@ bool fiemap_maps_share(const struct fiemap *tgt, uint64_t tgt_off,
 		       const struct fiemap *dm, uint64_t dest_off, uint64_t len);
 
 /*
- * The physical addresses `fm` references, sorted, for fiemap_unshared_bytes()
- * to look up. Built once per target and reused across its destinations.
- * Returns NULL (count 0) for an empty map or on allocation failure; the caller
- * frees it.
+ * The physical addresses a group has already accounted for, sorted and unique.
+ * Seeded from the dedupe target's map, then grown by fiemap_unshared_bytes()
+ * as each destination is measured, so storage two destinations already share
+ * with each other is only ever credited once (#191).
  */
-uint64_t *fiemap_phys_sorted(const struct fiemap *fm, unsigned int *count);
+struct fiemap_phys_set {
+	uint64_t	*v;
+	unsigned int	n;
+	unsigned int	cap;
+};
+
+void fiemap_phys_set_init(struct fiemap_phys_set *set, const struct fiemap *fm);
+void fiemap_phys_set_free(struct fiemap_phys_set *set);
 
 /*
- * Bytes of [dest_off, dest_off+len) that are not already on storage `tgt_phys`
- * references - what deduping the destination would actually stop duplicating,
- * as opposed to what the kernel reports having compared. See the definition for
- * where it approximates.
+ * Bytes of [dest_off, dest_off+len) not already on storage `seen` accounts
+ * for - what deduplicating this destination would actually stop duplicating,
+ * as opposed to what the kernel reports having compared. Adds the
+ * destination's own addresses to `seen`. See the definition for where it
+ * approximates; it must only ever feed a reported figure, never a decision to
+ * skip work.
  */
-uint64_t fiemap_unshared_bytes(const uint64_t *tgt_phys, unsigned int tgt_n,
+uint64_t fiemap_unshared_bytes(struct fiemap_phys_set *seen,
 			       const struct fiemap *dm, uint64_t dest_off,
 			       uint64_t len);
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -460,10 +460,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	 * is open; tgt_mapped says the attempt was made, so a target we cannot
 	 * fiemap is not retried for every remaining member. */
 	_cleanup_(freep) struct fiemap *tgt_map = NULL;
-	/* The target's physical addresses, for measuring how much of a
-	 * destination is genuinely duplicated rather than already shared. */
-	_cleanup_(freep) uint64_t *tgt_phys = NULL;
-	unsigned int tgt_phys_n = 0;
+	/* Storage this group has already accounted for: the target's, plus each
+	 * destination's as it is measured, so two destinations that already
+	 * share an extent are not both credited for it. */
+	_cleanup_(fiemap_phys_set_free) struct fiemap_phys_set seen = {0};
+	bool seen_built = false;
 	bool tgt_mapped = false;
 	/* What that check compares: all of `len` the kernel would dedupe. */
 	uint64_t cmp_len = 0;
@@ -675,13 +676,13 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 							extent->e_loff, cmp_len);
 
 			if (!shared) {
-				/* Built on first real use: a run over an
+				/* Seeded on first real use: a run over an
 				 * already-shared tree never needs it. */
-				if (!tgt_phys)
-					tgt_phys = fiemap_phys_sorted(tgt_map,
-								      &tgt_phys_n);
-				unshared = fiemap_unshared_bytes(tgt_phys,
-								 tgt_phys_n,
+				if (!seen_built) {
+					seen_built = true;
+					fiemap_phys_set_init(&seen, tgt_map);
+				}
+				unshared = fiemap_unshared_bytes(&seen,
 								 dest_map,
 								 extent->e_loff,
 								 cmp_len);

--- a/src/tests.c
+++ b/src/tests.c
@@ -285,11 +285,12 @@ static uint64_t unshared(const struct fm_rec *rt, unsigned int nt,
 			 uint64_t dest_off, uint64_t len)
 {
 	struct fiemap *t = mkmap(rt, nt), *d = nd ? mkmap(rd, nd) : NULL;
-	unsigned int n = 0;
-	uint64_t *phys = fiemap_phys_sorted(t, &n);
-	uint64_t bytes = fiemap_unshared_bytes(phys, n, d, dest_off, len);
+	struct fiemap_phys_set seen;
+	uint64_t bytes;
 
-	free(phys);
+	fiemap_phys_set_init(&seen, t);
+	bytes = fiemap_unshared_bytes(&seen, d, dest_off, len);
+	fiemap_phys_set_free(&seen);
 	free(t);
 	free(d);
 	return bytes;
@@ -365,6 +366,65 @@ MU_TEST(test_fiemap_unshared_bytes) {
 	/* Matching holes to the end of the range. */
 	mu_check(share(tgt, 1, 0, tgt, 1, 0, 262144));
 	mu_check(unshared(tgt, 1, tgt, 1, 0, 262144) == 0);
+}
+
+/*
+ * Storage two destinations of one group already share with *each other* must
+ * be credited once, not once each: releasing that one extent frees its length
+ * once (#191). The set the measure carries is what makes that work, so drive
+ * it across several destinations the way a group does.
+ */
+MU_TEST(test_fiemap_unshared_bytes_accumulates) {
+	const uint32_t SH = FIEMAP_EXTENT_SHARED;
+	struct fm_rec tgt[] = {{0, 4096, 8192, SH}};
+	struct fm_rec on_b[] = {{0, 50000, 8192, SH}};
+	struct fm_rec on_c[] = {{0, 90000, 8192, 0}};
+	struct fiemap *t = mkmap(tgt, 1), *b = mkmap(on_b, 1), *c = mkmap(on_c, 1);
+	struct fiemap_phys_set seen;
+
+	fiemap_phys_set_init(&seen, t);
+
+	/* First destination on extent B: its length is genuinely duplicated. */
+	mu_check(fiemap_unshared_bytes(&seen, b, 0, 8192) == 8192);
+	/* A second destination on the same extent frees nothing further. */
+	mu_check(fiemap_unshared_bytes(&seen, b, 0, 8192) == 0);
+	/* A third, on storage of its own, is credited again. */
+	mu_check(fiemap_unshared_bytes(&seen, c, 0, 8192) == 8192);
+	mu_check(fiemap_unshared_bytes(&seen, c, 0, 8192) == 0);
+	/* The target's own storage was never creditable. */
+	mu_check(fiemap_unshared_bytes(&seen, t, 0, 8192) == 0);
+
+	fiemap_phys_set_free(&seen);
+	free(t);
+	free(b);
+	free(c);
+}
+
+/* The set has to stay sorted and unique across many merges, or bsearch starts
+ * missing addresses and the over-count creeps back in one destination at a
+ * time. Drive enough destinations to force it through several growths. */
+MU_TEST(test_fiemap_phys_set_grows) {
+	struct fiemap *t = mkmap((struct fm_rec[]){{0, 4096, 4096, 0}}, 1);
+	struct fiemap_phys_set seen;
+
+	fiemap_phys_set_init(&seen, t);
+	free(t);
+
+	for (unsigned int i = 0; i < 200; i++) {
+		/* Descending addresses, so every merge prepends. */
+		struct fm_rec r[] = {{0, 1000000 - i * 4096, 4096, 0}};
+		struct fiemap *d = mkmap(r, 1);
+
+		mu_check(fiemap_unshared_bytes(&seen, d, 0, 4096) == 4096);
+		mu_check(fiemap_unshared_bytes(&seen, d, 0, 4096) == 0);
+		free(d);
+	}
+
+	mu_check(seen.n == 201);		/* target + 200 distinct */
+	for (unsigned int i = 1; i < seen.n; i++)
+		mu_check(seen.v[i - 1] < seen.v[i]);	/* sorted, unique */
+
+	fiemap_phys_set_free(&seen);
 }
 
 MU_TEST(test_sanitize_ctrl) {
@@ -1006,6 +1066,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_get_extent);
 	MU_RUN_TEST(test_fiemap_maps_share);
 	MU_RUN_TEST(test_fiemap_unshared_bytes);
+	MU_RUN_TEST(test_fiemap_unshared_bytes_accumulates);
+	MU_RUN_TEST(test_fiemap_phys_set_grows);
 	MU_RUN_TEST(test_sanitize_ctrl);
 	MU_RUN_TEST(test_progress_copy_path);
 	MU_RUN_TEST(test_progress_path_two_stage_render);

--- a/tests/integration/test_convergence.py
+++ b/tests/integration/test_convergence.py
@@ -124,9 +124,11 @@ class ConvergenceTest(DuperemoveTest):
     ALL = ("independent", "three_way", "unaligned", "sub_block", "sparse",
            "trailing_hole", "split_tail", "half_shared",
            "two_physical_classes", "two_extent_classes")
-    # Layouts where the reported figure is exactly the storage freed.
+    # Layouts where the reported figure is exactly the storage freed. The two
+    # two-class ones are here because of #191: their members already share
+    # storage with each other, which used to be credited once per member.
     EXACT = ("independent", "three_way", "sparse", "trailing_hole",
-             "half_shared")
+             "half_shared", "two_physical_classes", "two_extent_classes")
     # Already as shared as the kernel can make them, so a run must free nothing
     # and say so - the case an over-reporting figure used to hide.
     NOTHING_TO_FREE = ("split_tail",)
@@ -176,11 +178,9 @@ class ConvergenceTest(DuperemoveTest):
         of what oans computed - the check neither #186 nor #187 had, which is
         why both could ship. Per layout, so a failure names the shape.
 
-        The two-class layouts are left out: two members of one group sitting
-        on a single extent are each credited in full, while releasing that
-        extent frees its length once (2.0 MiB reported against 1 MiB freed). A
-        real over-count (#191); convergence is unaffected and the test above
-        covers both layouts.
+        The two-class layouts matter most here: their members already share
+        storage with each other, so crediting each in full claimed twice what
+        releasing that one extent frees (#191).
         """
         seen = 0
         for name in self.EXACT + self.BLOCK_ROUNDED + self.NOTHING_TO_FREE:


### PR DESCRIPTION
Fixes #191.

## The problem

`fiemap_unshared_bytes()` measured each destination against the **target's** addresses only. Two members of one group already sitting on the same extent were therefore each credited its full length — while releasing that one extent frees that length once.

Four identical 1 MiB files in two reflinked pairs:

```
footprint before: 2097152
 Reclaimed 2.0 MiB across 1 group
footprint after:  1048576      <- 1 MiB actually freed
```

## The fix

The set of accounted-for storage now accumulates: seeded from the target, then grown with each destination's addresses as it is measured. Whoever is measured first pays for the extent and the rest are free — which is exactly what releasing it does.

```
 Reclaimed 1.0 MiB across 1 group
```

**Merged per destination, not inserted per address.** Insertion into the sorted array is O(n) each, and the groups that array exists for — fragmented whole-file ones, ~32k extents per CLAUDE.md's own `fragmented` profile — make that hopeless. A backwards in-place merge is O(n) per destination instead. On allocation failure the set is left as it was, so the figure loses accuracy for the rest of the group and nothing else changes.

## How it was found, and how it is proved

This is what the tests in #192 were added for. The two-class layouts move out of "excluded with a pointer to the issue" and into the exact-equality set — that assertion *is* the proof.

Reinstating the old behaviour fails:

| check | failure |
| --- | --- |
| `two_physical_classes` | `1048576 != 2097152` |
| `two_extent_classes` | `4194304 != 8388608` |
| `test_fiemap_unshared_bytes_accumulates` | several destinations over one extent |
| `test_fiemap_phys_set_grows` | set stays sorted and unique across growth |

That last one exists because a set that quietly stopped being sorted or unique would let `bsearch` start missing addresses, and the over-count would creep back one destination at a time rather than failing outright.

## Unchanged

What gets deduplicated, convergence, and the ordinary case — a 1 MiB pair of independent copies still reports 1.0 MiB. One address repeated within a *single* destination is still counted twice; bounded, and now stated at the definition rather than left implicit.

## Note on the issue's shell reproducer

The `cp a1 b1` in #191's snippet does not actually reproduce it: coreutils `cp` goes through `copy_file_range()`, which btrfs implements as a reflink, so all four files start out sharing one extent. The measurements in that issue came from independent Python writes, which is also what the test uses. Same trap CLAUDE.md already warns about — worth knowing it caught me twice.

`scripts/verify.sh`, `make integration-valgrind` (no findings) and the ASan/UBSan leg all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)