### PR TITLE
scan: resume hashing a very large file instead of restarting it (#159)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ __pycache__/
 version
 .version-stamp
 .pandoc/
+
+# Core dumps: oans aborts (abort_on) leave these next to the binary.
+core
+core.*
+vgcore.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,18 @@ run picks the file up there.
   Extent rows are only ever written by a checkpoint, so none exist past one;
   block rows flush on their own batch cadence (#161) and can, hence
   `dbfile_remove_hashes_from()` on resume.
+- **Restarting converges, but only above the commit interval.** Measured on a
+  30 GiB / 6006-file tree with repeated `SIGKILL`s: everything ends up hashed,
+  no checkpoints left. The floor is `COMMIT_INTERVAL_SEC` (10 s) — nothing is
+  durable until the batched writer commits, so **killing more often than that
+  loops forever at zero progress**. Pre-existing, and this change strictly
+  improves it: at 1.4 s kills v1.9.1 persisted 0 files over six rounds, where
+  this code reached 1875 before stalling, because a checkpoint force-commits the
+  whole shared batch. **There is no signal handler anywhere in the tree**, so
+  Ctrl-C discards the open batch exactly as `SIGKILL` does (measured: both
+  persisted 0 at 3 s). "Ctrl-C is safe" means the hashfile is not corrupted, not
+  that the run's work is kept. A SIGINT handler that flushes would raise the
+  floor; nobody has built one.
 - Test hooks: `DUPEREMOVE_CHECKPOINT_BYTES` lowers the interval,
   `DUPEREMOVE_CHECKPOINT_STOP=N` abandons a file after N checkpoints — an
   interrupted run, deterministically, rather than racing a signal against a read.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,69 @@ walkers.**
 - Cold-walk cost is fundamental btrfs metadata I/O (`statx→btrfs_iget→btree`);
   SQLite is <2%, so parallelizing the consumer wouldn't help.
 
+## Hash resume for very large files (#159)
+
+A 1 TiB file interrupted six hours into hashing used to restart at byte zero, so
+on a big enough file a scheduled scan could never finish. Now `csum_whole_file()`
+writes a **checkpoint** every `CHECKPOINT_INTERVAL_BYTES` (1 GiB) and the next
+run picks the file up there.
+
+- **The digest is unchanged — that was the whole design constraint.** The
+  original plan (#158) was to redefine the file digest as a hash of extent
+  digests, which is additive and so trivially resumable; it was rejected because
+  it makes fragmentation part of file identity, so byte-identical files with
+  different extent layouts stop matching. Instead the *running xxhash state* is
+  snapshotted (`running_checksum_save/restore` in `csum.c`, the only file that
+  knows xxhash). Nothing about what a digest means changed, and no existing
+  hashfile is invalidated.
+  - xxhash publishes no serialization, so this copies `XXH3_state_t` verbatim.
+    Legitimate within one build (`XXH3_copyState` is the same copy) but not
+    across, so the blob carries magic + `XXH_versionNumber()` + `sizeof(state)`
+    and **restore refuses anything it cannot vouch for** — a distro xxhash
+    upgrade just means a rehash, never a wrong digest. On restore, `extSecret`
+    must be re-pointed at this process's static secret; everything else is data.
+  - **`start_running_checksum()` memsets the state before resetting it.** A
+    reset only initialises the fields it uses, leaving alignment padding and the
+    unused tail of the internal buffer undefined — harmless until the struct is
+    copied out, at which point those bytes get written to the hashfile. Valgrind
+    caught exactly this. Don't drop the memset; it costs nothing measurable
+    (`fragmented`, 262k extents: 2.53 → 2.54 s median).
+- **The in-flight extent digest rides along in the checkpoint.** The first cut
+  only checkpointed at extent boundaries, so no extent state was needed — and it
+  never fired, because **btrfs reports a contiguously allocated file as a single
+  fiemap extent however large it is**. That is precisely the shape this feature
+  exists for. So a checkpoint carries the partial extent digest plus
+  `ext_loff`/`ext_len`, and a resume that does not find that extent where it was
+  left discards the checkpoint and starts over — which doubles as the one cheap
+  check that the layout was not rewritten underneath (mtime and size need not
+  move on a defrag).
+- **Change detection had a matching hole.** A file's row is written with its
+  mtime and size *before* hashing starts; only the digest says it was ever
+  hashed. `SELECT_FILE_CHANGES` therefore also selects `digest is not null`, and
+  the up-to-date shortcut requires it. Until now nothing noticed, because
+  `dbfile_prune_unscanned_files()` deleted every digest-less row at startup —
+  that prune now spares rows with a checkpoint, which is what keeps them alive.
+- **A resumed file keeps its row but gets this run's `dedupe_seq`**
+  (`dbfile_update_dedupe_seq`, a targeted UPDATE). Re-running the usual upsert
+  would `INSERT OR REPLACE` the row and cascade away the checkpoint and stored
+  hashes; leaving the generation alone lets a dedupe phase in between draw level
+  with it, and a file at or below the watermark is one dedupe never looks at.
+  Pinned by `test_a_resumed_file_is_deduped_by_the_run_that_finishes_it`.
+- Hashes for the region just covered and the checkpoint claiming it land in **one
+  transaction, force-committed** (`scan_write_flush`, not the batched writer's
+  10 s cadence — a checkpoint still inside an open transaction protects nothing).
+  Extent rows are only ever written by a checkpoint, so none exist past one;
+  block rows flush on their own batch cadence (#161) and can, hence
+  `dbfile_remove_hashes_from()` on resume.
+- Test hooks: `DUPEREMOVE_CHECKPOINT_BYTES` lowers the interval,
+  `DUPEREMOVE_CHECKPOINT_STOP=N` abandons a file after N checkpoints — an
+  interrupted run, deterministically, rather than racing a signal against a read.
+  `tests/integration/test_hash_resume.py` drives a tree through dozens of
+  interruptions and asserts the digests, extent hashes and block hashes are
+  **identical to one straight-through scan**; that is the property that matters,
+  since nothing downstream could tell a wrong digest from a file with no
+  duplicate.
+
 ## io-threads default (storage heuristic)
 
 `--io-threads` sizes three pools (walkers, csum/read, dedupe). One mechanism

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,25 @@ run picks the file up there.
   left discards the checkpoint and starts over — which doubles as the one cheap
   check that the layout was not rewritten underneath (mtime and size need not
   move on a defrag).
+- **A checkpoint is trusted on mtime + size, and that is not certain.** Measured:
+  a `chattr +C` (nodatacow) file modified in place with the timestamp restored
+  afterwards resumes across the change and yields a digest of a byte string that
+  never existed. The point is that **the ordinary incremental path has the same
+  blind spot** — measured on the same file, a full scan then the same
+  modification leaves a stored digest that no longer describes it — so resume
+  inherits oans's guarantee rather than weakening it, and the real safety net is
+  that `FIDEDUPERANGE` byte-verifies (two files oans believed identical deduped
+  to `0 B` with both intact). Don't "fix" this in the resume path alone; a
+  stronger identity (statx `STATX_CHANGE_COOKIE`/`i_version`) would be a
+  repo-wide change to change detection or nothing.
+  - On CoW btrfs the extent check above usually catches that case anyway, since
+    an in-place write splits the extent. Incidental, not a guarantee: it is gone
+    on nodatacow and whenever a checkpoint lands on an extent boundary (no
+    extent state, so nothing to check).
+  - **The checkpoint stamps the mtime read when the file was *listed*, not the
+    one current at checkpoint time.** Stamping the current one would make a file
+    modified *during* run 1's hashing look consistent to run 2, which would then
+    resume across the modification. Listing-time makes it fail closed.
 - **Change detection had a matching hole.** A file's row is written with its
   mtime and size *before* hashing starts; only the digest says it was ever
   hashed. `SELECT_FILE_CHANGES` therefore also selects `digest is not null`, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,26 @@ run picks the file up there.
   Extent rows are only ever written by a checkpoint, so none exist past one;
   block rows flush on their own batch cadence (#161) and can, hence
   `dbfile_remove_hashes_from()` on resume.
+- **Checkpointed files are handed to the pool before the walk starts**
+  (`seed_checkpointed_files()`, from `filescan_walk_run()`). The walk would find
+  them eventually, but on a large tree "eventually" is minutes — measured on a
+  120k-file tree with the file six directories down, time-to-resume went
+  **0.73 s → 0.02 s**, and the seeded figure doesn't grow with the tree. Three
+  constraints, each with a test:
+  - **Only under this run's roots, and only if `check_file()` accepts it.** One
+    hashfile may cover several trees scanned on different days; seeding outside
+    the named roots would hash terabytes nobody asked for. `scan_root_paths`
+    exists solely for this (prefix match, guarding against `/data` vs
+    `/database`).
+  - **Mark it seen (`mark_inode_seen` + `mark_file_seen`) or the walk queues it
+    twice** and two workers hash one file at once. Pinned by asserting
+    `run_history.files_scanned`, which is 2 instead of 1 when this is dropped.
+  - **Seed *after* the walker handles are open, before the consume loop.** The
+    csum pool is already running, so a seeded file produces a write transaction
+    immediately, and every `dbfile_open_handle()` runs `CREATE TABLE IF NOT
+    EXISTS` — which then can't get the write lock and aborts on `!wdb`. Seeding
+    also force-flushes for the same reason. (Ordinary per-file writes never hit
+    this: by then the walkers are long connected.)
 - **Restarting converges, but only above the commit interval.** Measured on a
   30 GiB / 6006-file tree with repeated `SIGKILL`s: everything ends up hashed,
   no checkpoints left. The floor is `COMMIT_INTERVAL_SEC` (10 s) — nothing is

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -681,6 +681,15 @@ without corrupting either.
 Only a power loss can, in principle, damage a hashfile \(em and never
 your data.
 .PP
+An interrupted run also does not lose the work it had done.
+Files it finished hashing keep their hashes, and a very large file it
+was in the middle of \(em a disk image, a backup archive \(em is
+checkpointed as it goes, so the next run picks it up where the last one
+stopped rather than reading it again from the start.
+Checkpoints need a \f[B]\-\-hashfile\f[R] to live in; they are dropped
+automatically once the file is fully hashed, and ignored if the file
+changed in the meantime.
+.PP
 Two logically identical files are not always deduped: \f[CR]oans\f[R]
 works on extent boundaries, so files with the same content but a
 different on\-disk extent layout may not match unless block\-level

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -686,9 +686,20 @@ Files it finished hashing keep their hashes, and a very large file it
 was in the middle of \(em a disk image, a backup archive \(em is
 checkpointed as it goes, so the next run picks it up where the last one
 stopped rather than reading it again from the start.
-Checkpoints need a \f[B]\-\-hashfile\f[R] to live in; they are dropped
-automatically once the file is fully hashed, and ignored if the file
-changed in the meantime.
+Checkpoints need a \f[B]\-\-hashfile\f[R] to live in, and are dropped
+automatically once the file is fully hashed.
+.PP
+A checkpoint is only used if the file\(cqs size and modification time
+are still what they were, which is the same test \f[CR]oans\f[R] applies
+to every file in a hashfile to decide it need not be read again.
+A file whose contents change while size and mtime are both held fixed
+\(em restoring the timestamp after an in\-place write, say \(em is
+therefore not noticed, exactly as it would not be for a fully scanned
+file.
+The consequence is a stale or mismatched digest, so a duplicate may be
+missed or a group needlessly compared; it is never a risk to data,
+because the kernel byte\-verifies every deduplication and refuses any
+pair that does not match.
 .PP
 Two logically identical files are not always deduped: \f[CR]oans\f[R]
 works on extent boundaries, so files with the same content but a

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -681,13 +681,26 @@ without corrupting either.
 Only a power loss can, in principle, damage a hashfile \(em and never
 your data.
 .PP
-An interrupted run also does not lose the work it had done.
-Files it finished hashing keep their hashes, and a very large file it
-was in the middle of \(em a disk image, a backup archive \(em is
-checkpointed as it goes, so the next run picks it up where the last one
-stopped rather than reading it again from the start.
+Re\-running after an interruption resumes rather than starting over, so
+a scan too long to finish in one sitting still converges if you keep
+running it.
+Two things carry over: files that were fully hashed keep their hashes
+and are skipped next time, and a very large file that was in the middle
+of being hashed \(em a disk image, a backup archive \(em is checkpointed
+as it goes, so the next run picks it up where the last one stopped
+instead of reading it again from the start.
 Checkpoints need a \f[B]\-\-hashfile\f[R] to live in, and are dropped
 automatically once the file is fully hashed.
+.PP
+What does not carry over is anything not yet written to the hashfile.
+To keep a scan of millions of files from committing once per file,
+results are batched and written every ten seconds, and additionally at
+each checkpoint; a run killed before its first commit contributes
+nothing.
+Ctrl\-C is no gentler than a crash here \(em it is not trapped, so it
+discards the batch in progress too.
+In practice this only matters if runs are being cut short after a few
+seconds, which makes no progress however often it is repeated.
 .PP
 A checkpoint is only used if the file\(cqs size and modification time
 are still what they were, which is the same test \f[CR]oans\f[R] applies

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -692,6 +692,14 @@ instead of reading it again from the start.
 Checkpoints need a \f[B]\-\-hashfile\f[R] to live in, and are dropped
 automatically once the file is fully hashed.
 .PP
+A file left partly hashed is picked up at the very start of the next
+run, before the directory walk begins, rather than when the walk happens
+to reach it \(em on a large tree that can be minutes later, and a
+nearly\-finished large file is the one most worth completing.
+Only files under the roots named on that command line are resumed this
+way, so a hashfile shared between several trees never causes one run to
+hash another tree\(cqs files.
+.PP
 What does not carry over is anything not yet written to the hashfile.
 To keep a scan of millions of files from committing once per file,
 results are batched and written every ten seconds, and additionally at

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -580,6 +580,14 @@ hashfile is a transactional database, so you can stop and re-run without
 corrupting either. Only a power loss can, in principle, damage a hashfile — and
 never your data.
 
+An interrupted run also does not lose the work it had done. Files it finished
+hashing keep their hashes, and a very large file it was in the middle of —
+a disk image, a backup archive — is checkpointed as it goes, so the next run
+picks it up where the last one stopped rather than reading it again from the
+start. Checkpoints need a **\--hashfile** to live in; they are dropped
+automatically once the file is fully hashed, and ignored if the file changed in
+the meantime.
+
 Two logically identical files are not always deduped: `oans` works on extent
 boundaries, so files with the same content but a different on-disk extent layout
 may not match unless block-level matching is enabled with

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -589,6 +589,13 @@ next run picks it up where the last one stopped instead of reading it again
 from the start. Checkpoints need a **\--hashfile** to live in, and are dropped
 automatically once the file is fully hashed.
 
+A file left partly hashed is picked up at the very start of the next run,
+before the directory walk begins, rather than when the walk happens to reach
+it — on a large tree that can be minutes later, and a nearly-finished large
+file is the one most worth completing. Only files under the roots named on that
+command line are resumed this way, so a hashfile shared between several trees
+never causes one run to hash another tree's files.
+
 What does not carry over is anything not yet written to the hashfile. To keep a
 scan of millions of files from committing once per file, results are batched and
 written every ten seconds, and additionally at each checkpoint; a run killed

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -580,12 +580,22 @@ hashfile is a transactional database, so you can stop and re-run without
 corrupting either. Only a power loss can, in principle, damage a hashfile — and
 never your data.
 
-An interrupted run also does not lose the work it had done. Files it finished
-hashing keep their hashes, and a very large file it was in the middle of —
-a disk image, a backup archive — is checkpointed as it goes, so the next run
-picks it up where the last one stopped rather than reading it again from the
-start. Checkpoints need a **\--hashfile** to live in, and are dropped
+Re-running after an interruption resumes rather than starting over, so a scan
+too long to finish in one sitting still converges if you keep running it. Two
+things carry over: files that were fully hashed keep their hashes and are
+skipped next time, and a very large file that was in the middle of being
+hashed — a disk image, a backup archive — is checkpointed as it goes, so the
+next run picks it up where the last one stopped instead of reading it again
+from the start. Checkpoints need a **\--hashfile** to live in, and are dropped
 automatically once the file is fully hashed.
+
+What does not carry over is anything not yet written to the hashfile. To keep a
+scan of millions of files from committing once per file, results are batched and
+written every ten seconds, and additionally at each checkpoint; a run killed
+before its first commit contributes nothing. Ctrl-C is no gentler than a crash
+here — it is not trapped, so it discards the batch in progress too. In practice
+this only matters if runs are being cut short after a few seconds, which makes
+no progress however often it is repeated.
 
 A checkpoint is only used if the file's size and modification time are still
 what they were, which is the same test `oans` applies to every file in a

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -584,9 +584,18 @@ An interrupted run also does not lose the work it had done. Files it finished
 hashing keep their hashes, and a very large file it was in the middle of —
 a disk image, a backup archive — is checkpointed as it goes, so the next run
 picks it up where the last one stopped rather than reading it again from the
-start. Checkpoints need a **\--hashfile** to live in; they are dropped
-automatically once the file is fully hashed, and ignored if the file changed in
-the meantime.
+start. Checkpoints need a **\--hashfile** to live in, and are dropped
+automatically once the file is fully hashed.
+
+A checkpoint is only used if the file's size and modification time are still
+what they were, which is the same test `oans` applies to every file in a
+hashfile to decide it need not be read again. A file whose contents change
+while size and mtime are both held fixed — restoring the timestamp after an
+in-place write, say — is therefore not noticed, exactly as it would not be for
+a fully scanned file. The consequence is a stale or mismatched digest, so a
+duplicate may be missed or a group needlessly compared; it is never a risk to
+data, because the kernel byte-verifies every deduplication and refuses any pair
+that does not match.
 
 Two logically identical files are not always deduped: `oans` works on extent
 boundaries, so files with the same content but a different on-disk extent layout

--- a/src/csum.c
+++ b/src/csum.c
@@ -13,6 +13,7 @@
  * General Public License for more details.
  */
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,6 +64,17 @@ struct running_checksum *start_running_checksum(void)
 	struct xxhash_running_checksum *c =
 		calloc(1, sizeof(struct xxhash_running_checksum));
 	c->state = XXH3_createState();
+	/*
+	 * Zero the whole struct before resetting it, which xxhash sanctions
+	 * (XXH3_INITSTATE is a field-wise version of the same thing). A reset
+	 * only initialises the fields it uses, so the alignment padding and the
+	 * unused tail of the internal buffer stay whatever the allocator left -
+	 * fine while the state never leaves the process, but running_checksum_
+	 * save() copies it out verbatim and those bytes would then be written to
+	 * the hashfile uninitialised. Caught by valgrind, and worth keeping
+	 * caught: a snapshot must be fully defined bytes.
+	 */
+	memset(c->state, 0, sizeof(XXH3_state_t));
 	XXH3_128bits_reset(c->state);
 	return priv_to_rc(c);
 }
@@ -83,4 +95,78 @@ void finish_running_checksum(struct running_checksum *_c, unsigned char *digest)
 	if (digest)
 		store_digest(digest, hash);
 	XXH3_freeState(c->state);
+}
+
+/*
+ * Serialized form of an in-progress XXH3 hash: a header identifying the exact
+ * layout, then the state struct verbatim.
+ *
+ * xxhash publishes no serialization of XXH3_state_t, so this snapshots the
+ * struct itself - which is legitimate (XXH3_copyState is a plain copy of those
+ * same bytes) but only within one build. The header pins everything the layout
+ * depends on: the library version, the size of the struct, and the byte order.
+ * Anything unrecognised is refused rather than reinterpreted, so the cost of
+ * being wrong is a rehash, never a wrong digest. oans links xxhash from the
+ * system, so a distro upgrade genuinely can invalidate a saved state.
+ */
+#define CSUM_STATE_MAGIC	0x4f414e5343534d31ULL	/* "OANSCSM1" */
+
+struct csum_state_hdr {
+	uint64_t	magic;
+	uint32_t	xxh_version;	/* XXH_versionNumber() at save time */
+	uint32_t	state_size;	/* sizeof(XXH3_state_t) at save time */
+};
+
+size_t running_checksum_state_size(void)
+{
+	return sizeof(struct csum_state_hdr) + sizeof(XXH3_state_t);
+}
+
+int running_checksum_save(struct running_checksum *_c, void *buf, size_t len)
+{
+	struct xxhash_running_checksum *c = rc_to_priv(_c);
+	struct csum_state_hdr hdr = {
+		.magic		= CSUM_STATE_MAGIC,
+		.xxh_version	= XXH_versionNumber(),
+		.state_size	= sizeof(XXH3_state_t),
+	};
+
+	if (len < running_checksum_state_size())
+		return -EINVAL;
+
+	memcpy(buf, &hdr, sizeof(hdr));
+	memcpy((char *)buf + sizeof(hdr), c->state, sizeof(XXH3_state_t));
+	return 0;
+}
+
+struct running_checksum *running_checksum_restore(const void *buf, size_t len)
+{
+	struct csum_state_hdr hdr;
+	struct xxhash_running_checksum *c;
+	const unsigned char *secret;
+
+	if (len != running_checksum_state_size())
+		return NULL;
+
+	memcpy(&hdr, buf, sizeof(hdr));
+	if (hdr.magic != CSUM_STATE_MAGIC ||
+	    hdr.xxh_version != XXH_versionNumber() ||
+	    hdr.state_size != sizeof(XXH3_state_t))
+		return NULL;
+
+	c = rc_to_priv(start_running_checksum());
+	if (!c)
+		return NULL;
+
+	/*
+	 * The state holds a pointer to the library's static default secret, so
+	 * the saved copy of it means nothing in this process. Everything else
+	 * is plain data: take the freshly-reset state's pointer and overwrite
+	 * the rest.
+	 */
+	secret = c->state->extSecret;
+	memcpy(c->state, (const char *)buf + sizeof(hdr), sizeof(XXH3_state_t));
+	c->state->extSecret = secret;
+
+	return priv_to_rc(c);
 }

--- a/src/csum.h
+++ b/src/csum.h
@@ -50,6 +50,26 @@ void add_to_running_checksum(struct running_checksum *c,
 			     unsigned char *buf, unsigned int len);
 void finish_running_checksum(struct running_checksum *c, unsigned char *digest);
 
+/*
+ * Freeze a running checksum so hashing can be picked up later, in another
+ * process (#159). Together these let a multi-hour hash of one huge file survive
+ * an interruption without changing what the digest *is* - the alternative,
+ * redefining the file digest as a hash of chunk digests, would have invalidated
+ * every existing hashfile.
+ *
+ * The blob is an opaque snapshot of the hash library's internal streaming
+ * state, self-describing enough to be recognised as unreadable rather than
+ * misread: restore returns NULL for a blob written by a different xxhash than
+ * this binary links against, which a distro upgrade can and will produce. That
+ * is not an error - the caller simply rehashes from the beginning, which is
+ * what it would have done anyway.
+ *
+ * Saving does not consume the checksum: it stays usable afterwards.
+ */
+size_t running_checksum_state_size(void);
+int running_checksum_save(struct running_checksum *c, void *buf, size_t len);
+struct running_checksum *running_checksum_restore(const void *buf, size_t len);
+
 #define	DECLARE_RUNNING_CSUM_CAST_FUNCS(_type)				\
 static inline struct _type *						\
 rc_to_priv(struct running_checksum *rc)					\

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -350,6 +350,37 @@ static int create_tables(sqlite3 *db)
 		goto out;
 
 	/*
+	 * Where hashing of one very large file got to, so an interrupted run can
+	 * pick it up instead of starting the file over (#159). At most one row
+	 * per file, and only while that file is partially hashed: the row is
+	 * dropped the moment the digest lands.
+	 *
+	 * size and mtime are the file's as of the checkpoint, re-checked before
+	 * the state is used - the same staleness test the scan applies to
+	 * everything else. The two states are opaque running-checksum snapshots;
+	 * only csum.c interprets them, and it refuses any it cannot vouch for.
+	 *
+	 * ext_state is the digest of the extent being hashed when the checkpoint
+	 * was taken, NULL if the offset happened to fall on an extent boundary.
+	 * Carrying it is what lets a checkpoint land anywhere: btrfs reports a
+	 * contiguously allocated file as a single fiemap extent however large it
+	 * is, so waiting for a boundary would mean never checkpointing exactly
+	 * the files this is for. ext_loff/ext_len identify that extent, and a
+	 * resume that does not find it where it was left treats the whole
+	 * checkpoint as stale - which is also the one cheap check on the layout
+	 * having been rewritten underneath.
+	 */
+#define CREATE_TABLE_SCAN_CHECKPOINTS					\
+"CREATE TABLE IF NOT EXISTS scan_checkpoints("				\
+"fileid INTEGER PRIMARY KEY NOT NULL, loff INTEGER NOT NULL, "		\
+"size INTEGER NOT NULL, mtime INTEGER NOT NULL, state BLOB NOT NULL, "	\
+"ext_loff INTEGER NOT NULL, ext_len INTEGER NOT NULL, ext_state BLOB, "	\
+"FOREIGN KEY(fileid) REFERENCES files(id) ON DELETE CASCADE);"
+	ret = sqlite3_exec(db, CREATE_TABLE_SCAN_CHECKPOINTS, NULL, NULL, NULL);
+	if (ret)
+		goto out;
+
+	/*
 	 * One row per oans run (see dbfile_record_run): a timeline of what each
 	 * run reclaimed, for `--history` and the `--json` metrics export.
 	 */
@@ -876,8 +907,15 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 "delete from files where id = ?1;"
 	dbfile_prepare_stmt(delete_file_by_id, DELETE_FILE_BY_ID);
 
+	/*
+	 * `digest is not null` distinguishes a fully hashed file from one left
+	 * partway through by an interrupted run (#159). Without it, matching
+	 * mtime and size would read as "up to date" for a file that has no
+	 * digest at all - the row is written before hashing starts, not after.
+	 */
 #define SELECT_FILE_CHANGES						\
-"select mtime, size, filename, id from files where ino = ?1 and subvol = ?2;"
+"select mtime, size, filename, id, digest is not null from files "	\
+"where ino = ?1 and subvol = ?2;"
 	dbfile_prepare_stmt(select_file_changes, SELECT_FILE_CHANGES);
 
 #define COUNT_B_HASHES "select COUNT(*) from blocks;"
@@ -892,8 +930,51 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 #define GET_MAX_DEDUPE_SEQ "select max(dedupe_seq) from files;"
 	dbfile_prepare_stmt(get_max_dedupe_seq, GET_MAX_DEDUPE_SEQ);
 
-#define DELETE_UNSCANNED_FILES "delete from files where digest is NULL;"
+	/*
+	 * A row with no digest is the wreckage of an interrupted run - except
+	 * where that run left a checkpoint to resume from, which is the whole
+	 * point of keeping it (#159). Those rows are dropped by the scan itself
+	 * once it decides the checkpoint is unusable.
+	 */
+#define DELETE_UNSCANNED_FILES						\
+"delete from files where digest is NULL and "				\
+"id not in (select fileid from scan_checkpoints);"
 	dbfile_prepare_stmt(delete_unscanned_files, DELETE_UNSCANNED_FILES);
+
+#define WRITE_CHECKPOINT						\
+"INSERT OR REPLACE INTO scan_checkpoints "				\
+"(fileid, loff, size, mtime, state, ext_loff, ext_len, ext_state) "	\
+"VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);"
+	dbfile_prepare_stmt(write_checkpoint, WRITE_CHECKPOINT);
+
+#define SELECT_CHECKPOINT						\
+"select loff, size, mtime, state, ext_loff, ext_len, ext_state "	\
+"from scan_checkpoints where fileid = ?1;"
+	dbfile_prepare_stmt(select_checkpoint, SELECT_CHECKPOINT);
+
+#define DELETE_CHECKPOINT "delete from scan_checkpoints where fileid = ?1;"
+	dbfile_prepare_stmt(delete_checkpoint, DELETE_CHECKPOINT);
+
+	/*
+	 * Move a resumed file into this run's generation (#159). An update, not
+	 * the usual upsert: replacing the row would cascade away the very
+	 * checkpoint and hashes the resume is built on.
+	 */
+#define UPDATE_DEDUPE_SEQ "update files set dedupe_seq = ?2 where id = ?1;"
+	dbfile_prepare_stmt(update_dedupe_seq, UPDATE_DEDUPE_SEQ);
+
+	/*
+	 * Drop the hashes a resumed scan is about to recompute. Extent rows only
+	 * ever land at a checkpoint, so there are none past it; block rows flush
+	 * on their own batch cadence (#161) and can sit anywhere.
+	 */
+#define DELETE_BLOCKS_FROM						\
+"delete from blocks where fileid = ?1 and loff >= ?2;"
+	dbfile_prepare_stmt(delete_blocks_from, DELETE_BLOCKS_FROM);
+
+#define DELETE_EXTENTS_FROM						\
+"delete from extents where fileid = ?1 and loff >= ?2;"
+	dbfile_prepare_stmt(delete_extents_from, DELETE_EXTENTS_FROM);
 
 #define RENAME_FILE							\
 "update or replace files set filename = ?1, path_hash = ?2 where id = ?3;"
@@ -1811,6 +1892,140 @@ out_error:
 	return ret;
 }
 
+/* Run a statement that takes just a fileid, or a fileid and an offset. */
+static int run_by_fileid(sqlite3_stmt *stmt, int64_t fileid, const uint64_t *loff)
+{
+	int ret;
+
+	ret = sqlite3_bind_int64(stmt, 1, fileid);
+	if (!ret && loff)
+		ret = sqlite3_bind_int64(stmt, 2, *loff);
+	if (ret) {
+		perror_sqlite(ret, "binding values");
+		return ret;
+	}
+
+	ret = sqlite3_step(stmt);
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "executing statement");
+		return ret;
+	}
+
+	return 0;
+}
+
+int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
+			    const struct scan_checkpoint *cp)
+{
+	int ret;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.write_checkpoint;
+
+	ret = sqlite3_bind_int64(stmt, 1, fileid);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 2, cp->loff);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 3, cp->size);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 4, cp->mtime);
+	if (!ret)
+		ret = sqlite3_bind_blob(stmt, 5, cp->file_state,
+					cp->file_state_len, SQLITE_STATIC);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 6, cp->ext_loff);
+	if (!ret)
+		ret = sqlite3_bind_int64(stmt, 7, cp->ext_len);
+	if (!ret)
+		ret = cp->ext_state_len ?
+			sqlite3_bind_blob(stmt, 8, cp->ext_state,
+					  cp->ext_state_len, SQLITE_STATIC) :
+			sqlite3_bind_null(stmt, 8);
+	if (ret) {
+		perror_sqlite(ret, "binding values");
+		return ret;
+	}
+
+	ret = sqlite3_step(stmt);
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "executing statement");
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * Read one file's checkpoint. `file_state` and `ext_state` must point at
+ * buffers of `state_cap` bytes, which the *_len fields are set to describe.
+ *
+ * False when there is no checkpoint, or when a state does not fit - a blob
+ * written by a build whose snapshot was a different size, which is unreadable
+ * here for the same reason a foreign one is.
+ */
+bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
+			    struct scan_checkpoint *cp, size_t state_cap)
+{
+	int ret;
+	int len, ext_len;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.select_checkpoint;
+
+	ret = sqlite3_bind_int64(stmt, 1, fileid);
+	if (ret) {
+		perror_sqlite(ret, "binding fileid");
+		return false;
+	}
+
+	ret = sqlite3_step(stmt);
+	if (ret == SQLITE_DONE)
+		return false;
+	if (ret != SQLITE_ROW) {
+		perror_sqlite(ret, "fetching a checkpoint");
+		return false;
+	}
+
+	len = sqlite3_column_bytes(stmt, 3);
+	ext_len = sqlite3_column_bytes(stmt, 6);
+	if (len <= 0 || (size_t)len > state_cap ||
+	    ext_len < 0 || (size_t)ext_len > state_cap)
+		return false;
+
+	cp->loff = sqlite3_column_int64(stmt, 0);
+	cp->size = sqlite3_column_int64(stmt, 1);
+	cp->mtime = sqlite3_column_int64(stmt, 2);
+	memcpy(cp->file_state, sqlite3_column_blob(stmt, 3), len);
+	cp->file_state_len = len;
+	cp->ext_loff = sqlite3_column_int64(stmt, 4);
+	cp->ext_len = sqlite3_column_int64(stmt, 5);
+	if (ext_len)
+		memcpy(cp->ext_state, sqlite3_column_blob(stmt, 6), ext_len);
+	cp->ext_state_len = ext_len;
+
+	return true;
+}
+
+int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid)
+{
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.delete_checkpoint;
+	return run_by_fileid(stmt, fileid, NULL);
+}
+
+int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
+{
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
+	return run_by_fileid(stmt, fileid, &seq);
+}
+
+int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff)
+{
+	int ret;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *b = db->stmts.delete_blocks_from;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *e = db->stmts.delete_extents_from;
+
+	ret = run_by_fileid(b, fileid, &loff);
+	if (ret)
+		return ret;
+	return run_by_fileid(e, fileid, &loff);
+}
+
 int dbfile_store_extent_hashes(struct dbhandle *db, int64_t fileid,
 				uint64_t nb_hash, struct extent_csum *hashes)
 {
@@ -2152,6 +2367,7 @@ int dbfile_describe_file(struct dbhandle *db, uint64_t ino, uint64_t subvol,
 	}
 
 	dbfile->id = sqlite3_column_int64(stmt, 3);
+	dbfile->digest_valid = sqlite3_column_int(stmt, 4) != 0;
 
 	ret = 0;
 

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -963,6 +963,18 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 	dbfile_prepare_stmt(delete_checkpoint, DELETE_CHECKPOINT);
 
 	/*
+	 * Every file left partly hashed, so a run can pick them up immediately
+	 * instead of waiting for the walk to rediscover them (#159). Ordered
+	 * biggest-remainder first, which is the order the csum queue wants them
+	 * in anyway.
+	 */
+#define SELECT_CHECKPOINTED_FILES					\
+"select f.id, f.filename, f.ino, f.subvol, f.size, f.mtime "		\
+"from scan_checkpoints c join files f on f.id = c.fileid "		\
+"order by f.size - c.loff desc;"
+	dbfile_prepare_stmt(select_checkpointed_files, SELECT_CHECKPOINTED_FILES);
+
+	/*
 	 * Move a resumed file into this run's generation (#159). An update, not
 	 * the usual upsert: replacing the row would cascade away the very
 	 * checkpoint and hashes the resume is built on.
@@ -1987,6 +1999,67 @@ bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 		memcpy(cp->ext_state, sqlite3_column_blob(stmt, 6), len);
 
 	return true;
+}
+
+void dbfile_free_checkpointed_files(struct checkpointed_file *v, unsigned int n)
+{
+	if (!v)
+		return;
+	for (unsigned int i = 0; i < n; i++)
+		free(v[i].filename);
+	free(v);
+}
+
+int dbfile_load_checkpointed_files(struct dbhandle *db,
+				   struct checkpointed_file **out,
+				   unsigned int *count)
+{
+	int ret;
+	unsigned int n = 0, cap = 8;
+	struct checkpointed_file *v = calloc(cap, sizeof(*v));
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt =
+		db->stmts.select_checkpointed_files;
+
+	*out = NULL;
+	*count = 0;
+	if (!v)
+		return -ENOMEM;
+
+	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
+		if (n == cap) {
+			struct checkpointed_file *bigger =
+				realloc(v, cap * 2 * sizeof(*v));
+
+			if (!bigger)
+				goto oom;
+			v = bigger;
+			memset(v + cap, 0, cap * sizeof(*v));
+			cap *= 2;
+		}
+		v[n].id = sqlite3_column_int64(stmt, 0);
+		v[n].filename = strdup((const char *)sqlite3_column_text(stmt, 1));
+		if (!v[n].filename)
+			goto oom;
+		v[n].ino = sqlite3_column_int64(stmt, 2);
+		v[n].subvol = sqlite3_column_int64(stmt, 3);
+		v[n].size = sqlite3_column_int64(stmt, 4);
+		v[n].mtime = sqlite3_column_int64(stmt, 5);
+		n++;
+	}
+
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "listing checkpointed files");
+		dbfile_free_checkpointed_files(v, n);
+		return ret;
+	}
+
+	*out = v;
+	*count = n;
+	return 0;
+
+oom:
+	dbfile_free_checkpointed_files(v, n);
+	return -ENOMEM;
 }
 
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid)

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -962,17 +962,6 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 #define DELETE_CHECKPOINT "delete from scan_checkpoints where fileid = ?1;"
 	dbfile_prepare_stmt(delete_checkpoint, DELETE_CHECKPOINT);
 
-	/*
-	 * Every file left partly hashed, so a run can pick them up immediately
-	 * instead of waiting for the walk to rediscover them (#159). Ordered
-	 * biggest-remainder first, which is the order the csum queue wants them
-	 * in anyway.
-	 */
-#define SELECT_CHECKPOINTED_FILES					\
-"select f.id, f.filename, f.ino, f.subvol, f.size, f.mtime "		\
-"from scan_checkpoints c join files f on f.id = c.fileid "		\
-"order by f.size - c.loff desc;"
-	dbfile_prepare_stmt(select_checkpointed_files, SELECT_CHECKPOINTED_FILES);
 
 	/*
 	 * Move a resumed file into this run's generation (#159). An update, not
@@ -1799,27 +1788,34 @@ static int step_done(sqlite3_stmt *stmt)
 	return ret;
 }
 
-/* Run a statement taking a fileid, and optionally a logical offset. */
-static int run_by_fileid(sqlite3_stmt *stmt, int64_t fileid, const uint64_t *loff)
+/* Run a statement whose only parameter is a fileid. */
+static int run_by_fileid(sqlite3_stmt *stmt, int64_t fileid)
 {
-	int ret;
+	int ret = sqlite3_bind_int64(stmt, 1, fileid);
 
-	ret = sqlite3_bind_int64(stmt, 1, fileid);
-	if (!ret && loff)
-		ret = sqlite3_bind_int64(stmt, 2, *loff);
 	if (ret) {
 		perror_sqlite(ret, "binding values");
 		return ret;
 	}
-
 	return step_done(stmt);
+}
+
+/* ... and one that takes a second value after it. */
+static int run_by_fileid_arg(sqlite3_stmt *stmt, int64_t fileid, uint64_t arg)
+{
+	int ret = sqlite3_bind_int64(stmt, 2, arg);
+
+	if (ret) {
+		perror_sqlite(ret, "binding values");
+		return ret;
+	}
+	return run_by_fileid(stmt, fileid);
 }
 
 int dbfile_remove_extent_hashes(struct dbhandle *db, int64_t fileid)
 {
-	uint64_t all = 0;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.remove_extent_hashes;
-	return run_by_fileid(stmt, fileid, &all);
+	return run_by_fileid_arg(stmt, fileid, 0);
 }
 
 int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff)
@@ -1828,10 +1824,10 @@ int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *b = db->stmts.remove_block_hashes;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *e = db->stmts.remove_extent_hashes;
 
-	ret = run_by_fileid(b, fileid, &loff);
+	ret = run_by_fileid_arg(b, fileid, loff);
 	if (ret)
 		return ret;
-	return run_by_fileid(e, fileid, &loff);
+	return run_by_fileid_arg(e, fileid, loff);
 }
 
 int dbfile_remove_hashes(struct dbhandle *db, int64_t fileid)
@@ -2001,77 +1997,28 @@ bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 	return true;
 }
 
-void dbfile_free_checkpointed_files(struct checkpointed_file *v, unsigned int n)
+int dbfile_load_checkpointed_paths(struct dbhandle *db, char ***out, int *nout)
 {
-	if (!v)
-		return;
-	for (unsigned int i = 0; i < n; i++)
-		free(v[i].filename);
-	free(v);
-}
-
-int dbfile_load_checkpointed_files(struct dbhandle *db,
-				   struct checkpointed_file **out,
-				   unsigned int *count)
-{
-	int ret;
-	unsigned int n = 0, cap = 8;
-	struct checkpointed_file *v = calloc(cap, sizeof(*v));
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt =
-		db->stmts.select_checkpointed_files;
-
-	*out = NULL;
-	*count = 0;
-	if (!v)
-		return -ENOMEM;
-
-	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		if (n == cap) {
-			struct checkpointed_file *bigger =
-				realloc(v, cap * 2 * sizeof(*v));
-
-			if (!bigger)
-				goto oom;
-			v = bigger;
-			memset(v + cap, 0, cap * sizeof(*v));
-			cap *= 2;
-		}
-		v[n].id = sqlite3_column_int64(stmt, 0);
-		v[n].filename = strdup((const char *)sqlite3_column_text(stmt, 1));
-		if (!v[n].filename)
-			goto oom;
-		v[n].ino = sqlite3_column_int64(stmt, 2);
-		v[n].subvol = sqlite3_column_int64(stmt, 3);
-		v[n].size = sqlite3_column_int64(stmt, 4);
-		v[n].mtime = sqlite3_column_int64(stmt, 5);
-		n++;
-	}
-
-	if (ret != SQLITE_DONE) {
-		perror_sqlite(ret, "listing checkpointed files");
-		dbfile_free_checkpointed_files(v, n);
-		return ret;
-	}
-
-	*out = v;
-	*count = n;
-	return 0;
-
-oom:
-	dbfile_free_checkpointed_files(v, n);
-	return -ENOMEM;
+	/*
+	 * Biggest remainder first, which is the order the csum queue wants them
+	 * in anyway - though the queue re-sorts, so this is only a tie-break.
+	 */
+	return load_string_rows(db->db,
+				"select f.filename from scan_checkpoints c "
+				"join files f on f.id = c.fileid "
+				"order by f.size - c.loff desc;", out, nout);
 }
 
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid)
 {
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.delete_checkpoint;
-	return run_by_fileid(stmt, fileid, NULL);
+	return run_by_fileid(stmt, fileid);
 }
 
 int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
 {
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
-	return run_by_fileid(stmt, fileid, &seq);
+	return run_by_fileid_arg(stmt, fileid, seq);
 }
 
 int dbfile_store_extent_hashes(struct dbhandle *db, int64_t fileid,

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -771,12 +771,19 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 "mtime, dedupe_seq) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);"
 	dbfile_prepare_stmt(write_file, WRITE_FILE);
 
+	/*
+	 * Drop a file's hashes from `?2` onwards. Removing all of them is the
+	 * same statement with ?2 = 0, so there is one pair rather than two:
+	 * UNIQUE(fileid, loff...) makes both forms the same index range scan,
+	 * and struct stmts is per-connection - the listing handle, the batched
+	 * writer and every walker each prepare the whole set.
+	 */
 #define REMOVE_BLOCK_HASHES						\
-"delete from blocks where fileid = ?1;"
+"delete from blocks where fileid = ?1 and loff >= ?2;"
 	dbfile_prepare_stmt(remove_block_hashes, REMOVE_BLOCK_HASHES);
 
 #define REMOVE_EXTENT_HASHES						\
-"delete from extents where fileid = ?1;"
+"delete from extents where fileid = ?1 and loff >= ?2;"
 	dbfile_prepare_stmt(remove_extent_hashes, REMOVE_EXTENT_HASHES);
 
 #define LOAD_FILEREC							\
@@ -962,19 +969,6 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 	 */
 #define UPDATE_DEDUPE_SEQ "update files set dedupe_seq = ?2 where id = ?1;"
 	dbfile_prepare_stmt(update_dedupe_seq, UPDATE_DEDUPE_SEQ);
-
-	/*
-	 * Drop the hashes a resumed scan is about to recompute. Extent rows only
-	 * ever land at a checkpoint, so there are none past it; block rows flush
-	 * on their own batch cadence (#161) and can sit anywhere.
-	 */
-#define DELETE_BLOCKS_FROM						\
-"delete from blocks where fileid = ?1 and loff >= ?2;"
-	dbfile_prepare_stmt(delete_blocks_from, DELETE_BLOCKS_FROM);
-
-#define DELETE_EXTENTS_FROM						\
-"delete from extents where fileid = ?1 and loff >= ?2;"
-	dbfile_prepare_stmt(delete_extents_from, DELETE_EXTENTS_FROM);
 
 #define RENAME_FILE							\
 "update or replace files set filename = ?1, path_hash = ?2 where id = ?3;"
@@ -1781,43 +1775,56 @@ out_error:
 	return 0;
 }
 
-static int __dbfile_remove_file_hashes(sqlite3_stmt *stmt, int64_t fileid)
+/* Step a statement that returns no rows, reporting anything but a clean end. */
+static int step_done(sqlite3_stmt *stmt)
+{
+	int ret = sqlite3_step(stmt);
+
+	if (ret == SQLITE_DONE)
+		return 0;
+
+	perror_sqlite(ret, "executing statement");
+	return ret;
+}
+
+/* Run a statement taking a fileid, and optionally a logical offset. */
+static int run_by_fileid(sqlite3_stmt *stmt, int64_t fileid, const uint64_t *loff)
 {
 	int ret;
 
 	ret = sqlite3_bind_int64(stmt, 1, fileid);
+	if (!ret && loff)
+		ret = sqlite3_bind_int64(stmt, 2, *loff);
 	if (ret) {
-		perror_sqlite(ret, "binding fileid");
-		goto out;
+		perror_sqlite(ret, "binding values");
+		return ret;
 	}
 
-	ret = sqlite3_step(stmt);
-	if (ret != SQLITE_DONE) {
-		perror_sqlite(ret, "removing hashes statement");
-		goto out;
-	}
-
-	ret = 0;
-out:
-	return ret;
+	return step_done(stmt);
 }
 
 int dbfile_remove_extent_hashes(struct dbhandle *db, int64_t fileid)
 {
+	uint64_t all = 0;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.remove_extent_hashes;
-	return __dbfile_remove_file_hashes(stmt, fileid);
+	return run_by_fileid(stmt, fileid, &all);
+}
+
+int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff)
+{
+	int ret;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *b = db->stmts.remove_block_hashes;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *e = db->stmts.remove_extent_hashes;
+
+	ret = run_by_fileid(b, fileid, &loff);
+	if (ret)
+		return ret;
+	return run_by_fileid(e, fileid, &loff);
 }
 
 int dbfile_remove_hashes(struct dbhandle *db, int64_t fileid)
 {
-	int ret = 0;
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *b_stmt = db->stmts.remove_block_hashes;
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *e_stmt = db->stmts.remove_extent_hashes;
-
-	ret += __dbfile_remove_file_hashes(b_stmt, fileid);
-	ret += __dbfile_remove_file_hashes(e_stmt, fileid);
-
-	return ret;
+	return dbfile_remove_hashes_from(db, fileid, 0);
 }
 
 int dbfile_store_block_hashes(struct dbhandle *db, int64_t fileid,
@@ -1892,80 +1899,62 @@ out_error:
 	return ret;
 }
 
-/* Run a statement that takes just a fileid, or a fileid and an offset. */
-static int run_by_fileid(sqlite3_stmt *stmt, int64_t fileid, const uint64_t *loff)
-{
-	int ret;
-
-	ret = sqlite3_bind_int64(stmt, 1, fileid);
-	if (!ret && loff)
-		ret = sqlite3_bind_int64(stmt, 2, *loff);
-	if (ret) {
-		perror_sqlite(ret, "binding values");
-		return ret;
-	}
-
-	ret = sqlite3_step(stmt);
-	if (ret != SQLITE_DONE) {
-		perror_sqlite(ret, "executing statement");
-		return ret;
-	}
-
-	return 0;
-}
-
 int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
 			    const struct scan_checkpoint *cp)
 {
 	int ret;
+	size_t len = running_checksum_state_size();
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.write_checkpoint;
 
 	ret = sqlite3_bind_int64(stmt, 1, fileid);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 2, cp->loff);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 3, cp->size);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 4, cp->mtime);
-	if (!ret)
-		ret = sqlite3_bind_blob(stmt, 5, cp->file_state,
-					cp->file_state_len, SQLITE_STATIC);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 6, cp->ext_loff);
-	if (!ret)
-		ret = sqlite3_bind_int64(stmt, 7, cp->ext_len);
-	if (!ret)
-		ret = cp->ext_state_len ?
-			sqlite3_bind_blob(stmt, 8, cp->ext_state,
-					  cp->ext_state_len, SQLITE_STATIC) :
-			sqlite3_bind_null(stmt, 8);
-	if (ret) {
-		perror_sqlite(ret, "binding values");
-		return ret;
-	}
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_int64(stmt, 2, cp->loff);
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_int64(stmt, 3, cp->size);
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_int64(stmt, 4, cp->mtime);
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_blob(stmt, 5, cp->file_state, len, SQLITE_STATIC);
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_int64(stmt, 6, cp->ext_loff);
+	if (ret)
+		goto bind_error;
+	ret = sqlite3_bind_int64(stmt, 7, cp->ext_len);
+	if (ret)
+		goto bind_error;
+	ret = cp->has_ext_state ?
+		sqlite3_bind_blob(stmt, 8, cp->ext_state, len, SQLITE_STATIC) :
+		sqlite3_bind_null(stmt, 8);
+	if (ret)
+		goto bind_error;
 
-	ret = sqlite3_step(stmt);
-	if (ret != SQLITE_DONE) {
-		perror_sqlite(ret, "executing statement");
-		return ret;
-	}
+	return step_done(stmt);
 
-	return 0;
+bind_error:
+	perror_sqlite(ret, "binding values");
+	return ret;
 }
 
 /*
- * Read one file's checkpoint. `file_state` and `ext_state` must point at
- * buffers of `state_cap` bytes, which the *_len fields are set to describe.
+ * Read one file's checkpoint into the caller's buffers, which must each hold
+ * running_checksum_state_size() bytes.
  *
- * False when there is no checkpoint, or when a state does not fit - a blob
- * written by a build whose snapshot was a different size, which is unreadable
- * here for the same reason a foreign one is.
+ * False when there is no checkpoint, or when a stored state is not exactly that
+ * size - a blob written by a build whose snapshot differed, which is unreadable
+ * here for the same reason a foreign one is (running_checksum_restore() would
+ * refuse it a moment later anyway).
  */
 bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
-			    struct scan_checkpoint *cp, size_t state_cap)
+			    struct scan_checkpoint *cp)
 {
 	int ret;
-	int len, ext_len;
+	size_t len = running_checksum_state_size();
+	int ext_len;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.select_checkpoint;
 
 	ret = sqlite3_bind_int64(stmt, 1, fileid);
@@ -1982,22 +1971,20 @@ bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 		return false;
 	}
 
-	len = sqlite3_column_bytes(stmt, 3);
 	ext_len = sqlite3_column_bytes(stmt, 6);
-	if (len <= 0 || (size_t)len > state_cap ||
-	    ext_len < 0 || (size_t)ext_len > state_cap)
+	if ((size_t)sqlite3_column_bytes(stmt, 3) != len ||
+	    (ext_len != 0 && (size_t)ext_len != len))
 		return false;
 
 	cp->loff = sqlite3_column_int64(stmt, 0);
 	cp->size = sqlite3_column_int64(stmt, 1);
 	cp->mtime = sqlite3_column_int64(stmt, 2);
 	memcpy(cp->file_state, sqlite3_column_blob(stmt, 3), len);
-	cp->file_state_len = len;
 	cp->ext_loff = sqlite3_column_int64(stmt, 4);
 	cp->ext_len = sqlite3_column_int64(stmt, 5);
-	if (ext_len)
-		memcpy(cp->ext_state, sqlite3_column_blob(stmt, 6), ext_len);
-	cp->ext_state_len = ext_len;
+	cp->has_ext_state = ext_len != 0;
+	if (cp->has_ext_state)
+		memcpy(cp->ext_state, sqlite3_column_blob(stmt, 6), len);
 
 	return true;
 }
@@ -2012,18 +1999,6 @@ int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
 {
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
 	return run_by_fileid(stmt, fileid, &seq);
-}
-
-int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff)
-{
-	int ret;
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *b = db->stmts.delete_blocks_from;
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *e = db->stmts.delete_extents_from;
-
-	ret = run_by_fileid(b, fileid, &loff);
-	if (ret)
-		return ret;
-	return run_by_fileid(e, fileid, &loff);
 }
 
 int dbfile_store_extent_hashes(struct dbhandle *db, int64_t fileid,

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -60,8 +60,6 @@ struct stmts {
 	sqlite3_stmt *select_checkpoint;
 	sqlite3_stmt *delete_checkpoint;
 	sqlite3_stmt *update_dedupe_seq;
-	sqlite3_stmt *delete_blocks_from;
-	sqlite3_stmt *delete_extents_from;
 };
 
 struct dbhandle {
@@ -347,9 +345,10 @@ int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff
  * (#159). At most one checkpoint per file, alive only while that file is
  * partially hashed.
  *
- * The two states are opaque here - see running_checksum_save(). The extent one
- * is absent (ext_state_len 0) when loff fell on an extent boundary and no
- * extent digest was in progress.
+ * The two states are opaque here - see running_checksum_save(). Both buffers
+ * are owned by the caller and are always running_checksum_state_size() bytes;
+ * has_ext_state is false when loff fell on an extent boundary and no extent
+ * digest was in progress.
  */
 struct scan_checkpoint {
 	uint64_t	loff;		/* bytes of the file hashed so far */
@@ -358,15 +357,14 @@ struct scan_checkpoint {
 	uint64_t	ext_loff;	/* the extent being hashed at loff, */
 	uint64_t	ext_len;	/* checked to still be there on resume */
 	void		*file_state;
-	size_t		file_state_len;
 	void		*ext_state;
-	size_t		ext_state_len;
+	bool		has_ext_state;
 };
 
 int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
 			    const struct scan_checkpoint *cp);
 bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
-			    struct scan_checkpoint *cp, size_t state_cap);
+			    struct scan_checkpoint *cp);
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid);
 /* Put a resumed file in this run's dedupe generation, leaving its row (and so
  * its checkpoint and stored hashes) otherwise intact. */

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -59,7 +59,6 @@ struct stmts {
 	sqlite3_stmt *write_checkpoint;
 	sqlite3_stmt *select_checkpoint;
 	sqlite3_stmt *delete_checkpoint;
-	sqlite3_stmt *select_checkpointed_files;
 	sqlite3_stmt *update_dedupe_seq;
 };
 
@@ -369,22 +368,12 @@ bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid);
 
 /*
- * Every file a checkpoint is waiting on, biggest remainder first. A scan hands
- * these to the hashing pool up front rather than waiting for the walk to
- * rediscover them, which on a large tree takes minutes (#159). Caller frees.
+ * Paths of every file a checkpoint is waiting on. A scan hands these to the
+ * consumer up front rather than waiting for the walk to rediscover them, which
+ * on a large tree takes minutes (#159). Free with scan_config_free()'s idiom:
+ * each string, then the array.
  */
-struct checkpointed_file {
-	int64_t		id;
-	char		*filename;
-	uint64_t	ino;
-	uint64_t	subvol;
-	uint64_t	size;
-	uint64_t	mtime;
-};
-int dbfile_load_checkpointed_files(struct dbhandle *db,
-				   struct checkpointed_file **out,
-				   unsigned int *count);
-void dbfile_free_checkpointed_files(struct checkpointed_file *v, unsigned int n);
+int dbfile_load_checkpointed_paths(struct dbhandle *db, char ***out, int *nout);
 /* Put a resumed file in this run's dedupe generation, leaving its row (and so
  * its checkpoint and stored hashes) otherwise intact. */
 int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq);

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -59,6 +59,7 @@ struct stmts {
 	sqlite3_stmt *write_checkpoint;
 	sqlite3_stmt *select_checkpoint;
 	sqlite3_stmt *delete_checkpoint;
+	sqlite3_stmt *select_checkpointed_files;
 	sqlite3_stmt *update_dedupe_seq;
 };
 
@@ -366,6 +367,24 @@ int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
 bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 			    struct scan_checkpoint *cp);
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid);
+
+/*
+ * Every file a checkpoint is waiting on, biggest remainder first. A scan hands
+ * these to the hashing pool up front rather than waiting for the walk to
+ * rediscover them, which on a large tree takes minutes (#159). Caller frees.
+ */
+struct checkpointed_file {
+	int64_t		id;
+	char		*filename;
+	uint64_t	ino;
+	uint64_t	subvol;
+	uint64_t	size;
+	uint64_t	mtime;
+};
+int dbfile_load_checkpointed_files(struct dbhandle *db,
+				   struct checkpointed_file **out,
+				   unsigned int *count);
+void dbfile_free_checkpointed_files(struct checkpointed_file *v, unsigned int n);
 /* Put a resumed file in this run's dedupe generation, leaving its row (and so
  * its checkpoint and stored hashes) otherwise intact. */
 int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq);

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -56,6 +56,12 @@ struct stmts {
 	sqlite3_stmt *get_max_dedupe_seq;
 	sqlite3_stmt *delete_unscanned_files;
 	sqlite3_stmt *rename_file;
+	sqlite3_stmt *write_checkpoint;
+	sqlite3_stmt *select_checkpoint;
+	sqlite3_stmt *delete_checkpoint;
+	sqlite3_stmt *update_dedupe_seq;
+	sqlite3_stmt *delete_blocks_from;
+	sqlite3_stmt *delete_extents_from;
 };
 
 struct dbhandle {
@@ -78,6 +84,13 @@ struct file {
 	uint64_t	mtime;
 	unsigned int	dedupe_seq;
 	char		digest[DIGEST_LEN];
+	/*
+	 * Whether the stored row actually has a digest. It gets one only once
+	 * the file has been hashed all the way through, so this is what tells a
+	 * scanned file from one an interrupted run left partway (#159) - mtime
+	 * and size are written up front and say nothing about it.
+	 */
+	bool		digest_valid;
 	unsigned int	flags;
 };
 
@@ -326,6 +339,38 @@ static inline void sqlite3_reset_stmt(sqlite3_stmt **stmt)
 
 void dbfile_set_gdb(struct dbhandle *db);
 int dbfile_remove_hashes(struct dbhandle *db, int64_t fileid);
+/* Drop a file's block and extent hashes at or past `loff` (resume, #159). */
+int dbfile_remove_hashes_from(struct dbhandle *db, int64_t fileid, uint64_t loff);
+
+/*
+ * How far hashing of one file got, and enough state to carry on from there
+ * (#159). At most one checkpoint per file, alive only while that file is
+ * partially hashed.
+ *
+ * The two states are opaque here - see running_checksum_save(). The extent one
+ * is absent (ext_state_len 0) when loff fell on an extent boundary and no
+ * extent digest was in progress.
+ */
+struct scan_checkpoint {
+	uint64_t	loff;		/* bytes of the file hashed so far */
+	uint64_t	size;		/* the file as of the checkpoint, so a */
+	uint64_t	mtime;		/* resume can tell it has since changed */
+	uint64_t	ext_loff;	/* the extent being hashed at loff, */
+	uint64_t	ext_len;	/* checked to still be there on resume */
+	void		*file_state;
+	size_t		file_state_len;
+	void		*ext_state;
+	size_t		ext_state_len;
+};
+
+int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
+			    const struct scan_checkpoint *cp);
+bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
+			    struct scan_checkpoint *cp, size_t state_cap);
+int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid);
+/* Put a resumed file in this run's dedupe generation, leaving its row (and so
+ * its checkpoint and stored hashes) otherwise intact. */
+int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq);
 
 unsigned int get_max_dedupe_seq(struct dbhandle *db);
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -416,6 +416,33 @@ struct buffer {
  */
 static unsigned int block_batch_max = BLOCK_BATCH_MAX;
 
+/*
+ * How much of one file is hashed between checkpoints (#159).
+ *
+ * A checkpoint costs a commit of the hashes gathered since the last one plus a
+ * few hundred bytes of running-checksum state, so it is only worth taking when
+ * the work it protects is worth far more than that. At 1 GiB a checkpoint is
+ * seconds of reading on any storage oans runs on, and a file small enough never
+ * to reach one is a file that was never at risk: rehashing it costs less than
+ * the checkpoint would have.
+ *
+ * The bound this buys is on *lost work*, not on file size - a 1 TiB file
+ * interrupted at 900 GiB resumes having lost at most this much.
+ */
+#define CHECKPOINT_INTERVAL_BYTES	(1ULL << 30)
+
+/*
+ * Test hooks, read once on the main thread in filescan_init() (see
+ * DUPEREMOVE_BLOCK_BATCH above for why that is enough synchronisation).
+ *
+ * DUPEREMOVE_CHECKPOINT_BYTES lowers the interval so resume is reachable
+ * without a multi-gigabyte file. DUPEREMOVE_CHECKPOINT_STOP abandons a file
+ * after that many checkpoints, which is what an interrupted run leaves behind -
+ * deterministically, where racing a real signal against a read is not.
+ */
+static uint64_t checkpoint_interval = CHECKPOINT_INTERVAL_BYTES;
+static unsigned int checkpoint_stop_after;
+
 struct hashes {
 	unsigned int extents_count;
 	unsigned int extents_index;
@@ -1477,6 +1504,127 @@ static inline bool is_file_renamed(char *path_in_db, char *path)
 }
 
 /*
+ * Take up hashing a file where an interrupted run left off (#159).
+ *
+ * True only if there is a checkpoint, it describes the file as it is now, and
+ * this binary can read the checksum state in it - so the caller gets either a
+ * usable resume point or the ordinary "hash it from the start" path, never a
+ * half-adopted one. Anything unusable is deleted on the way out: it describes a
+ * file that has since changed, or a running checksum from an xxhash this binary
+ * is not linked against, and either way it will never become valid again.
+ *
+ * Hashes at or past the resume point go too. There should be none - extent rows
+ * are only written by a checkpoint - but block rows flush on their own batch
+ * cadence (#161), so a run killed between the last checkpoint and the next can
+ * leave blocks beyond it, and those are about to be hashed again.
+ */
+static void drop_resume_csums(struct file_to_scan *resume)
+{
+	if (resume->resume_csum)
+		finish_running_checksum(resume->resume_csum, NULL);
+	if (resume->resume_ext_csum)
+		finish_running_checksum(resume->resume_ext_csum, NULL);
+	resume->resume_csum = resume->resume_ext_csum = NULL;
+}
+
+/*
+ * Write the file's row for a scan that starts at the beginning: drop whatever a
+ * previous run recorded about it and upsert the record the hashing will fill
+ * in. Returns its id, or 0 if the row could not be written.
+ */
+static int64_t store_file_row(struct file *dbfile, char *path, bool file_renamed)
+{
+	struct dbhandle *wdb = scan_writer;
+	int64_t fileid;
+
+	dbfile_lock();
+	if (scan_write_begin()) {
+		dbfile_unlock();
+		return 0;
+	}
+
+	if (file_renamed && dbfile_rename_file(wdb, dbfile->id, path)) {
+		vprintf("dbfile_rename_file failed\n");
+		dbfile_unlock();
+		return 0;
+	}
+
+	if (dbfile->mtime != 0 || dbfile->size != 0) {
+		/*
+		 * The file was scanned in a previous run.
+		 * We will rescan it, so let's remove old hashes
+		 */
+		dbfile_remove_hashes(wdb, dbfile->id);
+	}
+
+	/* Upsert the file record */
+	fileid = dbfile_store_file_info(wdb, dbfile);
+	if (!fileid)
+		scan_write_abort();
+	else
+		scan_write_end();
+	dbfile_unlock();
+
+	return fileid;
+}
+
+static bool resume_scan(struct dbhandle *db, struct file *dbfile,
+			struct file_to_scan *resume)
+{
+	size_t cap = running_checksum_state_size();
+	_cleanup_(freep) void *file_state = malloc(cap);
+	_cleanup_(freep) void *ext_state = malloc(cap);
+	struct scan_checkpoint cp = { .file_state = file_state,
+				      .ext_state = ext_state };
+
+	if (!file_state || !ext_state)
+		return false;
+
+	if (!dbfile_load_checkpoint(db, dbfile->id, &cp, cap))
+		return false;
+
+	if (cp.size == dbfile->size && cp.mtime == dbfile->mtime &&
+	    cp.loff > 0 && cp.loff < dbfile->size) {
+		resume->resume_csum = running_checksum_restore(cp.file_state,
+							       cp.file_state_len);
+		if (cp.ext_state_len)
+			resume->resume_ext_csum =
+				running_checksum_restore(cp.ext_state,
+							 cp.ext_state_len);
+		/* Both or neither: half a checkpoint is no checkpoint. */
+		if (!resume->resume_csum ||
+		    (cp.ext_state_len && !resume->resume_ext_csum))
+			drop_resume_csums(resume);
+	}
+
+	dbfile_lock();
+	if (scan_write_begin() != 0) {
+		dbfile_unlock();
+		drop_resume_csums(resume);
+		return false;
+	}
+	if (resume->resume_csum)
+		dbfile_remove_hashes_from(scan_writer, dbfile->id, cp.loff);
+	else
+		dbfile_remove_checkpoint(scan_writer, dbfile->id);
+	scan_write_end();
+	dbfile_unlock();
+
+	if (!resume->resume_csum) {
+		vprintf("Discarding an unusable checkpoint for %s; hashing it "
+			"from the start\n", dbfile->filename);
+		return false;
+	}
+
+	resume->resume_off = cp.loff;
+	resume->resume_ext_loff = cp.ext_loff;
+	resume->resume_ext_len = cp.ext_len;
+	vprintf("Resuming %s at %"PRIu64" of %"PRIu64" bytes\n",
+		dbfile->filename, cp.loff, (uint64_t)dbfile->size);
+	return true;
+}
+
+/*
  * Returns nonzero on fatal errors only
  * This function schedules csum_whole_file()
  * The caller must call check_file() before and must not call
@@ -1489,7 +1637,8 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	static unsigned int seq = 0, counter = 0;
 	struct file_to_scan *file;
 	int64_t fileid = 0;
-	bool file_renamed;
+	bool file_renamed, unchanged, resumed = false;
+	struct file_to_scan resume = {0,};
 	static uint64_t position = 0;
 
 	/*
@@ -1551,10 +1700,11 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	}
 
 	file_renamed = is_file_renamed(dbfile.filename, path);
+	unchanged = dbfile.mtime == timestamp_to_nano(st->stx_mtime)
+		    && dbfile.size == st->stx_size;
 
 	/* Database is up-to-date, nothing more to do */
-	if (dbfile.mtime == timestamp_to_nano(st->stx_mtime)
-	    && dbfile.size == st->stx_size && !file_renamed) {
+	if (unchanged && dbfile.digest_valid && !file_renamed) {
 		mark_file_seen(dbfile.id);	/* still on disk: prune can skip it */
 		return 0;
 	}
@@ -1577,44 +1727,37 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	dbfile.mtime = timestamp_to_nano(st->stx_mtime);
 	dbfile.dedupe_seq = seq;
 
-	/* Reads use the caller's handle; all writes go to the scan writer. */
-	struct dbhandle *wdb = scan_writer;
+	/*
+	 * No digest, but the file is as an earlier run last saw it: that run was
+	 * interrupted partway through hashing it, and may have left enough state
+	 * to carry on from (#159). Only its own hashing is picked up - the row
+	 * itself stays exactly as it was, since rewriting it would cascade the
+	 * checkpoint and the hashes already stored straight back out.
+	 */
+	if (unchanged && !dbfile.digest_valid && !file_renamed)
+		resumed = resume_scan(db, &dbfile, &resume);
 
-	dbfile_lock();
-	ret = scan_write_begin();
-	if (ret) {
-		dbfile_unlock();
-		return 0;
-	}
-
-	if (file_renamed) {
-		ret = dbfile_rename_file(wdb, dbfile.id, path);
-		if (ret) {
-			vprintf("dbfile_rename_file failed\n");
-			dbfile_unlock();
-			return 0;
+	/*
+	 * Resuming keeps the existing row - replacing it would cascade away the
+	 * checkpoint and the hashes the resume is built on - but moves it into
+	 * this run's generation. The one it carries is the interrupted run's,
+	 * which a dedupe phase since then may have drawn level with, and a file
+	 * at or below that watermark is one dedupe never looks at.
+	 */
+	if (resumed) {
+		fileid = dbfile.id;
+		dbfile_lock();
+		if (scan_write_begin() == 0) {
+			dbfile_update_dedupe_seq(scan_writer, fileid, seq);
+			scan_write_end();
 		}
-	}
-
-	if (dbfile.mtime != 0 || dbfile.size != 0) {
-		/*
-		 * The file was scanned in a previous run.
-		 * We will rescan it, so let's remove old hashes
-		 */
-		dbfile_remove_hashes(wdb, dbfile.id);
-	}
-
-	/* Upsert the file record */
-	fileid = dbfile_store_file_info(wdb, &dbfile);
-	if (!fileid) {
-		scan_write_abort();
 		dbfile_unlock();
-		return 0;
+	} else {
+		fileid = store_file_row(&dbfile, path, file_renamed);
 	}
+	if (!fileid)
+		return 0;
 	mark_file_seen(fileid);		/* on disk: the prune can skip it */
-
-	scan_write_end();
-	dbfile_unlock();
 
 	/* Remember this inode so later hardlinks to it are skipped. */
 	mark_inode_seen(dbfile.ino, dbfile.subvol);
@@ -1622,11 +1765,14 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	/* Schedule the file for scan */
 	file = malloc(sizeof(struct file_to_scan)); /* Freed by csum_whole_file() */
 
+	*file = resume;			/* zeroed unless we are resuming */
 	file->path = strdup(path);
 	file->fileid = fileid;
 	file->filesize = st->stx_size;
+	file->mtime = dbfile.mtime;
 
-	pscan_set_progress(1, st->stx_size);
+	/* Only the bytes still to be read are this run's work. */
+	pscan_set_progress(1, st->stx_size - file->resume_off);
 	position++;
 	file->file_position = position;
 
@@ -1785,6 +1931,165 @@ static int flush_block_hashes(struct hashes *hashes)
 	hashes->blocks_flushed += hashes->blocks_index;
 	hashes->blocks_index = 0;
 	return 0;
+}
+
+/*
+ * Write the extent digests gathered so far and reset the batch. The mirror of
+ * flush_block_hashes(); only a checkpoint calls it mid-file, so unlike the
+ * blocks there is never an extent row past the last checkpoint.
+ */
+static int flush_extent_hashes(struct hashes *hashes)
+{
+	int ret;
+
+	if (!hashes->extents_index)
+		return 0;
+
+	ret = dbfile_store_extent_hashes(hashes->db, hashes->fileid,
+					 hashes->extents_index, hashes->extents);
+	if (ret)
+		return ret;
+
+	hashes->extents_index = 0;
+	return 0;
+}
+
+/*
+ * Record how far this file has been hashed, so an interrupted run resumes here
+ * rather than at byte zero (#159).
+ *
+ * Everything the resume needs lands in one transaction: the hashes for the
+ * region just covered, and the checkpoint that claims that region is done. That
+ * is what makes a kill at any instant safe - the two can never be committed
+ * apart, so a resumed scan can neither skip a region nor hash one twice.
+ *
+ * Committed rather than left to the batched writer's ten-second cadence: a
+ * checkpoint that is still in an open transaction protects nothing, and the
+ * point of the exercise is to survive the process dying.
+ */
+static int write_checkpoint(struct hashes *hashes, struct scan_ctxt *ctxt,
+			    uint64_t mtime)
+{
+	int ret;
+	size_t len = running_checksum_state_size();
+	_cleanup_(freep) void *file_state = malloc(len);
+	_cleanup_(freep) void *ext_state = malloc(len);
+	struct scan_checkpoint cp = {
+		.loff		= ctxt->off,
+		.size		= ctxt->filesize,
+		.mtime		= mtime,
+		.file_state	= file_state,
+		.file_state_len	= len,
+		.ext_state	= ext_state,
+	};
+
+	if (!file_state || !ext_state)
+		return -ENOMEM;
+
+	ret = running_checksum_save(ctxt->file_csum, file_state, len);
+	if (ret)
+		return ret;
+
+	/*
+	 * An extent digest in progress covers bytes the file digest has already
+	 * consumed, so it has to be carried too - otherwise resuming would have
+	 * to re-read back to the start of the extent, which on a file laid out
+	 * as one extent is the whole file. Record which extent it belongs to so
+	 * the resume can tell the layout has not moved under it.
+	 */
+	if (ctxt->extent_csum) {
+		struct fiemap_extent *e = get_extent(ctxt->fiemap, ctxt->off,
+						     &ctxt->extent_cursor);
+
+		if (!e)
+			return -EINVAL;
+		ret = running_checksum_save(ctxt->extent_csum, ext_state, len);
+		if (ret)
+			return ret;
+		cp.ext_loff = e->fe_logical;
+		cp.ext_len = e->fe_length;
+		cp.ext_state_len = len;
+	}
+
+	dbfile_lock();
+	ret = scan_write_begin();
+	if (ret) {
+		dbfile_unlock();
+		return ret;
+	}
+
+	ret = flush_extent_hashes(hashes);
+	if (!ret && hashes->blocks_index) {
+		ret = dbfile_store_block_hashes(hashes->db, hashes->fileid,
+						hashes->blocks_index,
+						hashes->blocks);
+		if (!ret) {
+			hashes->blocks_flushed += hashes->blocks_index;
+			hashes->blocks_index = 0;
+		}
+	}
+	if (!ret)
+		ret = dbfile_store_checkpoint(hashes->db, hashes->fileid, &cp);
+	if (ret)
+		scan_write_abort();
+	else
+		ret = scan_write_flush();
+	dbfile_unlock();
+
+	return ret;
+}
+
+/*
+ * True if the extent a resumed checkpoint left half-hashed is not where it was.
+ *
+ * The digest carried over covers part of one specific extent, so it means
+ * nothing if that extent has been rewritten. mtime and size - what normally
+ * stands for "unchanged" - need not move when a file is defragmented or deduped
+ * by something else, so the record the resume depends on is checked directly.
+ */
+static bool checkpoint_extent_moved(struct scan_ctxt *ctxt,
+				    struct file_to_scan *file)
+{
+	struct fiemap_extent *e = get_extent(ctxt->fiemap, ctxt->off,
+					     &ctxt->extent_cursor);
+
+	return !e || e->fe_logical != file->resume_ext_loff ||
+	       e->fe_length != file->resume_ext_len;
+}
+
+/*
+ * Give up on a resume and hash the file from byte zero. Everything stored for
+ * it describes a layout that is no longer there, so none of it may survive -
+ * including the checkpoint itself, which is now describing nothing.
+ *
+ * False only if a fresh checksum could not be allocated, i.e. the file cannot
+ * be hashed at all.
+ */
+static bool rewind_to_start(struct scan_ctxt *ctxt, struct file_to_scan *file,
+			    struct pscan_thread *tprogress, struct dbhandle *db)
+{
+	finish_running_checksum(ctxt->extent_csum, NULL);
+	ctxt->extent_csum = NULL;
+	finish_running_checksum(ctxt->file_csum, NULL);
+	ctxt->file_csum = start_running_checksum();
+	if (!ctxt->file_csum)
+		return false;
+	ctxt->off = 0;
+	ctxt->extent_cursor = 0;
+
+	/* The skipped bytes are back on the bill, here and in the run-wide
+	 * total __scan_file() sized without them. */
+	pscan_set_file(tprogress, file->path, ctxt->filesize);
+	pscan_set_progress(0, file->resume_off);
+
+	dbfile_lock();
+	if (scan_write_begin() == 0) {
+		dbfile_remove_hashes(db, file->fileid);
+		dbfile_remove_checkpoint(db, file->fileid);
+		scan_write_end();
+	}
+	dbfile_unlock();
+	return true;
 }
 
 static int add_block_hash(struct hashes *hashes,
@@ -2320,12 +2625,39 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 */
 	abort_on(!tprogress);
 	tprogress->status = thread_mapping;	/* open + do_fiemap: no bytes yet */
-	pscan_set_file(tprogress, file->path, file->filesize);
+	/*
+	 * Resuming, the bytes an earlier run already hashed are not this run's
+	 * work: __scan_file() left them out of the global total, so leave them
+	 * out here too or the file would reconcile against a total it was never
+	 * going to reach.
+	 */
+	pscan_set_file(tprogress, file->path, file->filesize - file->resume_off);
 	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
 
 	/* Dummy variables used to trigger the cleanup code */
 	_cleanup_(freep) char *path = file->path;
 	_cleanup_(freep) struct file_to_scan *clean_file = file;
+
+	/*
+	 * Adopt the running checksum an interrupted run left behind, before any
+	 * early return can leak it. ctxt.off starts where that run stopped, so
+	 * the loop below reads the rest of the file and nothing else; free_scan_
+	 * ctxt() disposes of the checksum on every path out of here.
+	 */
+	ctxt.file_csum = file->resume_csum;
+	ctxt.extent_csum = file->resume_ext_csum;
+	ctxt.off = file->resume_off;
+	/*
+	 * Non-zero exactly while a checkpoint row exists for this file, so it
+	 * also says whether one has to be retired when the digest lands.
+	 */
+	uint64_t last_checkpoint = ctxt.off;
+	unsigned int checkpoints = 0;
+	/*
+	 * Nothing to resume from without a hashfile - the database dies with
+	 * the process - so don't pay for checkpoints there.
+	 */
+	bool checkpoints_enabled = options.hashfile != NULL;
 
 	/* Used to detected eof if file changed since
 	 * we stat() it
@@ -2359,7 +2691,8 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	}
 
 	ctxt.filesize = file->filesize;
-	ctxt.file_csum = start_running_checksum();
+	if (!ctxt.file_csum)
+		ctxt.file_csum = start_running_checksum();
 	if (!ctxt.file_csum)
 		return;
 
@@ -2377,6 +2710,24 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	ctxt.fiemap = do_fiemap(ctxt.fd);
 	if (!ctxt.fiemap)
 		return;
+
+	/*
+	 * The extent digest carried over from the interrupted run only means
+	 * anything if it is still the same extent. mtime and size are what
+	 * normally stand for "unchanged", and neither has to move when a file is
+	 * defragmented or deduped by something else, so check the one record the
+	 * resume actually depends on. If it moved, the run this checkpoint came
+	 * from was describing a layout that no longer exists: give up on it and
+	 * hash the file from the start (#159).
+	 */
+	if (ctxt.extent_csum && checkpoint_extent_moved(&ctxt, file)) {
+		vprintf("%s: extent layout changed since the checkpoint at "
+			"%"PRIu64" bytes; hashing from the start\n",
+			file->path, (uint64_t)ctxt.off);
+		if (!rewind_to_start(&ctxt, file, tprogress, db))
+			return;
+		last_checkpoint = 0;
+	}
 
 	if (!allocate_hashes(&hashes, &ctxt)) {
 		eprintf("allocate_hashes failed\n");
@@ -2475,6 +2826,35 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		if (eof_reached)
 			/* File may have change */
 			break;
+
+		/*
+		 * Far enough in to be worth protecting. Any offset here can be
+		 * described: ctxt.off is exactly what the file checksum has
+		 * consumed, extents completed before it are staged and ready to
+		 * store, and one still in flight rides along in the checkpoint.
+		 */
+		if (!checkpoints_enabled ||
+		    ctxt.off - last_checkpoint < checkpoint_interval)
+			continue;
+
+		ret = write_checkpoint(&hashes, &ctxt, file->mtime);
+		if (ret) {
+			eprintf("%s: could not checkpoint at %"PRIu64" bytes; "
+				"an interrupted run will rehash it from the "
+				"start.\n", file->path, (uint64_t)ctxt.off);
+			checkpoints_enabled = false;
+			continue;
+		}
+		last_checkpoint = ctxt.off;
+
+		/* Test hook: stand in for the kill this exists to survive. */
+		if (checkpoint_stop_after &&
+		    ++checkpoints >= checkpoint_stop_after) {
+			vprintf("%s: stopping after %u checkpoints at %"PRIu64
+				" bytes (DUPEREMOVE_CHECKPOINT_STOP)\n",
+				file->path, checkpoints, (uint64_t)ctxt.off);
+			return;
+		}
 	}
 
 	/*
@@ -2562,6 +2942,20 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		scan_write_abort();
 		dbfile_unlock();
 		return;
+	}
+
+	/*
+	 * The file is hashed, so there is nothing left to resume: retire the
+	 * checkpoint alongside the digest that supersedes it (#159). Same
+	 * transaction, so the pair a later run reads can never disagree.
+	 */
+	if (last_checkpoint) {
+		ret = dbfile_remove_checkpoint(db, file->fileid);
+		if (ret) {
+			scan_write_abort();
+			dbfile_unlock();
+			return;
+		}
 	}
 
 	ret = scan_write_end();
@@ -2858,6 +3252,8 @@ void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits)
 void filescan_init(void)
 {
 	const char *batch_env = getenv("DUPEREMOVE_BLOCK_BATCH");
+	const char *ckpt_env = getenv("DUPEREMOVE_CHECKPOINT_BYTES");
+	const char *stop_env = getenv("DUPEREMOVE_CHECKPOINT_STOP");
 
 	if (batch_env) {
 		unsigned long v = strtoul(batch_env, NULL, 10);
@@ -2865,6 +3261,16 @@ void filescan_init(void)
 		if (v > 0 && v <= BLOCK_BATCH_MAX)
 			block_batch_max = (unsigned int)v;
 	}
+
+	if (ckpt_env) {
+		unsigned long long v = strtoull(ckpt_env, NULL, 10);
+
+		if (v > 0)
+			checkpoint_interval = v;
+	}
+
+	if (stop_env)
+		checkpoint_stop_after = strtoul(stop_env, NULL, 10);
 
 	abort_on(scan_workq.workers);
 	abort_on(scan_writer_open());

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2502,7 +2502,10 @@ static inline bool is_inlined(struct scan_ctxt *ctxt)
 static void scan_workq_push(struct file_to_scan *file)
 {
 	struct scan_workq *q = &scan_workq;
-	unsigned b = scan_bucket(file->filesize);
+	/* Bucket on the work left, not the file's size: a 53 GiB image resumed
+	 * with 1 GiB to go is a small job, and sorting it as a huge one is
+	 * exactly the straggler the largest-first order exists to avoid. */
+	unsigned b = scan_bucket(file->filesize - file->resume.off);
 
 	file->next = NULL;
 	g_mutex_lock(&q->lock);
@@ -2647,13 +2650,20 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	abort_on(!tprogress);
 	tprogress->status = thread_mapping;	/* open + do_fiemap: no bytes yet */
 	/*
-	 * Resuming, the bytes an earlier run already hashed are not this run's
-	 * work: __scan_file() left them out of the global total, so leave them
-	 * out here too or the file would reconcile against a total it was never
-	 * going to reach.
+	 * A resumed file shows its real size with the bytes an earlier run
+	 * already hashed credited up front, so its line reads "3.9 GiB/18.4 GiB
+	 * (21%)" and carries on from there. Reporting only the remainder made
+	 * the line restart near 0% *and* understate the file - a 18.4 GiB movie
+	 * resumed at 3 GiB displayed as 15.4 GiB - which reads exactly like the
+	 * resume having failed.
+	 *
+	 * The global counters are unaffected: this credit never reaches
+	 * total_scanned_bytes, which accrues only bytes actually read, and
+	 * pscan_finish_file() reconciles against the same real size that
+	 * __scan_file() left out of the run-wide total.
 	 */
-	pscan_set_file(tprogress, file->path,
-		       file->filesize - file->resume.off);
+	pscan_set_file(tprogress, file->path, file->filesize);
+	tprogress->file_scanned_bytes = file->resume.off;
 	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
 
 	/* Dummy variables used to trigger the cleanup code */

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -77,6 +77,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st);
 static bool seen_inode(uint64_t ino, uint64_t subvol);
 static void mark_inode_seen(uint64_t ino, uint64_t subvol);
 static void mark_file_seen(int64_t id);
+static void seed_checkpointed_files(struct dbhandle *db);
 struct buffer;
 static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 			    struct pscan_thread *tprogress);
@@ -509,6 +510,54 @@ static unsigned int nr_roots_seeded;
  * the skip.
  */
 static unsigned int nr_roots_unusable;
+
+/*
+ * The realpath'd roots this run was pointed at, in the order given.
+ *
+ * Only the checkpoint seeder reads them: a hashfile may hold checkpoints for
+ * trees this run was not asked to look at (one hashfile, several roots on
+ * different days), and hashing those would be scanning what the user did not
+ * ask for. The walk does not need this - it only ever descends from a root.
+ *
+ * Built on the main thread by scan_file() before any walker exists, read on the
+ * same thread by the seeder, so no lock.
+ */
+static GPtrArray *scan_root_paths;
+
+static void scan_roots_reset(void)
+{
+	if (scan_root_paths)
+		g_ptr_array_free(scan_root_paths, TRUE);
+	scan_root_paths = g_ptr_array_new_with_free_func(g_free);
+}
+
+static void scan_roots_add(const char *path)
+{
+	if (scan_root_paths)
+		g_ptr_array_add(scan_root_paths, g_strdup(path));
+}
+
+/* True if `path` is one of the roots, or lives underneath one. */
+static bool path_under_a_root(const char *path)
+{
+	if (!scan_root_paths)
+		return false;
+
+	for (guint i = 0; i < scan_root_paths->len; i++) {
+		const char *root = g_ptr_array_index(scan_root_paths, i);
+		size_t len = strlen(root);
+
+		if (strncmp(path, root, len) != 0)
+			continue;
+		/* Either the root itself, or a child of it - never a sibling
+		 * that merely shares a prefix ("/data" vs "/database"). */
+		if (path[len] == '\0' || path[len] == '/' ||
+		    (len == 1 && root[0] == '/'))
+			return true;
+	}
+	return false;
+}
+
 
 unsigned int filescan_roots_unusable(void)
 {
@@ -1432,6 +1481,7 @@ void filescan_walk_begin(void)
 		if (n >= 1)
 			walk_nthreads = (unsigned int)n;
 	}
+	scan_roots_reset();
 	walk_dirq = g_async_queue_new();
 	walk_fileq = g_async_queue_new();
 	walk_dir_pending = 1;	/* seeding token; released by filescan_walk_run() */
@@ -1460,6 +1510,16 @@ int filescan_walk_run(struct dbhandle *db)
 		dbfile_set_cache_kb(wdb, DB_CACHE_KB_WALKER);
 		threads[i] = g_thread_new("walker", walk_thread, wdb);
 	}
+
+	/*
+	 * Only now that every walker has its connection: seeding queues files,
+	 * the csum pool is already running and picks them up at once, and the
+	 * write transaction that follows would block the CREATE TABLE IF NOT
+	 * EXISTS each dbfile_open_handle() above runs. Still before the consume
+	 * loop below, so the seen-sets are set up before the first walked file
+	 * reaches __scan_file() and nothing gets queued twice.
+	 */
+	seed_checkpointed_files(db);
 
 	/*
 	 * Release the seeding token now the roots are queued. If nothing was
@@ -1554,6 +1614,33 @@ static int64_t store_file_row(struct file *dbfile, char *path, bool file_renamed
 }
 
 /*
+ * Per-run scan state, shared by the walk's consumer (__scan_file) and the
+ * checkpoint seeder - both run on the single consumer thread, so neither needs
+ * a lock. `scan_seq` is the dedupe generation this run stamps on everything it
+ * hashes; `scan_position` only ever feeds the progress display.
+ */
+static unsigned int scan_seq, scan_seq_count;
+static uint64_t scan_position;
+
+/*
+ * The dedupe generation for the next file this run hashes. Starts one above the
+ * stored watermark and steps every --batchsize files, so a long scan is broken
+ * into generations the dedupe phase can process incrementally.
+ */
+static unsigned int scan_next_seq(void)
+{
+	if (scan_seq == 0)
+		scan_seq = dedupe_seq + 1;
+
+	if (options.batch_size != 0 &&
+	    ++scan_seq_count >= options.batch_size) {
+		scan_seq++;
+		scan_seq_count = 0;
+	}
+	return scan_seq;
+}
+
+/*
  * Take up hashing a file where an interrupted run left off (#159).
  *
  * True only if there is a checkpoint, it describes the file as it is now, and
@@ -1570,7 +1657,8 @@ static int64_t store_file_row(struct file *dbfile, char *path, bool file_renamed
  * batch cadence (#161), so a run killed between two checkpoints can leave
  * blocks beyond the last one.
  */
-static bool resume_scan(struct dbhandle *db, struct file *dbfile,
+static bool resume_scan(struct dbhandle *db, int64_t fileid, uint64_t size,
+			uint64_t mtime, const char *name,
 			struct scan_resume *resume)
 {
 	size_t cap = running_checksum_state_size();
@@ -1583,11 +1671,11 @@ static bool resume_scan(struct dbhandle *db, struct file *dbfile,
 	if (!file_state || !ext_state)
 		return false;
 
-	if (!dbfile_load_checkpoint(db, dbfile->id, &cp))
+	if (!dbfile_load_checkpoint(db, fileid, &cp))
 		return false;
 
-	if (cp.size == dbfile->size && cp.mtime == dbfile->mtime &&
-	    cp.loff > 0 && cp.loff < dbfile->size) {
+	if (cp.size == size && cp.mtime == mtime &&
+	    cp.loff > 0 && cp.loff < size) {
 		resume->csum = running_checksum_restore(cp.file_state, cap);
 		if (cp.has_ext_state)
 			resume->ext_csum = running_checksum_restore(cp.ext_state,
@@ -1606,15 +1694,15 @@ static bool resume_scan(struct dbhandle *db, struct file *dbfile,
 		return false;
 	}
 	if (usable)
-		dbfile_remove_hashes_from(scan_writer, dbfile->id, cp.loff);
+		dbfile_remove_hashes_from(scan_writer, fileid, cp.loff);
 	else
-		dbfile_remove_checkpoint(scan_writer, dbfile->id);
+		dbfile_remove_checkpoint(scan_writer, fileid);
 	scan_write_end();
 	dbfile_unlock();
 
 	if (!usable) {
 		vprintf("Discarding an unusable checkpoint for %s; hashing it "
-			"from the start\n", dbfile->filename);
+			"from the start\n", name);
 		return false;
 	}
 
@@ -1622,8 +1710,127 @@ static bool resume_scan(struct dbhandle *db, struct file *dbfile,
 	resume->ext_loff = cp.ext_loff;
 	resume->ext_len = cp.ext_len;
 	vprintf("Resuming %s at %"PRIu64" of %"PRIu64" bytes\n",
-		dbfile->filename, cp.loff, (uint64_t)dbfile->size);
+		name, cp.loff, size);
 	return true;
+}
+
+/*
+ * Hand a file to the hashing pool. Takes over `resume` (zeroed for the ordinary
+ * case of hashing from the start); the worker frees the request when done.
+ */
+static void queue_file_for_scan(const char *path, int64_t fileid,
+				uint64_t filesize, uint64_t mtime,
+				struct scan_resume *resume)
+{
+	struct file_to_scan *file = malloc(sizeof(*file));
+
+	abort_on(!file);
+	file->path = strdup(path);
+	abort_on(!file->path);
+	file->fileid = fileid;
+	file->filesize = filesize;
+	file->mtime = mtime;
+	file->resume = *resume;
+	resume->csum = resume->ext_csum = NULL;	/* the request owns them now */
+	file->file_position = ++scan_position;
+	file->next = NULL;
+
+	/* Only the bytes still to be read are this run's work. */
+	pscan_set_progress(1, filesize - file->resume.off);
+	scan_workq_push(file);
+}
+
+/*
+ * Hand every file a checkpoint is waiting on straight to the hashing pool,
+ * before the walk starts (#159).
+ *
+ * The walk would find them eventually, but "eventually" on a tree of millions
+ * of files is minutes - and a 53 GiB image that is already 90% hashed is the
+ * one file most worth finishing, both because it is nearly done and because
+ * every minute it waits is another minute an interruption costs its tail. The
+ * largest-first queue cannot help: it only orders what has been discovered.
+ *
+ * A checkpoint is only honoured for a file under one of this run's roots and
+ * acceptable to check_file() - the hashfile may describe trees this run was not
+ * asked about, and hashing those would be doing work the user did not request.
+ * Anything skipped here is simply left for the walk, which applies the same
+ * rules; nothing is lost by declining.
+ *
+ * Runs on the consumer thread with no walker alive, so the seen-sets and the
+ * generation counter are unsynchronised exactly as they are during the walk.
+ */
+static void seed_checkpointed_files(struct dbhandle *db)
+{
+	struct checkpointed_file *cps;
+	unsigned int n, seeded = 0;
+
+	/* No hashfile, no checkpoints. */
+	if (!options.hashfile)
+		return;
+	if (dbfile_load_checkpointed_files(db, &cps, &n))
+		return;
+
+	for (unsigned int i = 0; i < n; i++) {
+		struct checkpointed_file *cp = &cps[i];
+		struct scan_resume resume = {0,};
+		struct statx st;
+
+		if (!path_under_a_root(cp->filename))
+			continue;
+		/* longpath-ok: seeding is only a shortcut, so declining is
+		 * always safe - a path over PATH_MAX fails here and is left to
+		 * the walk, which reaches it from a directory fd (#117). */
+		if (statx(AT_FDCWD, cp->filename, 0, STATX_BASIC_STATS, &st) ||
+		    !(st.stx_mask & STATX_BASIC_STATS) ||
+		    !S_ISREG(st.stx_mode))
+			continue;
+		/* parent_checked: a root that failed to lock has already been
+		 * reported, and a file here is never a top-level seed. */
+		if (!check_file(db, cp->filename, &st, true))
+			continue;
+		/* Changed since the checkpoint - let the walk rescan it whole,
+		 * which also clears the stale checkpoint. */
+		if (st.stx_size != cp->size ||
+		    timestamp_to_nano(st.stx_mtime) != cp->mtime)
+			continue;
+
+		if (!resume_scan(db, cp->id, cp->size, cp->mtime,
+				 cp->filename, &resume))
+			continue;
+
+		dbfile_lock();
+		if (scan_write_begin() == 0) {
+			dbfile_update_dedupe_seq(scan_writer, cp->id,
+						 scan_next_seq());
+			scan_write_end();
+		}
+		dbfile_unlock();
+
+		/* The walk will meet this file too; both marks make it skip
+		 * over rather than queue it a second time. */
+		mark_file_seen(cp->id);
+		mark_inode_seen(cp->ino, cp->subvol);
+
+		queue_file_for_scan(cp->filename, cp->id, cp->size, cp->mtime,
+				    &resume);
+		seeded++;
+	}
+
+	/*
+	 * Commit before returning: the walkers are about to open their own
+	 * connections, and every open runs CREATE TABLE IF NOT EXISTS, which
+	 * wants the write lock this batch would otherwise still be holding.
+	 * Ordinary per-file writes never hit this because the walkers are
+	 * already connected by the time the first one happens.
+	 */
+	dbfile_lock();
+	scan_write_flush();
+	dbfile_unlock();
+
+	if (seeded)
+		vprintf("Resuming %u partially hashed file%s before the walk\n",
+			seeded, seeded == 1 ? "" : "s");
+	dbfile_free_checkpointed_files(cps, n);
 }
 
 /*
@@ -1636,20 +1843,9 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 {
 	int ret;
 	_cleanup_(file_cleanup) struct file dbfile = {0,};
-	static unsigned int seq = 0, counter = 0;
-	struct file_to_scan *file;
 	int64_t fileid = 0;
 	bool file_renamed, unchanged, resumed = false;
 	struct scan_resume resume = {0,};
-	static uint64_t position = 0;
-
-	/*
-	 * The first call initializes the static variable
-	 * from the global dedupe_seq
-	 * The subsequents calls will increase it every <batchsize> times
-	 */
-	if (seq == 0)
-		seq = dedupe_seq + 1;
 
 	abort_on(!S_ISREG(st->stx_mode));
 
@@ -1711,13 +1907,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		return 0;
 	}
 
-	if (options.batch_size != 0) {
-		counter += 1;
-		if (counter >= options.batch_size) {
-			seq++;
-			counter = 0;
-		}
-	}
+	unsigned int seq = scan_next_seq();
 
 	dbfile.ino = st->stx_ino;
 	dbfile.size = st->stx_size;
@@ -1737,7 +1927,8 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	 * checkpoint and the hashes already stored straight back out.
 	 */
 	if (dbfile.id && unchanged && !dbfile.digest_valid && !file_renamed)
-		resumed = resume_scan(db, &dbfile, &resume);
+		resumed = resume_scan(db, dbfile.id, dbfile.size,
+				      dbfile.mtime, dbfile.filename, &resume);
 
 	/*
 	 * Resuming keeps the existing row - replacing it would cascade away the
@@ -1766,22 +1957,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	/* Remember this inode so later hardlinks to it are skipped. */
 	mark_inode_seen(dbfile.ino, dbfile.subvol);
 
-	/* Schedule the file for scan */
-	file = malloc(sizeof(struct file_to_scan)); /* Freed by csum_whole_file() */
-
-	file->path = strdup(path);
-	file->fileid = fileid;
-	file->filesize = st->stx_size;
-	file->mtime = dbfile.mtime;
-	file->resume = resume;		/* zeroed unless we are resuming */
-
-	/* Only the bytes still to be read are this run's work. */
-	pscan_set_progress(1, st->stx_size - resume.off);
-	position++;
-	file->file_position = position;
-
-	scan_workq_push(file);
-
+	queue_file_for_scan(path, fileid, st->stx_size, dbfile.mtime, &resume);
 	return 0;
 }
 
@@ -1860,6 +2036,7 @@ int scan_file(char *in_path, struct dbhandle *db)
 	if (!check_file(db, path, &st, false))
 		return 0;
 
+	scan_roots_add(path);
 	if (S_ISREG(st.stx_mode))
 		fileq_push(path, &st);
 	else

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -524,25 +524,9 @@ static unsigned int nr_roots_unusable;
  */
 static GPtrArray *scan_root_paths;
 
-static void scan_roots_reset(void)
-{
-	if (scan_root_paths)
-		g_ptr_array_free(scan_root_paths, TRUE);
-	scan_root_paths = g_ptr_array_new_with_free_func(g_free);
-}
-
-static void scan_roots_add(const char *path)
-{
-	if (scan_root_paths)
-		g_ptr_array_add(scan_root_paths, g_strdup(path));
-}
-
 /* True if `path` is one of the roots, or lives underneath one. */
 static bool path_under_a_root(const char *path)
 {
-	if (!scan_root_paths)
-		return false;
-
 	for (guint i = 0; i < scan_root_paths->len; i++) {
 		const char *root = g_ptr_array_index(scan_root_paths, i);
 		size_t len = strlen(root);
@@ -1481,7 +1465,9 @@ void filescan_walk_begin(void)
 		if (n >= 1)
 			walk_nthreads = (unsigned int)n;
 	}
-	scan_roots_reset();
+	if (scan_root_paths)
+		g_ptr_array_free(scan_root_paths, TRUE);
+	scan_root_paths = g_ptr_array_new_with_free_func(g_free);
 	walk_dirq = g_async_queue_new();
 	walk_fileq = g_async_queue_new();
 	walk_dir_pending = 1;	/* seeding token; released by filescan_walk_run() */
@@ -1501,6 +1487,9 @@ int filescan_walk_run(struct dbhandle *db)
 
 	abort_on(!threads);
 
+	/* Ahead of the walkers, so these sit at the head of the file queue. */
+	seed_checkpointed_files(db);
+
 	for (i = 0; i < walk_nthreads; i++) {
 		struct dbhandle *wdb = dbfile_open_handle(options.hashfile);
 
@@ -1510,16 +1499,6 @@ int filescan_walk_run(struct dbhandle *db)
 		dbfile_set_cache_kb(wdb, DB_CACHE_KB_WALKER);
 		threads[i] = g_thread_new("walker", walk_thread, wdb);
 	}
-
-	/*
-	 * Only now that every walker has its connection: seeding queues files,
-	 * the csum pool is already running and picks them up at once, and the
-	 * write transaction that follows would block the CREATE TABLE IF NOT
-	 * EXISTS each dbfile_open_handle() above runs. Still before the consume
-	 * loop below, so the seen-sets are set up before the first walked file
-	 * reaches __scan_file() and nothing gets queued twice.
-	 */
-	seed_checkpointed_files(db);
 
 	/*
 	 * Release the seeding token now the roots are queued. If nothing was
@@ -1614,30 +1593,24 @@ static int64_t store_file_row(struct file *dbfile, char *path, bool file_renamed
 }
 
 /*
- * Per-run scan state, shared by the walk's consumer (__scan_file) and the
- * checkpoint seeder - both run on the single consumer thread, so neither needs
- * a lock. `scan_seq` is the dedupe generation this run stamps on everything it
- * hashes; `scan_position` only ever feeds the progress display.
- */
-static unsigned int scan_seq, scan_seq_count;
-static uint64_t scan_position;
-
-/*
  * The dedupe generation for the next file this run hashes. Starts one above the
  * stored watermark and steps every --batchsize files, so a long scan is broken
  * into generations the dedupe phase can process incrementally.
+ *
+ * Consumer thread only, hence the bare statics.
  */
 static unsigned int scan_next_seq(void)
 {
-	if (scan_seq == 0)
-		scan_seq = dedupe_seq + 1;
+	static unsigned int seq, counter;
 
-	if (options.batch_size != 0 &&
-	    ++scan_seq_count >= options.batch_size) {
-		scan_seq++;
-		scan_seq_count = 0;
+	if (seq == 0)
+		seq = dedupe_seq + 1;
+
+	if (options.batch_size != 0 && ++counter >= options.batch_size) {
+		seq++;
+		counter = 0;
 	}
-	return scan_seq;
+	return seq;
 }
 
 /*
@@ -1714,6 +1687,12 @@ static bool resume_scan(struct dbhandle *db, int64_t fileid, uint64_t size,
 	return true;
 }
 
+/* Where hashing of this file begins: 0 unless an earlier run got partway. */
+static uint64_t file_resume_off(const struct file_to_scan *file)
+{
+	return file->resume ? file->resume->off : 0;
+}
+
 /*
  * Hand a file to the hashing pool. Takes over `resume` (zeroed for the ordinary
  * case of hashing from the start); the worker frees the request when done.
@@ -1722,6 +1701,7 @@ static void queue_file_for_scan(const char *path, int64_t fileid,
 				uint64_t filesize, uint64_t mtime,
 				struct scan_resume *resume)
 {
+	static uint64_t position;	/* consumer thread only */
 	struct file_to_scan *file = malloc(sizeof(*file));
 
 	abort_on(!file);
@@ -1730,107 +1710,80 @@ static void queue_file_for_scan(const char *path, int64_t fileid,
 	file->fileid = fileid;
 	file->filesize = filesize;
 	file->mtime = mtime;
-	file->resume = *resume;
-	resume->csum = resume->ext_csum = NULL;	/* the request owns them now */
-	file->file_position = ++scan_position;
+	if (resume->csum) {
+		file->resume = malloc(sizeof(*file->resume));
+		abort_on(!file->resume);
+		*file->resume = *resume;
+		resume->csum = resume->ext_csum = NULL;	/* the request owns them */
+	} else {
+		file->resume = NULL;
+	}
+	file->file_position = ++position;
 	file->next = NULL;
 
 	/* Only the bytes still to be read are this run's work. */
-	pscan_set_progress(1, filesize - file->resume.off);
+	pscan_set_progress(1, filesize - file_resume_off(file));
 	scan_workq_push(file);
 }
 
 /*
- * Hand every file a checkpoint is waiting on straight to the hashing pool,
- * before the walk starts (#159).
+ * Queue every file a checkpoint is waiting on, ahead of the walk (#159).
  *
  * The walk would find them eventually, but "eventually" on a tree of millions
  * of files is minutes - and a 53 GiB image that is already 90% hashed is the
  * one file most worth finishing, both because it is nearly done and because
  * every minute it waits is another minute an interruption costs its tail. The
- * largest-first queue cannot help: it only orders what has been discovered.
+ * largest-first csum queue cannot help: it only orders what has been found.
  *
- * A checkpoint is only honoured for a file under one of this run's roots and
- * acceptable to check_file() - the hashfile may describe trees this run was not
- * asked about, and hashing those would be doing work the user did not request.
- * Anything skipped here is simply left for the walk, which applies the same
- * rules; nothing is lost by declining.
+ * These go onto the same file queue the walkers feed, so __scan_file() does all
+ * the deciding as usual - staleness, resume, generation, hardlinks. Being at
+ * the head of a FIFO nothing else has pushed to yet is the entire mechanism.
+ * The walk will meet these files again later and skip them, because by then
+ * __scan_file() has recorded their inodes (see seen_inode).
  *
- * Runs on the consumer thread with no walker alive, so the seen-sets and the
- * generation counter are unsynchronised exactly as they are during the walk.
+ * A checkpoint is only honoured for a file under one of this run's roots: the
+ * hashfile may describe trees this run was not asked about, and hashing those
+ * would be doing work the user did not request. Anything declined is simply
+ * left to the walk, which applies the same rules.
  */
 static void seed_checkpointed_files(struct dbhandle *db)
 {
-	struct checkpointed_file *cps;
-	unsigned int n, seeded = 0;
+	char **paths;
+	int n, seeded = 0;
 
 	/* No hashfile, no checkpoints. */
 	if (!options.hashfile)
 		return;
-	if (dbfile_load_checkpointed_files(db, &cps, &n))
+	if (dbfile_load_checkpointed_paths(db, &paths, &n))
 		return;
 
-	for (unsigned int i = 0; i < n; i++) {
-		struct checkpointed_file *cp = &cps[i];
-		struct scan_resume resume = {0,};
+	for (int i = 0; i < n; i++) {
 		struct statx st;
 
-		if (!path_under_a_root(cp->filename))
+		if (!path_under_a_root(paths[i]))
 			continue;
 		/* longpath-ok: seeding is only a shortcut, so declining is
 		 * always safe - a path over PATH_MAX fails here and is left to
 		 * the walk, which reaches it from a directory fd (#117). */
-		if (statx(AT_FDCWD, cp->filename, 0, STATX_BASIC_STATS, &st) ||
-		    !(st.stx_mask & STATX_BASIC_STATS) ||
-		    !S_ISREG(st.stx_mode))
+		if (statx(AT_FDCWD, paths[i], 0, STATX_BASIC_STATS, &st) ||
+		    !(st.stx_mask & STATX_BASIC_STATS) || !S_ISREG(st.stx_mode))
 			continue;
-		/* parent_checked: a root that failed to lock has already been
-		 * reported, and a file here is never a top-level seed. */
-		if (!check_file(db, cp->filename, &st, true))
-			continue;
-		/* Changed since the checkpoint - let the walk rescan it whole,
-		 * which also clears the stale checkpoint. */
-		if (st.stx_size != cp->size ||
-		    timestamp_to_nano(st.stx_mtime) != cp->mtime)
+		/* parent_checked: this is not a top-level seed, so a rejection
+		 * must not count as a root that failed to lock. */
+		if (!check_file(db, paths[i], &st, true))
 			continue;
 
-		if (!resume_scan(db, cp->id, cp->size, cp->mtime,
-				 cp->filename, &resume))
-			continue;
-
-		dbfile_lock();
-		if (scan_write_begin() == 0) {
-			dbfile_update_dedupe_seq(scan_writer, cp->id,
-						 scan_next_seq());
-			scan_write_end();
-		}
-		dbfile_unlock();
-
-		/* The walk will meet this file too; both marks make it skip
-		 * over rather than queue it a second time. */
-		mark_file_seen(cp->id);
-		mark_inode_seen(cp->ino, cp->subvol);
-
-		queue_file_for_scan(cp->filename, cp->id, cp->size, cp->mtime,
-				    &resume);
+		fileq_push(paths[i], &st);
 		seeded++;
 	}
 
-	/*
-	 * Commit before returning: the walkers are about to open their own
-	 * connections, and every open runs CREATE TABLE IF NOT EXISTS, which
-	 * wants the write lock this batch would otherwise still be holding.
-	 * Ordinary per-file writes never hit this because the walkers are
-	 * already connected by the time the first one happens.
-	 */
-	dbfile_lock();
-	scan_write_flush();
-	dbfile_unlock();
-
 	if (seeded)
-		vprintf("Resuming %u partially hashed file%s before the walk\n",
+		vprintf("Resuming %d partially hashed file%s before the walk\n",
 			seeded, seeded == 1 ? "" : "s");
-	dbfile_free_checkpointed_files(cps, n);
+
+	for (int i = 0; i < n; i++)
+		free(paths[i]);
+	free(paths);
 }
 
 /*
@@ -2036,7 +1989,7 @@ int scan_file(char *in_path, struct dbhandle *db)
 	if (!check_file(db, path, &st, false))
 		return 0;
 
-	scan_roots_add(path);
+	g_ptr_array_add(scan_root_paths, g_strdup(path));
 	if (S_ISREG(st.stx_mode))
 		fileq_push(path, &st);
 	else
@@ -2230,7 +2183,10 @@ static void free_file_to_scan(struct file_to_scan **filep)
 
 	if (!file)
 		return;
-	scan_resume_drop(&file->resume);
+	if (file->resume) {
+		scan_resume_drop(file->resume);
+		free(file->resume);
+	}
 	free(file);
 }
 
@@ -2251,7 +2207,7 @@ static void free_file_to_scan(struct file_to_scan **filep)
 static bool adopt_resume(struct scan_ctxt *ctxt, struct file_to_scan *file,
 			 struct pscan_thread *tprogress, struct dbhandle *db)
 {
-	struct scan_resume *r = &file->resume;
+	struct scan_resume *r = file->resume;
 	struct fiemap_extent *e;
 
 	if (r->ext_csum) {
@@ -2265,8 +2221,9 @@ static bool adopt_resume(struct scan_ctxt *ctxt, struct file_to_scan *file,
 			ctxt->extent_cursor = 0;
 
 			/* The skipped bytes are back on the bill, here and in
-			 * the run-wide total __scan_file() sized without them. */
-			pscan_set_file(tprogress, file->path, ctxt->filesize);
+			 * the run-wide total __scan_file() sized without them.
+			 * The row's path and size are already right. */
+			tprogress->file_scanned_bytes = 0;
 			pscan_set_progress(0, r->off);
 			r->off = 0;
 
@@ -2682,7 +2639,7 @@ static void scan_workq_push(struct file_to_scan *file)
 	/* Bucket on the work left, not the file's size: a 53 GiB image resumed
 	 * with 1 GiB to go is a small job, and sorting it as a huge one is
 	 * exactly the straggler the largest-first order exists to avoid. */
-	unsigned b = scan_bucket(file->filesize - file->resume.off);
+	unsigned b = scan_bucket(file->filesize - file_resume_off(file));
 
 	file->next = NULL;
 	g_mutex_lock(&q->lock);
@@ -2840,7 +2797,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * __scan_file() left out of the run-wide total.
 	 */
 	pscan_set_file(tprogress, file->path, file->filesize);
-	tprogress->file_scanned_bytes = file->resume.off;
+	tprogress->file_scanned_bytes = file_resume_off(file);
 	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
 
 	/* Dummy variables used to trigger the cleanup code */
@@ -2853,7 +2810,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * resume itself is only taken over once the fiemap can vouch for it,
 	 * below; until then this is a from-scratch scan.
 	 */
-	uint64_t last_checkpoint = file->resume.off;
+	uint64_t last_checkpoint = file_resume_off(file);
 	unsigned int checkpoints = 0;
 	/*
 	 * Nothing to resume from without a hashfile - the database dies with
@@ -2913,7 +2870,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		return;
 
 	/* Take over the interrupted run's state, if the layout still backs it. */
-	if (file->resume.csum &&
+	if (file->resume &&
 	    !adopt_resume(&ctxt, file, tprogress, db))
 		last_checkpoint = 0;	/* declined, and the row is already gone */
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1503,28 +1503,13 @@ static inline bool is_file_renamed(char *path_in_db, char *path)
 	return longpath_lstat(path_in_db, &st);
 }
 
-/*
- * Take up hashing a file where an interrupted run left off (#159).
- *
- * True only if there is a checkpoint, it describes the file as it is now, and
- * this binary can read the checksum state in it - so the caller gets either a
- * usable resume point or the ordinary "hash it from the start" path, never a
- * half-adopted one. Anything unusable is deleted on the way out: it describes a
- * file that has since changed, or a running checksum from an xxhash this binary
- * is not linked against, and either way it will never become valid again.
- *
- * Hashes at or past the resume point go too. There should be none - extent rows
- * are only written by a checkpoint - but block rows flush on their own batch
- * cadence (#161), so a run killed between the last checkpoint and the next can
- * leave blocks beyond it, and those are about to be hashed again.
- */
-static void drop_resume_csums(struct file_to_scan *resume)
+void scan_resume_drop(struct scan_resume *resume)
 {
-	if (resume->resume_csum)
-		finish_running_checksum(resume->resume_csum, NULL);
-	if (resume->resume_ext_csum)
-		finish_running_checksum(resume->resume_ext_csum, NULL);
-	resume->resume_csum = resume->resume_ext_csum = NULL;
+	if (resume->csum)
+		finish_running_checksum(resume->csum, NULL);
+	if (resume->ext_csum)
+		finish_running_checksum(resume->ext_csum, NULL);
+	resume->csum = resume->ext_csum = NULL;
 }
 
 /*
@@ -1568,57 +1553,74 @@ static int64_t store_file_row(struct file *dbfile, char *path, bool file_renamed
 	return fileid;
 }
 
+/*
+ * Take up hashing a file where an interrupted run left off (#159).
+ *
+ * True only if there is a checkpoint, it describes the file as it is now, and
+ * this binary can read both checksum states in it - so the caller gets either a
+ * usable resume point or the ordinary "hash it from the start" path, never a
+ * half-adopted one.
+ *
+ * A checkpoint that fails any of that is deleted rather than left to be
+ * re-examined: it describes a file that has since changed, or a running
+ * checksum from an xxhash this binary is not linked against, and neither will
+ * become valid again. A usable one instead drops the hashes at or past its
+ * offset, which are about to be recomputed. There should be none - extent rows
+ * are only ever written by a checkpoint - but block rows flush on their own
+ * batch cadence (#161), so a run killed between two checkpoints can leave
+ * blocks beyond the last one.
+ */
 static bool resume_scan(struct dbhandle *db, struct file *dbfile,
-			struct file_to_scan *resume)
+			struct scan_resume *resume)
 {
 	size_t cap = running_checksum_state_size();
 	_cleanup_(freep) void *file_state = malloc(cap);
 	_cleanup_(freep) void *ext_state = malloc(cap);
 	struct scan_checkpoint cp = { .file_state = file_state,
 				      .ext_state = ext_state };
+	bool usable = false;
 
 	if (!file_state || !ext_state)
 		return false;
 
-	if (!dbfile_load_checkpoint(db, dbfile->id, &cp, cap))
+	if (!dbfile_load_checkpoint(db, dbfile->id, &cp))
 		return false;
 
 	if (cp.size == dbfile->size && cp.mtime == dbfile->mtime &&
 	    cp.loff > 0 && cp.loff < dbfile->size) {
-		resume->resume_csum = running_checksum_restore(cp.file_state,
-							       cp.file_state_len);
-		if (cp.ext_state_len)
-			resume->resume_ext_csum =
-				running_checksum_restore(cp.ext_state,
-							 cp.ext_state_len);
+		resume->csum = running_checksum_restore(cp.file_state, cap);
+		if (cp.has_ext_state)
+			resume->ext_csum = running_checksum_restore(cp.ext_state,
+								    cap);
 		/* Both or neither: half a checkpoint is no checkpoint. */
-		if (!resume->resume_csum ||
-		    (cp.ext_state_len && !resume->resume_ext_csum))
-			drop_resume_csums(resume);
+		usable = resume->csum &&
+			 (!cp.has_ext_state || resume->ext_csum);
+		if (!usable)
+			scan_resume_drop(resume);
 	}
 
 	dbfile_lock();
 	if (scan_write_begin() != 0) {
 		dbfile_unlock();
-		drop_resume_csums(resume);
+		scan_resume_drop(resume);
 		return false;
 	}
-	if (resume->resume_csum)
+	if (usable)
 		dbfile_remove_hashes_from(scan_writer, dbfile->id, cp.loff);
 	else
 		dbfile_remove_checkpoint(scan_writer, dbfile->id);
 	scan_write_end();
 	dbfile_unlock();
 
-	if (!resume->resume_csum) {
+	if (!usable) {
 		vprintf("Discarding an unusable checkpoint for %s; hashing it "
 			"from the start\n", dbfile->filename);
 		return false;
 	}
 
-	resume->resume_off = cp.loff;
-	resume->resume_ext_loff = cp.ext_loff;
-	resume->resume_ext_len = cp.ext_len;
+	resume->off = cp.loff;
+	resume->ext_loff = cp.ext_loff;
+	resume->ext_len = cp.ext_len;
 	vprintf("Resuming %s at %"PRIu64" of %"PRIu64" bytes\n",
 		dbfile->filename, cp.loff, (uint64_t)dbfile->size);
 	return true;
@@ -1638,7 +1640,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	struct file_to_scan *file;
 	int64_t fileid = 0;
 	bool file_renamed, unchanged, resumed = false;
-	struct file_to_scan resume = {0,};
+	struct scan_resume resume = {0,};
 	static uint64_t position = 0;
 
 	/*
@@ -1734,7 +1736,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	 * itself stays exactly as it was, since rewriting it would cascade the
 	 * checkpoint and the hashes already stored straight back out.
 	 */
-	if (unchanged && !dbfile.digest_valid && !file_renamed)
+	if (dbfile.id && unchanged && !dbfile.digest_valid && !file_renamed)
 		resumed = resume_scan(db, &dbfile, &resume);
 
 	/*
@@ -1755,8 +1757,10 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	} else {
 		fileid = store_file_row(&dbfile, path, file_renamed);
 	}
-	if (!fileid)
+	if (!fileid) {
+		scan_resume_drop(&resume);
 		return 0;
+	}
 	mark_file_seen(fileid);		/* on disk: the prune can skip it */
 
 	/* Remember this inode so later hardlinks to it are skipped. */
@@ -1765,14 +1769,14 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	/* Schedule the file for scan */
 	file = malloc(sizeof(struct file_to_scan)); /* Freed by csum_whole_file() */
 
-	*file = resume;			/* zeroed unless we are resuming */
 	file->path = strdup(path);
 	file->fileid = fileid;
 	file->filesize = st->stx_size;
 	file->mtime = dbfile.mtime;
+	file->resume = resume;		/* zeroed unless we are resuming */
 
 	/* Only the bytes still to be read are this run's work. */
-	pscan_set_progress(1, st->stx_size - file->resume_off);
+	pscan_set_progress(1, st->stx_size - resume.off);
 	position++;
 	file->file_position = position;
 
@@ -1903,6 +1907,40 @@ static int ensure_hash_capacity(void **arr, unsigned int *count,
  * bracket as everything else on the scan path, so the rows join the current
  * transaction rather than forcing a commit of their own.
  */
+static int store_block_batch(struct hashes *hashes)
+{
+	int ret;
+
+	if (!hashes->blocks_index)
+		return 0;
+
+	ret = dbfile_store_block_hashes(hashes->db, hashes->fileid,
+					hashes->blocks_index, hashes->blocks);
+	if (ret)
+		return ret;
+
+	hashes->blocks_flushed += hashes->blocks_index;
+	hashes->blocks_index = 0;
+	return 0;
+}
+
+/* The same, for the extent digests staged so far. */
+static int store_extent_batch(struct hashes *hashes)
+{
+	int ret;
+
+	if (!hashes->extents_index)
+		return 0;
+
+	ret = dbfile_store_extent_hashes(hashes->db, hashes->fileid,
+					 hashes->extents_index, hashes->extents);
+	if (ret)
+		return ret;
+
+	hashes->extents_index = 0;
+	return 0;
+}
+
 static int flush_block_hashes(struct hashes *hashes)
 {
 	int ret;
@@ -1917,41 +1955,14 @@ static int flush_block_hashes(struct hashes *hashes)
 		return ret;
 	}
 
-	ret = dbfile_store_block_hashes(hashes->db, hashes->fileid,
-					hashes->blocks_index, hashes->blocks);
+	ret = store_block_batch(hashes);
 	if (ret)
 		scan_write_abort();
 	else
 		ret = scan_write_end();
 	dbfile_unlock();
 
-	if (ret)
-		return ret;
-
-	hashes->blocks_flushed += hashes->blocks_index;
-	hashes->blocks_index = 0;
-	return 0;
-}
-
-/*
- * Write the extent digests gathered so far and reset the batch. The mirror of
- * flush_block_hashes(); only a checkpoint calls it mid-file, so unlike the
- * blocks there is never an extent row past the last checkpoint.
- */
-static int flush_extent_hashes(struct hashes *hashes)
-{
-	int ret;
-
-	if (!hashes->extents_index)
-		return 0;
-
-	ret = dbfile_store_extent_hashes(hashes->db, hashes->fileid,
-					 hashes->extents_index, hashes->extents);
-	if (ret)
-		return ret;
-
-	hashes->extents_index = 0;
-	return 0;
+	return ret;
 }
 
 /*
@@ -1979,7 +1990,6 @@ static int write_checkpoint(struct hashes *hashes, struct scan_ctxt *ctxt,
 		.size		= ctxt->filesize,
 		.mtime		= mtime,
 		.file_state	= file_state,
-		.file_state_len	= len,
 		.ext_state	= ext_state,
 	};
 
@@ -2008,7 +2018,7 @@ static int write_checkpoint(struct hashes *hashes, struct scan_ctxt *ctxt,
 			return ret;
 		cp.ext_loff = e->fe_logical;
 		cp.ext_len = e->fe_length;
-		cp.ext_state_len = len;
+		cp.has_ext_state = true;
 	}
 
 	dbfile_lock();
@@ -2018,16 +2028,9 @@ static int write_checkpoint(struct hashes *hashes, struct scan_ctxt *ctxt,
 		return ret;
 	}
 
-	ret = flush_extent_hashes(hashes);
-	if (!ret && hashes->blocks_index) {
-		ret = dbfile_store_block_hashes(hashes->db, hashes->fileid,
-						hashes->blocks_index,
-						hashes->blocks);
-		if (!ret) {
-			hashes->blocks_flushed += hashes->blocks_index;
-			hashes->blocks_index = 0;
-		}
-	}
+	ret = store_extent_batch(hashes);
+	if (!ret)
+		ret = store_block_batch(hashes);
 	if (!ret)
 		ret = dbfile_store_checkpoint(hashes->db, hashes->fileid, &cp);
 	if (ret)
@@ -2040,55 +2043,73 @@ static int write_checkpoint(struct hashes *hashes, struct scan_ctxt *ctxt,
 }
 
 /*
- * True if the extent a resumed checkpoint left half-hashed is not where it was.
- *
- * The digest carried over covers part of one specific extent, so it means
- * nothing if that extent has been rewritten. mtime and size - what normally
- * stands for "unchanged" - need not move when a file is defragmented or deduped
- * by something else, so the record the resume depends on is checked directly.
+ * Release a queued file. Its resume checksums are dropped too: they belong to
+ * the file_to_scan until adopt_resume() hands them to the scan context, and
+ * every early return before that point comes through here.
  */
-static bool checkpoint_extent_moved(struct scan_ctxt *ctxt,
-				    struct file_to_scan *file)
+static void free_file_to_scan(struct file_to_scan **filep)
 {
-	struct fiemap_extent *e = get_extent(ctxt->fiemap, ctxt->off,
-					     &ctxt->extent_cursor);
+	struct file_to_scan *file = *filep;
 
-	return !e || e->fe_logical != file->resume_ext_loff ||
-	       e->fe_length != file->resume_ext_len;
+	if (!file)
+		return;
+	scan_resume_drop(&file->resume);
+	free(file);
 }
 
 /*
- * Give up on a resume and hash the file from byte zero. Everything stored for
- * it describes a layout that is no longer there, so none of it may survive -
- * including the checkpoint itself, which is now describing nothing.
+ * Adopt what an interrupted run left behind, now that the fiemap is in hand.
  *
- * False only if a fresh checksum could not be allocated, i.e. the file cannot
- * be hashed at all.
+ * The carried extent digest covers part of one specific extent, so it means
+ * nothing if that extent has been rewritten - and mtime and size, what normally
+ * stands for "unchanged", need not move when a file is defragmented or deduped
+ * by something else. So the one record the resume depends on is checked
+ * directly, and if it moved the whole checkpoint is describing a layout that no
+ * longer exists (#159).
+ *
+ * Nothing is taken over until that check passes, so declining costs no unwind:
+ * the context is still the from-scratch one. Everything stored for the file
+ * goes, though, including the checkpoint itself.
  */
-static bool rewind_to_start(struct scan_ctxt *ctxt, struct file_to_scan *file,
-			    struct pscan_thread *tprogress, struct dbhandle *db)
+static bool adopt_resume(struct scan_ctxt *ctxt, struct file_to_scan *file,
+			 struct pscan_thread *tprogress, struct dbhandle *db)
 {
-	finish_running_checksum(ctxt->extent_csum, NULL);
-	ctxt->extent_csum = NULL;
-	finish_running_checksum(ctxt->file_csum, NULL);
-	ctxt->file_csum = start_running_checksum();
-	if (!ctxt->file_csum)
-		return false;
-	ctxt->off = 0;
-	ctxt->extent_cursor = 0;
+	struct scan_resume *r = &file->resume;
+	struct fiemap_extent *e;
 
-	/* The skipped bytes are back on the bill, here and in the run-wide
-	 * total __scan_file() sized without them. */
-	pscan_set_file(tprogress, file->path, ctxt->filesize);
-	pscan_set_progress(0, file->resume_off);
+	if (r->ext_csum) {
+		e = get_extent(ctxt->fiemap, r->off, &ctxt->extent_cursor);
+		if (!e || e->fe_logical != r->ext_loff ||
+		    e->fe_length != r->ext_len) {
+			vprintf("%s: extent layout changed since the checkpoint "
+				"at %"PRIu64" bytes; hashing from the start\n",
+				file->path, r->off);
+			scan_resume_drop(r);
+			ctxt->extent_cursor = 0;
 
-	dbfile_lock();
-	if (scan_write_begin() == 0) {
-		dbfile_remove_hashes(db, file->fileid);
-		dbfile_remove_checkpoint(db, file->fileid);
-		scan_write_end();
+			/* The skipped bytes are back on the bill, here and in
+			 * the run-wide total __scan_file() sized without them. */
+			pscan_set_file(tprogress, file->path, ctxt->filesize);
+			pscan_set_progress(0, r->off);
+			r->off = 0;
+
+			dbfile_lock();
+			if (scan_write_begin() == 0) {
+				dbfile_remove_hashes(db, file->fileid);
+				dbfile_remove_checkpoint(db, file->fileid);
+				scan_write_end();
+			}
+			dbfile_unlock();
+			return false;
+		}
 	}
-	dbfile_unlock();
+
+	/* free_scan_ctxt() owns the checksums from here on. */
+	finish_running_checksum(ctxt->file_csum, NULL);
+	ctxt->file_csum = r->csum;
+	ctxt->extent_csum = r->ext_csum;
+	ctxt->off = r->off;
+	r->csum = r->ext_csum = NULL;
 	return true;
 }
 
@@ -2631,27 +2652,21 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * out here too or the file would reconcile against a total it was never
 	 * going to reach.
 	 */
-	pscan_set_file(tprogress, file->path, file->filesize - file->resume_off);
+	pscan_set_file(tprogress, file->path,
+		       file->filesize - file->resume.off);
 	_cleanup_(pscan_finish_file) struct pscan_thread *finish = tprogress;
 
 	/* Dummy variables used to trigger the cleanup code */
 	_cleanup_(freep) char *path = file->path;
-	_cleanup_(freep) struct file_to_scan *clean_file = file;
+	_cleanup_(free_file_to_scan) struct file_to_scan *clean_file = file;
 
 	/*
-	 * Adopt the running checksum an interrupted run left behind, before any
-	 * early return can leak it. ctxt.off starts where that run stopped, so
-	 * the loop below reads the rest of the file and nothing else; free_scan_
-	 * ctxt() disposes of the checksum on every path out of here.
-	 */
-	ctxt.file_csum = file->resume_csum;
-	ctxt.extent_csum = file->resume_ext_csum;
-	ctxt.off = file->resume_off;
-	/*
 	 * Non-zero exactly while a checkpoint row exists for this file, so it
-	 * also says whether one has to be retired when the digest lands.
+	 * also says whether one has to be retired when the digest lands. The
+	 * resume itself is only taken over once the fiemap can vouch for it,
+	 * below; until then this is a from-scratch scan.
 	 */
-	uint64_t last_checkpoint = ctxt.off;
+	uint64_t last_checkpoint = file->resume.off;
 	unsigned int checkpoints = 0;
 	/*
 	 * Nothing to resume from without a hashfile - the database dies with
@@ -2691,8 +2706,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	}
 
 	ctxt.filesize = file->filesize;
-	if (!ctxt.file_csum)
-		ctxt.file_csum = start_running_checksum();
+	ctxt.file_csum = start_running_checksum();
 	if (!ctxt.file_csum)
 		return;
 
@@ -2711,23 +2725,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	if (!ctxt.fiemap)
 		return;
 
-	/*
-	 * The extent digest carried over from the interrupted run only means
-	 * anything if it is still the same extent. mtime and size are what
-	 * normally stand for "unchanged", and neither has to move when a file is
-	 * defragmented or deduped by something else, so check the one record the
-	 * resume actually depends on. If it moved, the run this checkpoint came
-	 * from was describing a layout that no longer exists: give up on it and
-	 * hash the file from the start (#159).
-	 */
-	if (ctxt.extent_csum && checkpoint_extent_moved(&ctxt, file)) {
-		vprintf("%s: extent layout changed since the checkpoint at "
-			"%"PRIu64" bytes; hashing from the start\n",
-			file->path, (uint64_t)ctxt.off);
-		if (!rewind_to_start(&ctxt, file, tprogress, db))
-			return;
-		last_checkpoint = 0;
-	}
+	/* Take over the interrupted run's state, if the layout still backs it. */
+	if (file->resume.csum &&
+	    !adopt_resume(&ctxt, file, tprogress, db))
+		last_checkpoint = 0;	/* declined, and the row is already gone */
 
 	if (!allocate_hashes(&hashes, &ctxt)) {
 		eprintf("allocate_hashes failed\n");
@@ -2912,24 +2913,13 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 */
 	abort_on(inlined && hashes.blocks_flushed != 0);
 
-	if (hashes.blocks_index != 0 && !inlined) {
-		ret = dbfile_store_block_hashes(db, file->fileid,
-						hashes.blocks_index, hashes.blocks);
-		if (ret) {
-			scan_write_abort();
-			dbfile_unlock();
-			return;
-		}
-	}
-
-
-	if (hashes.extents_index != 0) {
-		ret = dbfile_store_extent_hashes(db, file->fileid, hashes.extents_index, hashes.extents);
-		if (ret) {
-			scan_write_abort();
-			dbfile_unlock();
-			return;
-		}
+	ret = inlined ? 0 : store_block_batch(&hashes);
+	if (!ret)
+		ret = store_extent_batch(&hashes);
+	if (ret) {
+		scan_write_abort();
+		dbfile_unlock();
+		return;
 	}
 
 	/* Flag the file if its last extent is INLINED.
@@ -3269,8 +3259,12 @@ void filescan_init(void)
 			checkpoint_interval = v;
 	}
 
-	if (stop_env)
-		checkpoint_stop_after = strtoul(stop_env, NULL, 10);
+	if (stop_env) {
+		unsigned long v = strtoul(stop_env, NULL, 10);
+
+		if (v > 0 && v <= UINT_MAX)
+			checkpoint_stop_after = (unsigned int)v;
+	}
 
 	abort_on(scan_workq.workers);
 	abort_on(scan_writer_open());

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -131,29 +131,37 @@ struct extent_csum {
 	unsigned char	digest[DIGEST_LEN];
 };
 
+/*
+ * Where an earlier, interrupted run got to, and the running checksums as they
+ * stood there (#159). All zero for the normal case of hashing a file from the
+ * beginning: `csum` NULL means "there is nothing to resume".
+ *
+ * The checksums are restored on the listing thread, so a state this binary
+ * cannot read is spotted while the decision to rescan from scratch is still
+ * cheap to make. `ext_csum` is the digest of the extent that was mid-flight,
+ * with ext_loff/ext_len naming it so the worker can confirm the layout has not
+ * been rewritten since; NULL when the offset fell on an extent boundary.
+ */
+struct scan_resume {
+	uint64_t off;
+	struct running_checksum *csum;
+	struct running_checksum *ext_csum;
+	uint64_t ext_loff;
+	uint64_t ext_len;
+};
+
+/* Release checksums nothing has taken ownership of yet. */
+void scan_resume_drop(struct scan_resume *resume);
+
 struct file_to_scan {
 	char *path;
 	int64_t fileid;
 	size_t filesize;
 	uint64_t mtime;		/* stamped into any checkpoint this file writes */
 
-	/*
-	 * Where an earlier, interrupted run got to, and the running checksums as
-	 * they stood there (#159). Zero and NULL for the normal case of hashing
-	 * a file from the beginning. They are restored on the listing thread, so
-	 * a state this binary cannot read is spotted while the decision to
-	 * rescan from scratch is still cheap to make; the worker that picks the
-	 * file up takes ownership of them.
-	 *
-	 * resume_ext_csum is the digest of the extent that was mid-flight, with
-	 * resume_ext_loff/len naming it so the worker can confirm the layout has
-	 * not been rewritten since. NULL when the offset fell on a boundary.
-	 */
-	uint64_t resume_off;
-	struct running_checksum *resume_csum;
-	struct running_checksum *resume_ext_csum;
-	uint64_t resume_ext_loff;
-	uint64_t resume_ext_len;
+	/* Owned by whoever holds this file_to_scan, until the worker adopts
+	 * the checksums into its scan context. */
+	struct scan_resume resume;
 
 	/*
 	 * Used to record the current file position in the scan queue,

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -159,9 +159,17 @@ struct file_to_scan {
 	size_t filesize;
 	uint64_t mtime;		/* stamped into any checkpoint this file writes */
 
-	/* Owned by whoever holds this file_to_scan, until the worker adopts
-	 * the checksums into its scan context. */
-	struct scan_resume resume;
+	/*
+	 * NULL for the ordinary case of hashing from the start, which is every
+	 * file in almost every run - hence a pointer rather than the struct
+	 * inline. A scan queues one of these per listed file and the walk runs
+	 * far ahead of the hashing, so this is 32 bytes per *listed* file of
+	 * resident memory, ~17 MB on a half-million-file tree.
+	 *
+	 * Owned by whoever holds this file_to_scan, until the worker adopts the
+	 * checksums into its scan context.
+	 */
+	struct scan_resume *resume;
 
 	/*
 	 * Used to record the current file position in the scan queue,

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -135,6 +135,25 @@ struct file_to_scan {
 	char *path;
 	int64_t fileid;
 	size_t filesize;
+	uint64_t mtime;		/* stamped into any checkpoint this file writes */
+
+	/*
+	 * Where an earlier, interrupted run got to, and the running checksums as
+	 * they stood there (#159). Zero and NULL for the normal case of hashing
+	 * a file from the beginning. They are restored on the listing thread, so
+	 * a state this binary cannot read is spotted while the decision to
+	 * rescan from scratch is still cheap to make; the worker that picks the
+	 * file up takes ownership of them.
+	 *
+	 * resume_ext_csum is the digest of the extent that was mid-flight, with
+	 * resume_ext_loff/len naming it so the worker can confirm the layout has
+	 * not been rewritten since. NULL when the offset fell on a boundary.
+	 */
+	uint64_t resume_off;
+	struct running_checksum *resume_csum;
+	struct running_checksum *resume_ext_csum;
+	uint64_t resume_ext_loff;
+	uint64_t resume_ext_len;
 
 	/*
 	 * Used to record the current file position in the scan queue,

--- a/src/tests.c
+++ b/src/tests.c
@@ -1104,7 +1104,11 @@ MU_TEST(test_running_checksum_rejects_foreign_state) {
 
 	mu_check(running_checksum_save(c, blob, len) == 0);
 	finish_running_checksum(c, NULL);
-	mu_check(running_checksum_restore(blob, len) != NULL);
+
+	/* The control: unmodified, this one has to be accepted. */
+	c = running_checksum_restore(blob, len);
+	mu_check(c != NULL);
+	finish_running_checksum(c, NULL);
 
 	/* A different xxhash - what a distro upgrade leaves behind. */
 	blob[8] ^= 0xff;

--- a/src/tests.c
+++ b/src/tests.c
@@ -1058,7 +1058,70 @@ MU_TEST(test_glob_empty_set_matches_nothing) {
 	glob_set_free(gs);
 }
 
+/*
+ * The property the whole of #159 rests on: hashing a byte stream in one go and
+ * hashing it across a save/restore must give the same digest. If it ever did
+ * not, a resumed scan would store a digest matching nothing - silently, since
+ * nothing downstream can tell a wrong digest from a file that simply has no
+ * duplicate.
+ */
+MU_TEST(test_running_checksum_survives_save_restore) {
+	unsigned char data[8192];
+	unsigned char whole[DIGEST_LEN], resumed[DIGEST_LEN];
+	_cleanup_(freep) void *blob = malloc(running_checksum_state_size());
+	struct running_checksum *c;
+
+	for (unsigned int i = 0; i < sizeof(data); i++)
+		data[i] = (unsigned char)(i * 31 + (i >> 3));
+
+	c = start_running_checksum();
+	add_to_running_checksum(c, data, sizeof(data));
+	finish_running_checksum(c, whole);
+
+	/*
+	 * Split at 1000 bytes: not a multiple of XXH3's 256-byte internal
+	 * buffer, so the state carries buffered bytes across the break - the
+	 * case a naive "just keep the accumulators" save would get wrong.
+	 */
+	c = start_running_checksum();
+	add_to_running_checksum(c, data, 1000);
+	mu_check(running_checksum_save(c, blob, running_checksum_state_size()) == 0);
+	finish_running_checksum(c, NULL);
+
+	c = running_checksum_restore(blob, running_checksum_state_size());
+	mu_check(c != NULL);
+	add_to_running_checksum(c, data + 1000, sizeof(data) - 1000);
+	finish_running_checksum(c, resumed);
+
+	mu_check(memcmp(whole, resumed, DIGEST_LEN) == 0);
+}
+
+/* A blob this binary cannot vouch for must be refused, not reinterpreted. */
+MU_TEST(test_running_checksum_rejects_foreign_state) {
+	size_t len = running_checksum_state_size();
+	_cleanup_(freep) unsigned char *blob = malloc(len);
+	struct running_checksum *c = start_running_checksum();
+
+	mu_check(running_checksum_save(c, blob, len) == 0);
+	finish_running_checksum(c, NULL);
+	mu_check(running_checksum_restore(blob, len) != NULL);
+
+	/* A different xxhash - what a distro upgrade leaves behind. */
+	blob[8] ^= 0xff;
+	mu_check(running_checksum_restore(blob, len) == NULL);
+	blob[8] ^= 0xff;
+
+	/* Truncated, or from a build whose state struct was a different size. */
+	mu_check(running_checksum_restore(blob, len - 1) == NULL);
+
+	/* Not one of ours at all. */
+	blob[0] ^= 0xff;
+	mu_check(running_checksum_restore(blob, len) == NULL);
+}
+
 MU_TEST_SUITE(test_suite) {
+	MU_RUN_TEST(test_running_checksum_survives_save_restore);
+	MU_RUN_TEST(test_running_checksum_rejects_foreign_state);
 	MU_RUN_TEST(test_is_block_zeroed);
 	MU_RUN_TEST(test_block_len);
 	MU_RUN_TEST(test_is_file_renamed);

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -397,6 +397,17 @@ class DuperemoveTest(unittest.TestCase):
         finally:
             con.close()
 
+    def hf_exec(self, sql, params=()):
+        """Modify the hashfile behind oans's back, to set up a state that only
+        arises from an event a test cannot stage (a hash-library upgrade, a
+        defragmentation between runs)."""
+        con = sqlite3.connect(self.hf)
+        try:
+            con.execute(sql, params)
+            con.commit()
+        finally:
+            con.close()
+
     def hf_count(self, table):
         return self.hf_query(f"select count(*) from {table}")[0][0]
 

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -422,6 +422,21 @@ class DuperemoveTest(unittest.TestCase):
             "from files order by filename")
         return hashlib.sha256(repr(rows).encode()).hexdigest()
 
+    def blocks_fingerprint(self):
+        rows = self.hf_query(
+            "select f.filename, b.loff, quote(b.digest) from blocks b "
+            "join files f on f.id = b.fileid order by f.filename, b.loff")
+        return hashlib.sha256(repr(rows).encode()).hexdigest()
+
+    def drop_hashfile(self):
+        """Delete the hashfile and its WAL sidecars, so the next run starts
+        from nothing. Removing only the .db leaves a -wal SQLite will replay."""
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.unlink(self.hf + suffix)
+            except FileNotFoundError:
+                pass
+
     def extents_fingerprint(self):
         rows = self.hf_query(
             "select f.filename, e.loff, e.len, quote(e.digest) from extents e "

--- a/tests/integration/test_hash_resume.py
+++ b/tests/integration/test_hash_resume.py
@@ -252,6 +252,72 @@ class HashResumeTest(DuperemoveTest):
         self.assertDmOk("run that finishes the hashing")
         self.assertShared(a, b, "the resumed files were never deduped")
 
+    def test_a_checkpointed_file_is_resumed_before_the_walk(self):
+        """Partly-hashed files go to the pool up front, not when the walk gets
+        to them.
+
+        On a tree of millions of files the walk takes minutes to reach a file
+        buried a few directories down, and a nearly-finished 50 GiB image is
+        the one thing most worth finishing - waiting for rediscovery is another
+        few minutes in which an interruption costs its tail. Measured on a
+        120k-file tree, this took the delay from 0.73 s to 0.02 s, and the
+        seeded figure does not grow with the tree.
+
+        It must also not queue the file *twice*: the walk meets it as well, so
+        the run's own file count is what pins that.
+        """
+        deep = "tree/aa/bb/cc/dd/big.bin"
+        self.write(deep, os.urandom(6 * MiB))
+        for i in range(20):
+            self.write(f"tree/small{i}.bin", os.urandom(64 * KiB))
+        self.sync()
+        tree = self.path("tree")
+
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk("interrupted scan")
+        self.assertEqual(1, self.hf_count("scan_checkpoints"))
+
+        self.dm("-rv", tree, env=CKPT, quiet=False)
+        self.assertDmOk("resumed scan")
+        self.assertIn("partially hashed file", self.out,
+                      "the checkpointed file was not seeded before the walk")
+
+        # 21 files exist and 20 were finished by the first run, so this run
+        # hashed exactly one. Seeding it *and* letting the walk queue it would
+        # make that two - and have two workers hashing one file at once.
+        self.assertEqual(1, self.hf_scalar(
+            "select files_scanned from run_history order by rowid desc limit 1"),
+            "the resumed file was queued more than once")
+        self.assertEqual(0, self.hf_count("scan_checkpoints"))
+        self.assertEqual(0, self.hf_scalar(
+            "select count(*) from files where digest is null"))
+
+    def test_a_checkpoint_outside_the_scanned_roots_is_left_alone(self):
+        """One hashfile may cover several trees scanned on different days.
+        Seeding must not reach into a tree this run was not pointed at - that
+        would be hashing terabytes nobody asked for."""
+        self.write("other/big.bin", os.urandom(6 * MiB))
+        self.write("tree/a.bin", os.urandom(64 * KiB))
+        self.sync()
+
+        self.dm("-r", self.path("other"), env=STOP)
+        self.assertDmOk("interrupted scan of the other tree")
+        self.assertEqual(1, self.hf_count("scan_checkpoints"))
+        stopped_at = self.hf_scalar("select loff from scan_checkpoints")
+
+        self.dm("-rv", self.path("tree"), env=CKPT, quiet=False)
+        self.assertDmOk("scan of the requested tree")
+        self.assertNotIn("partially hashed file", self.out)
+        self.assertNotIn("other/big.bin", self.out)
+
+        # Untouched: same checkpoint, still no digest, ready for the day that
+        # tree is scanned again.
+        self.assertEqual(stopped_at,
+                         self.hf_scalar("select loff from scan_checkpoints"),
+                         "a checkpoint outside the scanned roots was consumed")
+        self.assertEqual(1, self.hf_scalar(
+            "select count(*) from files where digest is null"))
+
     def test_without_a_hashfile_nothing_is_checkpointed(self):
         """There would be nowhere to resume from - the database dies with the
         process - so an in-memory run must not pay for checkpoints, and must

--- a/tests/integration/test_hash_resume.py
+++ b/tests/integration/test_hash_resume.py
@@ -64,11 +64,8 @@ class HashResumeTest(DuperemoveTest):
 
     def fingerprints(self):
         """Everything the scan is supposed to have produced."""
-        blocks = self.hf_query(
-            "select f.filename, b.loff, quote(b.digest) from blocks b "
-            "join files f on f.id = b.fileid order by f.filename, b.loff")
         return (self.files_fingerprint(), self.extents_fingerprint(),
-                repr(blocks))
+                self.blocks_fingerprint())
 
     def scan_straight_through(self, tree, *extra):
         """Hash the tree in one go, into a fresh hashfile."""
@@ -77,12 +74,12 @@ class HashResumeTest(DuperemoveTest):
         self.assertDmOk("uninterrupted scan")
         return self.fingerprints()
 
-    def drop_hashfile(self):
-        for suffix in ("", "-wal", "-shm"):
-            try:
-                os.unlink(self.hf + suffix)
-            except FileNotFoundError:
-                pass
+    def interrupt_after_one_checkpoint(self, tree, *extra):
+        """One run that gives up at its first checkpoint, as a kill would."""
+        self.dm("-r", tree, *extra, env=STOP)
+        self.assertDmOk("interrupted scan")
+        self.assertGreater(self.hf_count("scan_checkpoints"), 0,
+                           "nothing was checkpointed")
 
     def scan_with_interruptions(self, tree, *extra, limit=40):
         """Hash the tree a checkpoint at a time until it finally completes.
@@ -133,13 +130,10 @@ class HashResumeTest(DuperemoveTest):
         the first one already hashed."""
         tree = self.build_tree()
         self.drop_hashfile()
-        self.dm("-r", tree, env=STOP)
-        self.assertDmOk("interrupted scan")
-
+        self.interrupt_after_one_checkpoint(tree)
         stopped_at = dict(self.hf_query(
             "select f.filename, c.loff from scan_checkpoints c "
             "join files f on f.id = c.fileid"))
-        self.assertTrue(stopped_at, "nothing was checkpointed")
 
         self.dm("-rv", tree, env=STOP, quiet=False)
         self.assertDmOk("resumed scan")
@@ -154,9 +148,7 @@ class HashResumeTest(DuperemoveTest):
         about it will ever change again."""
         tree = self.build_tree()
         self.drop_hashfile()
-        self.dm("-r", tree, env=STOP)
-        self.assertDmOk()
-        self.assertGreater(self.hf_count("scan_checkpoints"), 0)
+        self.interrupt_after_one_checkpoint(tree)
 
         self.scan(tree)
         self.assertDmOk()
@@ -169,9 +161,7 @@ class HashResumeTest(DuperemoveTest):
         tree = self.build_tree()
         expected_before = self.scan_straight_through(tree)
         self.drop_hashfile()
-        self.dm("-r", tree, env=STOP)
-        self.assertDmOk()
-        self.assertGreater(self.hf_count("scan_checkpoints"), 0)
+        self.interrupt_after_one_checkpoint(tree)
 
         self.write("tree/plain", os.urandom(6 * MiB))
         self.sync()
@@ -191,8 +181,7 @@ class HashResumeTest(DuperemoveTest):
         tree = self.build_tree()
         expected = self.scan_straight_through(tree)
         self.drop_hashfile()
-        self.dm("-r", tree, env=STOP)
-        self.assertDmOk()
+        self.interrupt_after_one_checkpoint(tree)
 
         self.hf_exec("update scan_checkpoints "
                      "set state = randomblob(length(state))")
@@ -273,9 +262,7 @@ class HashResumeTest(DuperemoveTest):
         self.sync()
         tree = self.path("tree")
 
-        self.dm("-r", tree, env=STOP)
-        self.assertDmOk("interrupted scan")
-        self.assertEqual(1, self.hf_count("scan_checkpoints"))
+        self.interrupt_after_one_checkpoint(tree)
 
         self.dm("-rv", tree, env=CKPT, quiet=False)
         self.assertDmOk("resumed scan")
@@ -300,9 +287,7 @@ class HashResumeTest(DuperemoveTest):
         self.write("tree/a.bin", os.urandom(64 * KiB))
         self.sync()
 
-        self.dm("-r", self.path("other"), env=STOP)
-        self.assertDmOk("interrupted scan of the other tree")
-        self.assertEqual(1, self.hf_count("scan_checkpoints"))
+        self.interrupt_after_one_checkpoint(self.path("other"))
         stopped_at = self.hf_scalar("select loff from scan_checkpoints")
 
         self.dm("-rv", self.path("tree"), env=CKPT, quiet=False)

--- a/tests/integration/test_hash_resume.py
+++ b/tests/integration/test_hash_resume.py
@@ -1,0 +1,261 @@
+"""Hashing one huge file survives being interrupted (#159).
+
+A 1 TiB file six hours into hashing used to start again from byte zero every
+time the run was killed, so on a big enough file a scheduled scan could never
+finish. Now a run leaves checkpoints behind and the next one picks up from the
+last of them.
+
+The property that matters is not that resuming is fast - it is that resuming is
+*invisible*: a file hashed across any number of interruptions must end up with
+exactly the digest, extent hashes and block hashes it would have had from one
+straight-through scan. Nothing downstream could tell a wrong digest from a file
+that simply has no duplicate, so a resume that quietly computed something else
+would corrupt the hashfile in silence.
+
+DUPEREMOVE_CHECKPOINT_BYTES lowers the one-gigabyte interval so this is
+reachable with small files; DUPEREMOVE_CHECKPOINT_STOP abandons a file after
+that many checkpoints, standing in for the kill deterministically rather than
+racing a signal against a read.
+"""
+
+import os
+from harness import DuperemoveTest, requires_reflink
+
+KiB = 1 << 10
+MiB = 1 << 20
+
+# Checkpoint every megabyte - the read buffer's size, so every pass through the
+# hash loop is a candidate and a few-megabyte file behaves like a huge one.
+CKPT = {"DUPEREMOVE_CHECKPOINT_BYTES": str(MiB)}
+# ... and give up after the first one, as an interrupted run would.
+STOP = dict(CKPT, DUPEREMOVE_CHECKPOINT_STOP="1")
+
+
+@requires_reflink
+class HashResumeTest(DuperemoveTest):
+    # The fragmented file below is built with fsync-forced extent boundaries,
+    # and what a checkpoint has to carry depends on which extent it lands in.
+    # See DuperemoveTest.serial.
+    serial = True
+
+    def build_tree(self):
+        """Files whose shapes stress different points of the hash loop."""
+        # Plain, and big enough for several checkpoints. btrfs reports a
+        # contiguously allocated file as one fiemap extent however large, so
+        # this is also the case where every checkpoint falls mid-extent.
+        self.write("tree/plain", os.urandom(6 * MiB))
+
+        # Many extents, so checkpoints land on and between their boundaries.
+        with open(self.path("tree/frag"), "wb") as f:
+            for _ in range(6):
+                f.write(os.urandom(MiB))
+                f.flush()
+                os.fsync(f.fileno())
+
+        # A hole is skipped without being read, so it moves the offset without
+        # feeding the checksum - a checkpoint has to describe that correctly.
+        self.make_sparse("tree/sparse", os.urandom(2 * MiB), 8 * MiB,
+                         os.urandom(2 * MiB))
+
+        # Never reaches a checkpoint: the ordinary case must stay untouched.
+        self.write("tree/small", os.urandom(64 * KiB))
+        self.sync()
+        return self.path("tree")
+
+    def fingerprints(self):
+        """Everything the scan is supposed to have produced."""
+        blocks = self.hf_query(
+            "select f.filename, b.loff, quote(b.digest) from blocks b "
+            "join files f on f.id = b.fileid order by f.filename, b.loff")
+        return (self.files_fingerprint(), self.extents_fingerprint(),
+                repr(blocks))
+
+    def scan_straight_through(self, tree, *extra):
+        """Hash the tree in one go, into a fresh hashfile."""
+        self.drop_hashfile()
+        self.scan(tree, *extra)
+        self.assertDmOk("uninterrupted scan")
+        return self.fingerprints()
+
+    def drop_hashfile(self):
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.unlink(self.hf + suffix)
+            except FileNotFoundError:
+                pass
+
+    def scan_with_interruptions(self, tree, *extra, limit=40):
+        """Hash the tree a checkpoint at a time until it finally completes.
+
+        Every run but the last is cut short after its first checkpoint, so each
+        file crawls forward one interval per run and every file ends up resumed
+        many times over - including from checkpoints an earlier resume wrote.
+        """
+        self.drop_hashfile()
+        runs = 0
+        while runs < limit:
+            runs += 1
+            self.dm("-r", tree, *extra, env=STOP)
+            self.assertDmOk(f"interrupted scan {runs}")
+            if not self.hf_count("scan_checkpoints"):
+                break
+        else:
+            self.fail(f"{limit} runs and the tree still had checkpoints")
+        self.assertGreater(runs, 3, "no file was ever actually interrupted")
+        return runs
+
+    def test_resumed_scan_matches_an_uninterrupted_one(self):
+        tree = self.build_tree()
+        expected = self.scan_straight_through(tree)
+
+        runs = self.scan_with_interruptions(tree)
+
+        self.assertEqual(expected, self.fingerprints(),
+                         f"hashing across {runs} interruptions did not produce "
+                         "what one straight run produces")
+
+    def test_resumed_scan_matches_with_block_hashes(self):
+        """--dedupe-options=partial adds per-block digests, which flush to the
+        hashfile on their own batch cadence rather than at checkpoints - so an
+        interrupted run can leave blocks past the point it resumes from."""
+        tree = self.build_tree()
+        opt = "--dedupe-options=partial"
+        expected = self.scan_straight_through(tree, opt)
+        self.assertGreater(self.hf_count("blocks"), 0, "no block hashes stored")
+
+        self.scan_with_interruptions(tree, opt)
+
+        self.assertEqual(expected, self.fingerprints(),
+                         "block hashes differ after resuming")
+
+    def test_resume_starts_where_it_stopped(self):
+        """The point of the exercise: the second run does not re-read the part
+        the first one already hashed."""
+        tree = self.build_tree()
+        self.drop_hashfile()
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk("interrupted scan")
+
+        stopped_at = dict(self.hf_query(
+            "select f.filename, c.loff from scan_checkpoints c "
+            "join files f on f.id = c.fileid"))
+        self.assertTrue(stopped_at, "nothing was checkpointed")
+
+        self.dm("-rv", tree, env=STOP, quiet=False)
+        self.assertDmOk("resumed scan")
+        for path, loff in stopped_at.items():
+            self.assertIn(f"Resuming {path} at {loff} of", self.out,
+                          "the resumed run started somewhere else")
+
+    def test_a_checkpointed_file_is_not_mistaken_for_up_to_date(self):
+        """Its row carries the current mtime and size from the moment it is
+        listed - only the digest says it was ever hashed. Reading those two as
+        "up to date" would leave the file permanently unhashed, since nothing
+        about it will ever change again."""
+        tree = self.build_tree()
+        self.drop_hashfile()
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk()
+        self.assertGreater(self.hf_count("scan_checkpoints"), 0)
+
+        self.scan(tree)
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_scalar(
+            "select count(*) from files where digest is null"),
+            "a file was left unhashed")
+        self.assertEqual(0, self.hf_count("scan_checkpoints"))
+
+    def test_a_file_changed_under_its_checkpoint_is_hashed_afresh(self):
+        tree = self.build_tree()
+        expected_before = self.scan_straight_through(tree)
+        self.drop_hashfile()
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk()
+        self.assertGreater(self.hf_count("scan_checkpoints"), 0)
+
+        self.write("tree/plain", os.urandom(6 * MiB))
+        self.sync()
+
+        self.scan(tree)
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_count("scan_checkpoints"))
+        after = self.fingerprints()
+        self.assertNotEqual(expected_before, after, "the file did change")
+        self.assertEqual(self.scan_straight_through(tree), after,
+                         "the rewritten file was not hashed from scratch")
+
+    def test_an_unreadable_checkpoint_is_discarded_not_misread(self):
+        """What a hash-library upgrade leaves behind: state this build cannot
+        vouch for. It has to be refused rather than fed back into a checksum,
+        which would produce a digest matching nothing."""
+        tree = self.build_tree()
+        expected = self.scan_straight_through(tree)
+        self.drop_hashfile()
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk()
+
+        self.hf_exec("update scan_checkpoints "
+                     "set state = randomblob(length(state))")
+
+        self.scan(tree)
+        self.assertDmOk()
+        self.assertEqual(0, self.hf_count("scan_checkpoints"))
+        self.assertEqual(expected, self.fingerprints(),
+                         "a corrupted checkpoint changed the hashes")
+
+    def test_a_moved_extent_invalidates_the_checkpoint(self):
+        """A checkpoint taken mid-extent carries that extent's part-finished
+        digest, which means nothing if the extent is no longer there. mtime and
+        size - what normally stands for "unchanged" - need not move when a file
+        is defragmented, so the extent it named is checked directly."""
+        tree = self.build_tree()
+        expected = self.scan_straight_through(tree)
+        self.drop_hashfile()
+        self.dm("-r", tree, env=STOP)
+        self.assertDmOk()
+        self.assertGreater(
+            self.hf_scalar("select count(*) from scan_checkpoints "
+                           "where ext_state is not null"), 0,
+            "no checkpoint landed mid-extent")
+
+        self.hf_exec("update scan_checkpoints set ext_loff = ext_loff + 4096 "
+                     "where ext_state is not null")
+
+        self.dm("-rv", tree, quiet=False)
+        self.assertDmOk()
+        self.assertIn("extent layout changed", self.out)
+        self.assertEqual(0, self.hf_count("scan_checkpoints"))
+        self.assertEqual(expected, self.fingerprints(),
+                         "the file was not re-hashed from the start")
+
+    def test_a_resumed_file_is_deduped_by_the_run_that_finishes_it(self):
+        """Its row still carries the generation the interrupted run gave it,
+        and the dedupe phase of any run in between moves the watermark past
+        that. A file at or below the watermark is one dedupe never looks at, so
+        without moving it forward a resumed file would be hashed and then
+        quietly ignored - by every later run too, since nothing about it would
+        change again."""
+        data = os.urandom(6 * MiB)
+        a = self.write("tree/a", data)
+        b = self.write("tree/b", data)
+        self.sync()
+        tree = self.path("tree")
+
+        # A run that abandons both files partway, then dedupes what little it
+        # has - which is what advances the watermark past their generation.
+        self.dm("-rd", tree, env=STOP)
+        self.assertDmOk("interrupted run")
+        self.assertEqual(2, self.hf_count("scan_checkpoints"))
+        self.assertNotShared(a, b, "nothing could have been deduped yet")
+
+        self.dedupe(tree)
+        self.assertDmOk("run that finishes the hashing")
+        self.assertShared(a, b, "the resumed files were never deduped")
+
+    def test_without_a_hashfile_nothing_is_checkpointed(self):
+        """There would be nowhere to resume from - the database dies with the
+        process - so an in-memory run must not pay for checkpoints, and must
+        not trip over the machinery either."""
+        tree = self.build_tree()
+        self.dm("-r", tree, hashfile=False, env=STOP)
+        self.assertDmOk()

--- a/tests/integration/test_progress_bytes.py
+++ b/tests/integration/test_progress_bytes.py
@@ -160,10 +160,7 @@ class ProgressBytesTest(DuperemoveTest):
         self.sync()
 
         # Fresh hashfile forces a full re-analysis of the (already shared) tree.
-        os.unlink(self.hf)
-        for sidecar in (self.hf + "-wal", self.hf + "-shm"):
-            if os.path.exists(sidecar):
-                os.unlink(sidecar)
+        self.drop_hashfile()
 
         _p, events = self._run("-rd", self.path("tree"))
         dedupe = self._dedupe_evs(events)

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -37,10 +37,7 @@ def _run_in_pty(argv, env=None):
     pid, fd = pty.fork()
     if pid == 0:                                  # child
         try:
-            if env is None:
-                os.execvp(argv[0], argv)
-            else:
-                os.execvpe(argv[0], argv, env)
+            os.execvpe(argv[0], argv, os.environ if env is None else env)
         finally:                                  # execvp raises, never returns
             os._exit(127)
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
@@ -60,15 +57,23 @@ def _run_in_pty(argv, env=None):
     return b"".join(chunks)
 
 
-def _worker_rows(data, name):
-    """Every worker row naming `name` that was ever drawn, in order.
+def _worker_rows(data, name, status="hashing"):
+    """Every worker row naming `name` drawn in `status`, in order.
 
     _render() rebuilds the *final* screen, and the block is wiped before exit -
     so a row that only existed mid-run has to be read out of the raw stream.
+
+    Filtering on the status matters: the same slot also renders the file while
+    mapping and committing, and those rows carry "(size: N)" instead of the
+    done/total the callers here are asking about.
     """
     text = _ANSI_TEXT.sub("", data.decode("utf-8", "replace"))
-    return [ln.strip() for ln in re.split(r"[\r\n]", text)
-            if name in ln and "hashing" in ln]
+    rows = []
+    for ln in re.split(r"[\r\n]", text):
+        m = WORKER_ROW.match(ln)
+        if m and m.group(1) == status and name in ln:
+            rows.append(ln.strip())
+    return rows
 
 
 def _render(data):

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -29,14 +29,18 @@ COLS, ROWS = 100, 30
 WORKER_ROW = re.compile(r"^ {2}\d+ {2}(idle|hashing|mapping|commit|wait lock|deduping)\b")
 
 _CSI = re.compile(rb"\x1b\[([0-9;?]*)([A-Za-z])")
+_ANSI_TEXT = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
-def _run_in_pty(argv):
+def _run_in_pty(argv, env=None):
     """Run argv on a COLS x ROWS pty; return its raw output bytes."""
     pid, fd = pty.fork()
     if pid == 0:                                  # child
         try:
-            os.execvp(argv[0], argv)
+            if env is None:
+                os.execvp(argv[0], argv)
+            else:
+                os.execvpe(argv[0], argv, env)
         finally:                                  # execvp raises, never returns
             os._exit(127)
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))
@@ -54,6 +58,17 @@ def _run_in_pty(argv):
     os.close(fd)
     os.waitpid(pid, 0)
     return b"".join(chunks)
+
+
+def _worker_rows(data, name):
+    """Every worker row naming `name` that was ever drawn, in order.
+
+    _render() rebuilds the *final* screen, and the block is wiped before exit -
+    so a row that only existed mid-run has to be read out of the raw stream.
+    """
+    text = _ANSI_TEXT.sub("", data.decode("utf-8", "replace"))
+    return [ln.strip() for ln in re.split(r"[\r\n]", text)
+            if name in ln and "hashing" in ln]
 
 
 def _render(data):
@@ -160,6 +175,57 @@ class ProgressTtyTest(DuperemoveTest):
         self.assertTrue(
             any("2 permission denied" in ln for ln in screen),
             f"the scan-skip report was erased by the block:\n  {shown}")
+
+    # Depends on hashing outlasting one REDRAW_MS (100 ms) tick, so the row
+    # exists at a redraw. Kept CPU-bound (4K blocks, partial mode) rather than
+    # sized in bytes: a faster disk shrinks an I/O-bound run but not this one.
+    # If it ever goes quiet, raise SIZE rather than deleting the assertion.
+    RESUME_SIZE = 256 * 1024 * 1024
+    RESUME_CKPT = 64 * 1024 * 1024
+
+    def test_resumed_file_shows_its_real_size_and_progress(self):
+        """A resumed file must look resumed, not restarted (#159).
+
+        Its row reports the whole file, with the bytes an earlier run already
+        hashed credited up front. Reporting only the remainder is what this
+        pins: the row then restarts near 0% *and* understates the file - an
+        18.4 GiB movie resumed at 3 GiB drew as "0.2 GiB/15.4 GiB (1%)", which
+        is indistinguishable from the resume having silently failed, and was
+        reported as exactly that.
+
+        The run-wide totals are a separate matter and deliberately do count
+        only this run's work, so this asserts on the per-file row alone.
+        """
+        opts = ["-b", "4096", "--dedupe-options=partial", "--io-threads=1"]
+        env = {"DUPEREMOVE_CHECKPOINT_BYTES": str(self.RESUME_CKPT)}
+        self.mkrand("tree/movie.bin", self.RESUME_SIZE)
+        self.sync()
+        tree = os.path.join(self.work, "tree")
+
+        # Stop after one checkpoint, as an interrupted run would.
+        self.dm("-r", tree, *opts, env=dict(env, DUPEREMOVE_CHECKPOINT_STOP="1"))
+        self.assertDmOk("interrupted scan")
+        stopped_at = self.hf_scalar("select loff from scan_checkpoints")
+        self.assertEqual(self.RESUME_CKPT, stopped_at, "unexpected resume point")
+
+        rows = _worker_rows(_run_in_pty(
+            [DUPEREMOVE, "-r", "--hashfile", self.hf, tree] + opts,
+            env=dict(os.environ, **env)), "movie.bin")
+        self.assertTrue(rows, "the resumed file never appeared in the block; "
+                              "see RESUME_SIZE above")
+
+        # 256.0 MiB is the file. 192.0 MiB - what is left after the
+        # checkpoint - is the bug: the remainder drawn as if it were the whole.
+        bad = [r for r in rows if "/256.0 MiB" not in r]
+        self.assertEqual([], bad, "a resumed row reported something other than "
+                                  "the file's real size:\n  " + "\n  ".join(bad))
+
+        # ... and it picks up from the checkpoint rather than starting over.
+        pct = re.search(r"\((\d+\.\d+)%\)", rows[0])
+        self.assertTrue(pct, f"no percentage in {rows[0]!r}")
+        self.assertGreaterEqual(
+            float(pct.group(1)), 100.0 * stopped_at / self.RESUME_SIZE,
+            f"the resumed row restarted below its checkpoint:\n  {rows[0]}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #159.

A 1 TiB file interrupted six hours into hashing started again from byte zero on the next run — so on a big enough file a scheduled scan could never finish. The scan now checkpoints every 1 GiB, and the next run picks each file up where it stopped.

Measured with a real `SIGKILL` on a 12 GiB file, both runs cold:

| | |
|---|---|
| killed at | 3 GiB of 12 GiB |
| resumed run | 5.02 s (reads the remaining 9 GiB) |
| full cold run | 6.22 s |
| digest | identical to a straight scan |

## The digest does not change

That was the design constraint. The original plan (#158) — redefine the file digest as a hash of extent digests, which is additive and so trivially resumable — was rejected because it makes fragmentation part of file identity: byte-identical files with different extent layouts would stop matching. It would also have invalidated every existing hashfile.

So the *running xxhash state* is snapshotted instead (`running_checksum_save`/`restore`, confined to `csum.c`). xxhash publishes no serialization, so this copies `XXH3_state_t` verbatim — legitimate within one build, not across one. The blob carries magic + `XXH_versionNumber()` + `sizeof(state)`, and restore **refuses anything it cannot vouch for**: a distro xxhash upgrade costs a rehash, never a wrong digest.

## The in-flight extent digest rides along

The first cut only checkpointed at extent boundaries, so no extent state was needed. It never fired once — **btrfs reports a contiguously allocated file as a single fiemap extent however large it is**, which is exactly the shape this feature is for. A checkpoint now carries the partial extent digest plus that extent's `loff`/`len`, and a resume that doesn't find it where it was left discards the checkpoint. That doubles as the one cheap check that the layout wasn't rewritten underneath — mtime and size need not move on a defrag.

## Resumed files start immediately, not when the walk finds them

Reported from a 4.9 TiB run: a 53 GiB Steam pak file was nowhere to be seen after a restart. It *was* being resumed — the walk simply hadn't reached it yet, six directories down a tree of 1.7 M files. Largest-first ordering can't help, because it only orders what has been discovered.

A run now asks the hashfile which files it left partway and pushes them onto the walk's file queue up front, so the ordinary consumer (`__scan_file`) handles them first. On a 120k-file tree with the file six levels deep, time-to-resume went **0.73 s → 0.02 s**, and the seeded figure doesn't grow with the tree. Only files under the roots named on that command line are seeded — a hashfile shared across several trees must never make one run hash another tree's files.

## What this does *not* promise

Two limits worth stating plainly, both measured rather than reasoned about, and both documented in the man page:

- **A checkpoint is trusted on mtime + size.** A `nodatacow` file modified in place with its timestamp restored resumes across the change and yields a digest of a byte string that never existed. **The ordinary incremental path has the identical blind spot** — measured on the same file — so resume inherits oans's existing guarantee rather than weakening it, and the real safety net is that `FIDEDUPERANGE` byte-verifies (two files oans believed identical deduped to `0 B`, both intact).
- **An interrupted run keeps what was *committed*, not what was done.** The batched writer commits every 10 s, and Ctrl-C is not trapped, so it discards the open batch exactly as a crash does — measured: SIGINT and SIGKILL at 3 s both persist nothing. Repeated interruption still converges (verified over a 30 GiB tree: every file hashed, no checkpoints left), but killing more often than the commit interval loops at zero progress. That is pre-existing: at 1.4 s kills v1.9.1 persisted 0 files over six rounds where this code reaches 1875, because a checkpoint force-commits the batch.

## Three bugs found on the way

- **Change detection had a matching hole.** A file's row carries its mtime and size from the moment it is *listed*; only the digest says it was ever hashed. Nothing had noticed because `dbfile_prune_unscanned_files()` deleted every digest-less row at startup. That prune now spares checkpointed rows, so the up-to-date check has to consult the digest — otherwise a checkpointed file would read as up to date and never be hashed again.
- **Valgrind caught an uninitialised write.** A reset `XXH3_state_t` leaves its alignment padding and the unused tail of its internal buffer undefined. Fine while it never leaves the process; not fine once it is copied into a database.
- **A resumed file's progress row lied.** It reported only the bytes still to read, so an 18.4 GiB movie resumed at 3 GiB drew as `0.2 GiB/15.4 GiB (1%)` — indistinguishable from the resume having failed, and reported as exactly that. It now shows the real size with the already-hashed bytes credited up front.

Also: a resumed file keeps its row (replacing it would cascade away the checkpoint and hashes the resume is built on) but is moved into the current run's `dedupe_seq`. Without that, a dedupe phase in between draws level with its generation and the file is hashed and then silently never deduped.

## Testing

`tests/integration/test_hash_resume.py` — 11 tests. The central one builds a tree of awkward shapes (one-extent, fsync-fragmented, sparse, and one too small to ever checkpoint), drives it through dozens of interruptions, and asserts the digests, extent hashes **and** block hashes come out identical to one straight-through scan. That is the property that matters: nothing downstream can tell a wrong digest from a file that simply has no duplicate.

Mutations confirm the tests bite — dropping the carried extent state, ignoring the saved file state, removing the `dedupe_seq` refresh, and ignoring the scan roots each fail their own tests.

Also covered: resume starts at the recorded offset; a changed file discards its checkpoint; an unreadable state blob is discarded rather than misread; a moved extent invalidates the checkpoint; an in-memory run doesn't checkpoint; a seeded file is not queued twice; a checkpoint outside the scanned roots is left alone. Plus a pty test that the resumed progress row shows the real size, and two unit tests for save/restore across a non-buffer-aligned split and for refusing foreign state.

Gates: `scripts/verify.sh`, full `make integration-valgrind` (no findings), TSan and ASan/UBSan over unit **and** integration.

No new CLI options and no schema-version bump — `scan_checkpoints` is a new `CREATE TABLE IF NOT EXISTS`, so existing hashfiles are untouched. An older binary reading a hashfile with checkpoint rows simply deletes them via the existing cascade, i.e. reverts to pre-#159 behaviour.

## Performance

Interleaved, distinct binaries. The only cost on the ordinary path is a 576-byte memset per running checksum (+3.2 ns/call), needed so the snapshot contains no undefined bytes:

| profile | base | new |
|---|---|---|
| `fragmented` (262k extents) | 2.53 s | 2.54 s |
| `realistic` | 5.02 s | 5.03 s |

Two `/simplify` passes folded the new code onto existing helpers rather than beside them: the checkpoint seeder feeds `__scan_file()` instead of re-implementing it, the batch stores and statement runners are shared, and `struct file_to_scan` allocates its resume state only when there is one — the inline version cost +27 MB peak RSS on a 518k-file scan, now +10 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)