### PR TITLE
dedupe: elect a group's target from stored data, not a live fiemap (#197)

### DIFF
--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -410,6 +410,17 @@ static int create_tables(sqlite3 *db)
 	 * after the first hits it - so the error is discarded rather than
 	 * probed for with a PRAGMA table_info round-trip.
 	 */
+	/*
+	 * Extent count as of the scan that recorded the file. The dedupe phase
+	 * ranks a group's members on it to choose a target, and that ranking has
+	 * to give the same answer in every generation window - a live fiemap
+	 * does not, which is #197. Additive, so per CLAUDE.md no DB_FILE_MINOR
+	 * bump: an old hashfile gets the column with 0 everywhere, which ranks
+	 * purely by id, and an older binary never selects it.
+	 */
+	sqlite3_exec(db, "ALTER TABLE files ADD COLUMN nr_extents INTEGER NOT NULL DEFAULT 0",
+		     NULL, NULL, NULL);
+
 	static const char * const run_history_adds[] = {
 		"ALTER TABLE run_history ADD COLUMN skip_permission INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE run_history ADD COLUMN skip_unreadable INTEGER NOT NULL DEFAULT 0",
@@ -758,7 +769,7 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 	dbfile_prepare_stmt(insert_extent, INSERT_EXTENTS);
 
 #define UPDATE_SCANNED_FILE						\
-"UPDATE files SET digest = ?1, flags = ?2 where id = ?3;"
+"UPDATE files SET digest = ?1, flags = ?2, nr_extents = ?4 where id = ?3;"
 	dbfile_prepare_stmt(update_scanned_file, UPDATE_SCANNED_FILE);
 
 #define	UPDATE_EXTENT_POFF						\
@@ -878,6 +889,23 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
  * mutually shared from their own pass - never need reloading. `grp` is the set
  * of qualifying groups (a member in range, and >1 member overall).
  */
+/*
+ * A generation window's whole-file duplicates: the members new this pass, plus
+ * the group's *target*.
+ *
+ * The target is computed here rather than chosen by the worker, from columns
+ * fixed at scan time, over every member of the group - not just this window's.
+ * That is what makes it the same file in every window (#197). It was previously
+ * min(id) among earlier members, with the first window free to elect someone
+ * else by live fiemap; the two disagreed, so a window could dedupe into a file
+ * that an overlapping earlier window was still relocating, stranding a cluster.
+ *
+ * Ranking: a read-only member first (the kernel will not write one, so it is
+ * the copy that must be the source), then fewest extents as of its scan, then
+ * lowest id to break ties. Every window sees the same rows, so every window
+ * reaches the same answer, and since the target is never a destination it never
+ * moves underneath anyone.
+ */
 #define GET_DUPLICATE_FILES							\
 "with grp(digest, size) as ( "							\
 "	select digest, size from files "				\
@@ -885,17 +913,21 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 "		select digest, size from files "				\
 "		where dedupe_seq > ?1 and dedupe_seq <= ?2 "			\
 "		and not (flags & 1)) "						\
-"	group by digest, size having count(*) > 1) "			\
-"select id, size, digest, filename, dedupe_seq from files "			\
-"where not (flags & 1) "						\
-"and (digest, size) in (select digest, size from grp) and ( "		\
-"	(dedupe_seq > ?1 and dedupe_seq <= ?2) "			\
-"	or id in ( "							\
-"		select min(id) from files "				\
-"		where dedupe_seq <= ?1 and not (flags & 1) "		\
-"		and (digest, size) in (select digest, size from grp) "	\
-"		group by digest, size)) "				\
-"order by (dedupe_seq > ?1), id;"
+"	group by digest, size having count(*) > 1), "			\
+"tgt(digest, size, fileid) as ( "					\
+"	select digest, size, id from ( "				\
+"		select digest, size, id, row_number() over ( "		\
+"			partition by digest, size "			\
+"			order by (flags & 2) desc, nr_extents, id) rn "	\
+"		from files where not (flags & 1) "			\
+"		and (digest, size) in (select digest, size from grp)) "	\
+"	where rn = 1) "							\
+"select f.id, f.size, f.digest, f.filename, f.dedupe_seq, "		\
+"       (f.id = t.fileid) as is_target "					\
+"from files f join tgt t on t.digest = f.digest and t.size = f.size "	\
+"where not (f.flags & 1) and ( "					\
+"	(f.dedupe_seq > ?1 and f.dedupe_seq <= ?2) or f.id = t.fileid) "	\
+"order by is_target desc, f.id;"
 	dbfile_prepare_stmt(get_duplicate_files, GET_DUPLICATE_FILES);
 
 #define GET_NONDUPE_EXTENTS						\
@@ -1875,7 +1907,8 @@ out_error:
 }
 
 int dbfile_update_scanned_file(struct dbhandle *db, int64_t fileid,
-				unsigned char *digest, unsigned int flags)
+				unsigned char *digest, unsigned int flags,
+				unsigned int nr_extents)
 {
 	int ret;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_scanned_file;
@@ -1890,6 +1923,10 @@ int dbfile_update_scanned_file(struct dbhandle *db, int64_t fileid,
 		goto bind_error;
 
 	ret = sqlite3_bind_int64(stmt, 3, fileid);
+	if (ret)
+		goto bind_error;
+
+	ret = sqlite3_bind_int64(stmt, 4, nr_extents);
 	if (ret)
 		goto bind_error;
 
@@ -2392,17 +2429,15 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		unsigned int seq;
 		bool is_anchor;
 
 		fileid = sqlite3_column_int64(stmt, 0);
 		size = sqlite3_column_int64(stmt, 1);
 		digest = (unsigned char *)sqlite3_column_blob(stmt, 2);
 		filename = sqlite3_column_text(stmt, 3);
-		seq = sqlite3_column_int64(stmt, 4);
-		/* A member from an earlier pass (seq <= seq_lo) is the anchor:
-		 * the group must keep it as target so copies keep converging. */
-		is_anchor = seq <= seq_lo;
+		/* The query elects the group's target and sorts it first; the
+		 * worker must not re-elect one (#197). */
+		is_anchor = sqlite3_column_int(stmt, 5) != 0;
 
 		file = filerec_find(fileid);
 		if (!file) {

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -296,7 +296,8 @@ int dbfile_store_block_hashes(struct dbhandle *db, int64_t fileid,
 int dbfile_store_extent_hashes(struct dbhandle *db, int64_t fileid,
 				uint64_t nb_hash, struct extent_csum *hashes);
 int dbfile_update_scanned_file(struct dbhandle *db, int64_t fileid,
-				unsigned char *digest, unsigned int flags);
+				unsigned char *digest, unsigned int flags,
+				unsigned int nr_extents);
 int dbfile_begin_trans(sqlite3 *db);
 int dbfile_commit_trans(sqlite3 *db);
 int dbfile_abort_trans(sqlite3 *db);

--- a/src/file_flags.h
+++ b/src/file_flags.h
@@ -13,4 +13,13 @@
  */
 #define FILE_INLINED		0x0001
 
+/*
+ * File lives in a read-only btrfs subvolume, as of the scan that recorded it.
+ * Stored so the dedupe phase can prefer such a file as a group's *source*
+ * without probing the filesystem: the choice has to be identical in every
+ * generation window or the windows disagree about the target (#197), and a
+ * live probe is not (a subvolume can be flipped mid-run).
+ */
+#define FILE_RO_SUBVOL		0x0002
+
 #endif

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -3037,6 +3037,12 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * once here rather than twice under the write lock below.
 	 */
 	bool inlined = is_inlined(&ctxt);
+	/*
+	 * Recorded now, while the fd is open, because the dedupe phase needs a
+	 * value that cannot change between its generation windows (#197). The
+	 * probe is cached per device, so this is a hash lookup per file.
+	 */
+	bool rdonly_subvol = filescan_fd_is_readonly_subvol(ctxt.fd);
 
 	tprogress->status = thread_waiting_lock;
 	dbfile_lock();
@@ -3071,7 +3077,9 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * of needless work: https://github.com/markfasheh/duperemove/issues/316
 	 */
 	ret = dbfile_update_scanned_file(db, file->fileid, file_digest,
-			inlined ? FILE_INLINED : 0);
+			(inlined ? FILE_INLINED : 0) |
+			(rdonly_subvol ? FILE_RO_SUBVOL : 0),
+			ctxt.fiemap->fm_mapped_extents);
 	if (ret) {
 		scan_write_abort();
 		dbfile_unlock();

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -358,56 +358,6 @@ static void clean_deduped(struct dupe_extents **ret_dext,
  * it to the front of the list; the loop below always dedupes against the first
  * entry. Extent-dedupe members are single extents, so this is skipped there.
  */
-static void pick_dedupe_target(struct dupe_extents *dext)
-{
-	struct extent *extent, *best = NULL;
-	unsigned int best_extents = 0;
-	bool best_rdonly = false;
-
-	list_for_each_entry(extent, &dext->de_extents, e_list) {
-		unsigned int n;
-		bool rdonly;
-
-		if (filerec_open(extent->e_file, true))
-			continue;
-		/* Count-only fiemap: we need the extent count, not the map. */
-		n = fiemap_count_extents(extent->e_file->fd, extent->e_loff,
-					 extent_len(extent));
-		/* n == 0 means the fiemap failed; ignore that candidate before
-		 * paying for anything else. */
-		if (!n) {
-			filerec_close(extent->e_file);
-			continue;
-		}
-		rdonly = filescan_fd_is_readonly_subvol(extent->e_file->fd);
-		filerec_close(extent->e_file);
-
-		/*
-		 * Rank on (read-only, then fewest extents).
-		 *
-		 * The kernel is happy to dedupe *into* a read-only subvolume -
-		 * content is byte-verified and never changes, only which
-		 * extents back it - and people rely on that to shrink snapshot
-		 * backups, so this is a preference and never a refusal. What it
-		 * buys: where the destination is reached through a read-only
-		 * *mount* the ioctl does fail (mnt_want_write_file), and
-		 * electing the read-only member as the source is the direction
-		 * that still works. It also leaves snapshots alone in favour of
-		 * rewriting the writable copy, which is the less surprising
-		 * outcome. Among equals the least-fragmented copy still wins.
-		 */
-		if (best == NULL || rdonly > best_rdonly ||
-		    (rdonly == best_rdonly && n < best_extents)) {
-			best = extent;
-			best_extents = n;
-			best_rdonly = rdonly;
-		}
-	}
-
-	if (best)
-		list_move(&best->e_list, &dext->de_extents);
-}
-
 /* Show this group on the thread's status line: target path (the group's first
  * member) plus the bytes the kernel still has to byte-verify as work total. */
 static void slot_show_group(struct pscan_thread *slot, struct dupe_extents *dext)
@@ -488,19 +438,15 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 	shared_prev = shared_post = 0ULL;
 
 	/*
-	 * Settle the target first: it is the head of the list, and everything
-	 * below is relative to it. Ordering matters - clean_deduped() culls
-	 * against the target, so a later reorder would leave it having culled
-	 * against the wrong one.
+	 * The target is the head of the list, and everything below is relative
+	 * to it - clean_deduped() culls against it, so nothing may reorder the
+	 * list from here on.
 	 *
-	 * Only for whole files, and only when the group has no anchor from an
-	 * earlier pass - an anchored group must keep its anchor (loaded first)
-	 * as target so every pass converges the copies onto the same physical
-	 * extent. See pick_dedupe_target() for how the target is chosen.
+	 * Whole-file groups get their target elected by the loader, from data
+	 * fixed at scan time, so that every generation window picks the same
+	 * one; electing it here from a live fiemap made windows disagree and
+	 * strand a cluster (#197). See GET_DUPLICATE_FILES.
 	 */
-	if (whole_file_dedup && !dext->de_anchored)
-		pick_dedupe_target(dext);
-
 	/*
 	 * Remove any extents which have already been deduped. This
 	 * will free dext for us if the number of available extents

--- a/tests/integration/test_cross_pass.py
+++ b/tests/integration/test_cross_pass.py
@@ -13,6 +13,8 @@ from harness import DuperemoveTest, requires_reflink, phys_extents, files_share
 
 @requires_reflink
 class CrossPassTest(DuperemoveTest):
+    # The new test below asserts on physical extent layout.
+    serial = True
     # tiny passes + small batchsize => the group appears in many passes
     ENV = {"DUPEREMOVE_FILES_PER_PASS": "8"}
     BOPT = ("-B", "4")
@@ -67,3 +69,50 @@ class CrossPassTest(DuperemoveTest):
         self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
         self.assertDmOk()
         self.assertNoNewSharing()
+
+    def test_target_is_the_least_fragmented_member_not_the_first(self):
+        """The least-fragmented copy is still preferred as the target.
+
+        Target election moved out of the worker's live fiemap and into the
+        loader, so that every generation window reaches the same answer (#197).
+        This guards the half of that change which is easy to lose silently: the
+        preference itself. Built so the two candidate rules disagree - the
+        lowest-id copy is deliberately the most fragmented - so a target chosen
+        by id alone would land somewhere this assertion can see.
+
+        It does *not* reproduce #197: three copies occupy a single window, and
+        the bug needs a group spread across two windows that are in flight
+        together. test_many_copies_converge_across_passes covers that, at the
+        cost of only failing when the race actually happens.
+        """
+        data = os.urandom(4 << 20)
+
+        # c000 first, and fragmented: many flushed writes force extent splits.
+        with open(self.path("tree/c000"), "wb") as f:
+            for off in range(0, len(data), 64 << 10):
+                f.write(data[off:off + (64 << 10)])
+                f.flush()
+                os.fsync(f.fileno())
+        # ... then two contiguous copies, so id order and extent order differ.
+        for name in ("c001", "c002"):
+            self.write(f"tree/{name}", data)
+        self.sync()
+
+        frag = len(phys_extents(self.path("tree/c000")))
+        tidy = len(phys_extents(self.path("tree/c001")))
+        self.assertGreater(frag, tidy,
+                           "setup failed: c000 was meant to be the fragmented one")
+        target_phys = phys_extents(self.path("tree/c001"))
+
+        self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)
+        self.assertDmOk()
+        self.sync()
+
+        landed = phys_extents(self.path("tree/c000"))
+        self.assertTrue(landed & target_phys,
+                        "copies converged onto the fragmented lowest-id copy "
+                        f"instead of the tidy one: {sorted(landed)} vs "
+                        f"{sorted(target_phys)}")
+        self.assertEqual(1, len({p for n in ("c000", "c001", "c002")
+                                 for p in phys_extents(self.path(f"tree/{n}"))}),
+                         "all three copies should share one extent")


### PR DESCRIPTION
Fixes #197.

A generation window could deduplicate a group onto storage that an overlapping earlier window was in the middle of vacating, stranding a cluster of copies on an extent nothing else references. The run reports full success — the savings are just smaller, permanently, since a later run resumes above the watermark and never revisits the group.

## Why the windows disagreed

The first window of a group has no anchor, so it elected a target with `pick_dedupe_target()`, ranking on a **live fiemap**. Every later window instead anchored on `min(id)`. Those name different files whenever the lowest-id copy is not the least fragmented — and then the `min(id)` copy is a *destination* in the first window, while `DEDUPE_MAX_INFLIGHT = 2` lets a later window target it mid-move. Traced on CI:

```
TRACE group members=7 anchored=0 target=.../c001 poff=13742080
TRACE group members=9 anchored=1 target=.../c000 poff=13660160   <- pre-move
TRACE group members=9 anchored=1 target=.../c000 poff=13742080   <- settled
```

## The fix

The whole scan finishes before dedupe starts, so **every window can already see every member of every group**. Rank them on data fixed at scan time and each window reaches the same answer with no communication — no persisted decision, no drain, no barrier — and the elected target is never a destination, so it never moves.

Two additive columns carry that data: the extent count as of the scan, and whether the file is in a read-only subvolume. An old hashfile gets `0`/unset and ranks by id, which is still stable, so there is no `DB_FILE_MINOR` bump and no forced rescan.

`pick_dedupe_target()` and its per-member open + fiemap go away.

## Measured

| | base | this PR |
|---|---|---|
| dedupe, 400 groups x 4 copies (2 MiB) | 2.01 s | 2.02 s |
| dedupe, 15 000 groups x 3 copies (8 KiB) | 2.55 s | 2.58 s |
| loader query, 518k-file hashfile | 0.081 s | 0.076 s |
| reclaimed, both workloads | identical | identical |

I predicted removing the fiemap would be a *win*. It is not — it is neutral. The count-only fiemap is cheap and the files are already open and cached. Reporting that rather than the prediction.

Convergence on the pathological cross-pass workload: **1 extent, 5 runs out of 5** (previously the shape that stranded 8 of 120 copies).

## The trade

The preference is now ranked over every member of a group rather than one window's, which is if anything better. Against that, it uses the layout as of the last scan where the old code re-measured — so for a file deduped in an earlier run the figure can be stale. Stability is what correctness requires here, and a stale ranking only picks a slightly worse target. Same for the read-only flag if a subvolume is flipped between runs, which per #182 is low-risk: the kernel deduplicates *into* read-only subvolumes happily; only a read-only mount refuses.

## Testing

New `test_target_is_the_least_fragmented_member_not_the_first` guards the half of this that is easy to lose silently — that the preference survived the move into SQL. **It does not reproduce #197** (three copies occupy one window; the bug needs two windows in flight together) and it passes on master too. The #197 coverage remains `test_many_copies_converge_across_passes`, which only fails when the race actually happens.

Gates: `scripts/verify.sh`, full `make integration-valgrind` (no findings), TSan and ASan/UBSan over unit and integration — 211 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)