### PR TITLE
progress: route messages to the caller's stream, not always stdout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -705,10 +705,16 @@ what belongs here is when it bites:
   drives a real pty and replays the stream through a small ANSI emulator:
   `tests/integration/test_progress_tty.py`. Its invariant — *no worker-slot row
   may survive the end of a run* — catches the whole class, not just this site.
-- **Known gap, not yet fixed:** a routed `eprintf` lands on **stdout**, because
-  `print_above_block()` only knows the stream the block lives on. So an error's
-  destination depends on whether a block happened to be up. Pre-existing; fixing
-  it means flushing across the two streams mid-redraw.
+- **Routing honors the caller's stream (#203).** `print_above_block()` takes the
+  `FILE *` and writes the message there, so an `eprintf` reaches stderr whether
+  or not a block was up (it used to always land on stdout, and `2>errors.log`
+  lost exactly the errors raised mid-run). The block itself is still stdout-only,
+  so the erase must be `fflush`ed before the message and the message flushed
+  before the redraw — otherwise the two streams' buffers interleave and the
+  message lands inside the block. Don't drop those flushes.
+  - Consequence for `--progress=json`: the JSON stream is **stderr**, so
+    diagnostics share it. That was already true for anything printed outside the
+    printer's lifetime; a consumer must skip lines that don't parse.
 
 ## Valgrind
 

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -470,6 +470,8 @@ The final line is
 \f[CR]{\(dqevent\(dq:\(dqdone\(dq,\(dqelapsed_sec\(dq:...,\(dqfiles_scanned\(dq:...,\(dqgroups_deduped\(dq:...,\(dqreclaimed_bytes\(dq:...}\f[R].
 Fields that are not yet known (an ETA, a rate) are omitted; a consumer
 reading a line at a time can ignore any line that is not valid JSON.
+Diagnostics share standard error with the stream (an unreadable file, a
+failed ioctl), so such lines do occur.
 .PP
 Combine with \f[B]\-q\f[R] to silence the human stdout too, e.g.
 \f[CR]oans \-qd \-\-progress=json \-\-hashfile=FILE /srv/data 2>progress.jsonl\f[R].

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -390,6 +390,8 @@ file is recorded once.
     `{"event":"done","elapsed_sec":...,"files_scanned":...,"groups_deduped":...,"reclaimed_bytes":...}`.
     Fields that are not yet known (an ETA, a rate) are omitted; a consumer
     reading a line at a time can ignore any line that is not valid JSON.
+    Diagnostics share standard error with the stream (an unreadable file, a
+    failed ioctl), so such lines do occur.
 
     Combine with **-q** to silence the human stdout too, e.g.
     `oans -qd --progress=json --hashfile=FILE /srv/data 2>progress.jsonl`.

--- a/src/progress.c
+++ b/src/progress.c
@@ -1194,12 +1194,13 @@ void pscan_slot_waiting(struct pscan_thread *slot, bool waiting)
 
 /* Erase the live block, print where it sat (that row becomes scrollback), then
  * redraw the block below the message. */
-static void print_above_block(const char *fmt, va_list args)
+static void print_above_block(FILE *stream, const char *fmt, va_list args)
 {
-	/* JSON mode draws no block (and the progress stream is on stderr), so a
-	 * routed message is just a plain stdout print. */
+	/* JSON mode draws no block, so a routed message is just a plain print
+	 * on the caller's stream. */
 	if (progress_json) {
-		vfprintf(stdout, fmt, args);
+		vfprintf(stream, fmt, args);
+		fflush(stream);
 		return;
 	}
 
@@ -1209,7 +1210,16 @@ static void print_above_block(const char *fmt, va_list args)
 	progress_wipe();
 	drawn_lines = 0;
 
-	vfprintf(stdout, fmt, args);
+	/*
+	 * The block lives on stdout; `stream` may be another descriptor pointing
+	 * at the same tty. Flush the erase before writing the message, or the
+	 * two streams' buffers interleave and the message lands inside the block
+	 * it was supposed to replace. When stderr is redirected instead, the
+	 * erase+redraw is a harmless wipe/redraw cycle on the tty.
+	 */
+	fflush(stdout);
+	vfprintf(stream, fmt, args);
+	fflush(stream);
 
 	print_progress();
 	g_mutex_unlock(&pscan.mutex);
@@ -1217,8 +1227,10 @@ static void print_above_block(const char *fmt, va_list args)
 
 /*
  * Print a message without disturbing the live block (see block_live()). The
- * message lands above the block and scrolls away as history; `stream` is used
- * only when there is no block to work around.
+ * message lands above the block and scrolls away as history, and always on the
+ * caller's `stream`: routing used to force every message to stdout, so whether
+ * an eprintf() reached stderr depended on whether a block happened to be up,
+ * and `2>errors.log` silently lost exactly the errors raised mid-run (#203).
  *
  * Two states count as "a block to work around", and missing either one is what
  * #179 was: a printer thread is animating it, *or* one is simply sitting there
@@ -1237,7 +1249,7 @@ void progress_printf(FILE *stream, const char *fmt, ...)
 
 	va_start(args, fmt);
 	if (printer || block_live())
-		print_above_block(fmt, args);
+		print_above_block(stream, fmt, args);
 	else
 		vfprintf(stream, fmt, args);
 	va_end(args);

--- a/tests/integration/test_progress_json.py
+++ b/tests/integration/test_progress_json.py
@@ -9,6 +9,7 @@ output. This lets scheduled and non-interactive runs be monitored.
 import json
 import os
 import subprocess
+import unittest
 
 from harness import DuperemoveTest, requires_reflink, DUPEREMOVE
 
@@ -145,6 +146,29 @@ class ProgressJsonTest(DuperemoveTest):
         self.assertNotIn("⣿".encode(), out)  # ⣿, a filled bar cell
         # The JSON stream, ending with a done event, is on stderr.
         self.assertIn('"event":"done"', err)
+
+    @unittest.skipIf(os.geteuid() == 0,
+                     "running as root defeats the chmod 000 unreadable file")
+    def test_errors_go_to_stderr_not_the_report_stream(self):
+        """A mid-run error must not land on stdout in JSON mode either (#203).
+
+        The progress printer runs for the whole run here, so every message is
+        routed - which used to mean forced onto stdout, mixing diagnostics into
+        the stream that carries the human/compat report.
+        """
+        for i in range(4):
+            self.mkdup(f"tree/a{i}", f"tree/b{i}", 200_000)
+        os.chmod(self.mkrand("tree/locked.bin", 65536), 0)
+        d = os.path.join(self.work, "tree")
+
+        p = subprocess.run(
+            [DUPEREMOVE, "--io-threads=4", "--hashfile", self.hf,
+             "--progress=json", "-rd", d],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.assertEqual(p.returncode, 0)
+        self.assertIn("while opening file", p.stderr)
+        self.assertNotIn("while opening file", p.stdout)
+        self.assertNotIn("locked.bin", p.stdout)
 
     def test_invalid_progress_value_is_rejected(self):
         p = subprocess.run(

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -32,11 +32,20 @@ _CSI = re.compile(rb"\x1b\[([0-9;?]*)([A-Za-z])")
 _ANSI_TEXT = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
-def _run_in_pty(argv, env=None):
-    """Run argv on a COLS x ROWS pty; return its raw output bytes."""
+def _run_in_pty(argv, env=None, stderr_path=None):
+    """Run argv on a COLS x ROWS pty; return its raw output bytes.
+
+    With `stderr_path`, the child's stderr is redirected to that file while
+    stdout stays on the pty - the `2>errors.log` case of #203.
+    """
     pid, fd = pty.fork()
     if pid == 0:                                  # child
         try:
+            if stderr_path is not None:
+                efd = os.open(stderr_path,
+                              os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+                os.dup2(efd, 2)
+                os.close(efd)
             os.execvpe(argv[0], argv, os.environ if env is None else env)
         finally:                                  # execvp raises, never returns
             os._exit(127)
@@ -180,6 +189,41 @@ class ProgressTtyTest(DuperemoveTest):
         self.assertTrue(
             any("2 permission denied" in ln for ln in screen),
             f"the scan-skip report was erased by the block:\n  {shown}")
+
+    def test_routed_errors_follow_the_redirected_stderr(self):
+        """`2>errors.log` must catch errors raised while a block is live (#203).
+
+        An unreadable file fails open() inside a csum worker, so its eprintf is
+        raised mid-hash with the block on screen - precisely the messages that
+        used to be forced onto stdout and vanish from the redirect.
+        """
+        for i in range(8):
+            self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 256 * 1024)
+        for i in range(2):
+            os.chmod(self.mkrand(f"tree/locked/{i}.bin", 64 * 1024), 0)
+        tree = os.path.join(self.work, "tree")
+        errlog = os.path.join(self.work, "errors.log")
+
+        raw = _run_in_pty([DUPEREMOVE, "-dr", "--hashfile", self.hf, tree],
+                          stderr_path=errlog)
+        with open(errlog, encoding="utf-8", errors="replace") as f:
+            errors = f.read()
+        screen = "\n  ".join(_render(raw))
+
+        for i in range(2):
+            self.assertIn(f"{i}.bin", errors,
+                          f"the open error never reached stderr:\n{errors}")
+        self.assertIn("while opening file", errors)
+        self.assertNotIn("while opening file", screen,
+                         f"a redirected error was still printed to the tty:"
+                         f"\n  {screen}")
+
+        # The block still cleans up around the routed message, and stdout keeps
+        # the report that is genuinely stdout's (the #179 invariant).
+        stranded = [ln for ln in _render(raw) if WORKER_ROW.match(ln)]
+        self.assertEqual([], stranded,
+                         f"worker rows left on screen:\n  {screen}")
+        self.assertIn("2 permission denied", screen)
 
     # Depends on hashing outlasting one REDRAW_MS (100 ms) tick, so the row
     # exists at a redraw. Kept CPU-bound (4K blocks, partial mode) rather than


### PR DESCRIPTION
Fixes #203.

## Problem

`eprintf` is `progress_printf(stderr, …)`, but when a progress block was live, `progress_printf()` routed through `print_above_block()`, which wrote to stdout unconditionally — the `stream` argument was honored only on the no-block path. So an error's destination depended on whether a block happened to be on screen: `oans -dr … 2>errors.log` silently lost exactly the errors raised mid-run, and in `--progress=json` mode diagnostics were pushed onto stdout, which carries the human/compat report.

## Fix

`print_above_block()` takes the `FILE *` and writes the message there.

The block itself still lives on stdout, so ordering matters when stderr is the same tty: `fflush(stdout)` after the erase, `vfprintf(stream, …)`, `fflush(stream)`, then redraw. Without those the two streams' buffers interleave and the message lands inside the block it was supposed to replace. When stderr is redirected, the erase+redraw is a harmless wipe/redraw cycle on the tty. Visual behavior is unchanged in the same-tty case.

All callers go through the `dprintf`/`vprintf`/`qprintf`/`eprintf` macros, so no call sites changed.

## Note on `--progress=json`

The issue assumed the JSON stream is stdout; it is **stderr** (`--progress=json` leaves stdout to the human/compat output — see the man page). So the acceptance criterion "stdout is pure JSON" reads instead as *stdout stays free of diagnostics*, which is what the new test asserts. Errors now land on stderr alongside the JSON records. That was already the case for anything printed outside the progress printer's lifetime, so this makes the behavior consistent rather than introducing a new class; the man page already told consumers to skip lines that don't parse, and now says why they occur.

## Tests

Both fail on `v1.10.1` and pass here:

- `test_progress_tty.py::test_routed_errors_follow_the_redirected_stderr` — real pty with stderr redirected to a file, `chmod 000` files failing `open()` inside a csum worker (so the eprintf is raised with the block live). Asserts the errors are in the file and *not* in the pty stream, plus the existing #179 invariant (no stranded worker rows) and that the stdout-owned skip report still appears. `_run_in_pty()` grew an optional `stderr_path`.
- `test_progress_json.py::test_errors_go_to_stderr_not_the_report_stream` — same forced error under `--progress=json`; error text on stderr, absent from stdout.

## Gate

`scripts/verify.sh` green (build with warnings-as-failure, 213 tests, valgrind smoke). `make doc` regenerated cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)