### PR TITLE
scan: add --max-filesize, the mirror of --min-filesize

### DIFF
--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -177,6 +177,25 @@ Trees full of tiny files scan much faster this way, since such files
 rarely dedupe usefully.
 Default \f[B]1\f[R], which skips only empty files.
 .TP
+\f[B]\-\-max\-filesize\f[R]=\f[I]SIZE\f[R]
+Skip regular files larger than \f[I]SIZE\f[R] bytes (suffixes
+\f[CR]K\f[R]/\f[CR]M\f[R]/\f[CR]G\f[R] accepted).
+By default there is no upper bound.
+Use it to leave VM images or backup archives to other tooling, or to
+bound the worst\-case time spent on a single file.
+A file of exactly \f[I]SIZE\f[R] bytes is still scanned.
+It is an error to give a \f[I]SIZE\f[R] below
+\f[B]\-\-min\-filesize\f[R], since nothing could then be scanned.
+.RS
+.PP
+Like \f[B]\-\-min\-filesize\f[R], this shapes only what is
+\f[I]scanned\f[R].
+A file hashed by an earlier run and excluded by a later
+\f[B]\-\-max\-filesize\f[R] keeps its rows until it is deleted from disk
+\(em pruning is by existence, not by whether a run covered the file \(em
+so it is simply not re\-scanned, and never re\-deduped.
+.RE
+.TP
 \f[B]\-\-skip\-zeroes\f[R]
 Detect and skip all\-zero blocks while reading.
 Speeds up scanning of sparse or zero\-filled data, at the cost of not

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -146,6 +146,24 @@ file is recorded once.
     accepted). Trees full of tiny files scan much faster this way, since such
     files rarely dedupe usefully. Default **1**, which skips only empty files.
 
+<!-- Keep the blank line between this term and its `~` body below: without it
+     pandoc >=3.9 collapses this multi-paragraph definition into a single block. -->
+**\--max-filesize**=*SIZE*
+
+  ~ Skip regular files larger than *SIZE* bytes (suffixes `K`/`M`/`G`
+    accepted). By default there is no upper bound. Use it to leave VM images or
+    backup archives to other tooling, or to bound the worst-case time spent on
+    a single file. A file of exactly *SIZE* bytes is still scanned. It is an
+    error to give a *SIZE* below **\--min-filesize**, since nothing could then
+    be scanned.
+
+    <!-- -->
+
+    Like **\--min-filesize**, this shapes only what is *scanned*. A file hashed
+    by an earlier run and excluded by a later **\--max-filesize** keeps its rows
+    until it is deleted from disk — pruning is by existence, not by whether a
+    run covered the file — so it is simply not re-scanned, and never re-deduped.
+
 **\--skip-zeroes**
   ~ Detect and skip all-zero blocks while reading. Speeds up scanning of sparse
     or zero-filled data, at the cost of not deduplicating runs of zeroes.

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1303,7 +1303,8 @@ int dbfile_store_scan_config(struct dbhandle *dbh, const struct scan_config *sc)
 	    (ret = sync_config_int(stmt, "opt_only_whole_files", sc->only_whole_files)) ||
 	    (ret = sync_config_int(stmt, "opt_do_block_hash", sc->do_block_hash)) ||
 	    (ret = sync_config_int(stmt, "opt_dedupe_same_file", sc->dedupe_same_file)) ||
-	    (ret = sync_config_int(stmt, "opt_min_filesize", (int64_t)sc->min_filesize)))
+	    (ret = sync_config_int(stmt, "opt_min_filesize", (int64_t)sc->min_filesize)) ||
+	    (ret = sync_config_int(stmt, "opt_max_filesize", (int64_t)sc->max_filesize)))
 		goto err;
 
 	ret = replace_string_rows(db,
@@ -1408,6 +1409,18 @@ int dbfile_load_scan_config(struct dbhandle *dbh, struct scan_config *sc)
 		if (ret)
 			return ret;
 		sc->min_filesize = (uint64_t)mfs;
+
+		/*
+		 * Additive key: a hashfile written before --max-filesize
+		 * existed has no row, and get_config_int64() then leaves the
+		 * caller's value alone - 0, "no upper bound", which is the
+		 * behaviour those runs had.
+		 */
+		mfs = 0;
+		ret = get_config_int64(stmt, "opt_max_filesize", &mfs);
+		if (ret)
+			return ret;
+		sc->max_filesize = (uint64_t)mfs;
 	}
 
 	ret = load_string_rows(db, "select path from scan_roots order by rowid;",

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -165,6 +165,7 @@ struct scan_config {
 	int		do_block_hash;
 	int		dedupe_same_file;
 	uint64_t	min_filesize;
+	uint64_t	max_filesize;	/* 0 = no upper bound */
 	char		**roots;
 	int		nroots;
 	char		**excludes;

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -192,6 +192,7 @@ static const struct {
 	[SCAN_SKIP_UNSUPPORTED_FS]= { "unsupported_fs",	"unsupported filesystem", true },
 	[SCAN_SKIP_EXCLUDED]	  = { "excluded",	"excluded",		false },
 	[SCAN_SKIP_TOO_SMALL]	  = { "too_small",	"below --min-filesize",	false },
+	[SCAN_SKIP_TOO_LARGE]	  = { "too_large",	"above --max-filesize",	false },
 	[SCAN_SKIP_NOT_REGULAR]	  = { "not_regular",	"not a regular file",	false },
 	[SCAN_SKIP_READONLY_SUBVOL] = { "readonly_subvol",
 					"read-only subvolume",		false },
@@ -1053,6 +1054,14 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		vprintf("Skipping file below --min-filesize: %s (%llu < %"PRIu64")\n",
 			path, st->stx_size, options.min_filesize);
 		filescan_count_skip(SCAN_SKIP_TOO_SMALL);
+		return false;
+	}
+
+	if (S_ISREG(st->stx_mode) && options.max_filesize &&
+	    st->stx_size > options.max_filesize) {
+		vprintf("Skipping file above --max-filesize: %s (%llu > %"PRIu64")\n",
+			path, st->stx_size, options.max_filesize);
+		filescan_count_skip(SCAN_SKIP_TOO_LARGE);
 		return false;
 	}
 

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -75,6 +75,7 @@ enum scan_skip_bucket {
 	SCAN_SKIP_UNSUPPORTED_FS,	/* not btrfs/XFS, or a foreign fs */
 	SCAN_SKIP_EXCLUDED,		/* --exclude matched */
 	SCAN_SKIP_TOO_SMALL,		/* below --min-filesize */
+	SCAN_SKIP_TOO_LARGE,		/* above --max-filesize */
 	SCAN_SKIP_NOT_REGULAR,		/* neither a regular file nor a directory */
 	SCAN_SKIP_READONLY_SUBVOL,	/* read-only btrfs subvolume, see #156 */
 	SCAN_SKIP__COUNT

--- a/src/oans.c
+++ b/src/oans.c
@@ -124,6 +124,8 @@ static char *scan_config_options_str(const struct scan_config *sc)
 		g_string_append(s, "--skip-readonly-subvols ");
 	if (sc->min_filesize > 1)
 		g_string_append_printf(s, "--min-filesize=%"PRIu64" ", sc->min_filesize);
+	if (sc->max_filesize)
+		g_string_append_printf(s, "--max-filesize=%"PRIu64" ", sc->max_filesize);
 
 	if (sc->only_whole_files)
 		dtok[nd++] = "only_whole_files";
@@ -769,6 +771,7 @@ enum {
 	BATCH_SIZE_OPTION,
 	NO_COLOR_OPTION,
 	MIN_FILESIZE_OPTION,
+	MAX_FILESIZE_OPTION,
 	STATS_OPTION,
 	PRUNE_BLOCKS_OPTION,
 	HISTORY_OPTION,
@@ -838,6 +841,7 @@ static void help(void)
 "  -b SIZE                     hashing block size, 4K-1M (default 128K)\n"
 "  -B, --batchsize=N           dedupe every N scanned files (default 1024)\n"
 "  -m, --min-filesize=SIZE     skip files smaller than SIZE (default 1)\n"
+"      --max-filesize=SIZE     skip files larger than SIZE (default: no limit)\n"
 "      --skip-zeroes           detect and skip all-zero blocks\n"
 "      --exclude=PATTERN       exclude matching paths (may be repeated)\n"
 "      --dedupe-options=OPT    [no]same, [no]partial, [no]only_whole_files\n"
@@ -894,6 +898,7 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 		{ "batchsize", 1, NULL, BATCH_SIZE_OPTION },
 		{ "no-color", 0, NULL, NO_COLOR_OPTION },
 		{ "min-filesize", 1, NULL, MIN_FILESIZE_OPTION },
+		{ "max-filesize", 1, NULL, MAX_FILESIZE_OPTION },
 		{ "stats", 0, NULL, STATS_OPTION },
 		{ "prune-block-hashes", 0, NULL, PRUNE_BLOCKS_OPTION },
 		{ "history", 0, NULL, HISTORY_OPTION },
@@ -1011,6 +1016,13 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 				return EINVAL;
 			}
 			break;
+		case MAX_FILESIZE_OPTION:
+			options.max_filesize = parse_size(optarg);
+			if (options.max_filesize == 0) {
+				eprintf("Error: --max-filesize must be greater than zero\n");
+				return EINVAL;
+			}
+			break;
 		case EXCLUDE_OPTION:
 			/*
 			 * A rejected pattern is a typo in the command line, and
@@ -1063,6 +1075,13 @@ static int parse_options(int argc, char **argv, int *filelist_idx)
 	*filelist_idx = optind;
 	if (numfiles == 1 && strcmp(argv[optind], "-") == 0)
 		stdin_filelist = 1;
+
+	if (options.max_filesize && options.max_filesize < options.min_filesize) {
+		eprintf("Error: --max-filesize (%"PRIu64") is below "
+			"--min-filesize (%"PRIu64"); no file could be "
+			"scanned.\n", options.max_filesize, options.min_filesize);
+		return 1;
+	}
 
 	/* -L/-R/--stats/--history/--json are mutually exclusive report modes. */
 	unsigned int report_count = list_only_opt + rm_only_opt + stats_only_opt
@@ -1628,6 +1647,7 @@ static int apply_scan_config(const struct scan_config *sc)
 	options.do_block_hash = sc->do_block_hash;
 	options.dedupe_same_file = sc->dedupe_same_file;
 	options.min_filesize = sc->min_filesize;
+	options.max_filesize = sc->max_filesize;
 
 	/*
 	 * A stored pattern that no longer parses must stop the run, for the
@@ -1751,6 +1771,7 @@ static void persist_scan_config(struct dbhandle *db, char **roots, int nroots)
 	sc.do_block_hash = options.do_block_hash;
 	sc.dedupe_same_file = options.dedupe_same_file;
 	sc.min_filesize = options.min_filesize;
+	sc.max_filesize = options.max_filesize;
 	sc.roots = abs;
 	sc.excludes = user_excludes;
 	sc.nexcludes = n_user_excludes;

--- a/src/opt.c
+++ b/src/opt.c
@@ -25,4 +25,5 @@ struct options options = {
 	.dedupe_same_file = true,
 	.batch_size = 1024,
 	.min_filesize = 1,	/* default: only skip empty files */
+	.max_filesize = 0,	/* default: no upper bound */
 };

--- a/src/opt.h
+++ b/src/opt.h
@@ -46,6 +46,7 @@ struct options {
 	unsigned int batch_size;
 	char *hashfile;
 	uint64_t min_filesize;	/* skip regular files smaller than this */
+	uint64_t max_filesize;	/* skip regular files larger than this; 0 = no limit */
 	bool progress_json : 1;	/* stream JSONL progress to stderr, no ANSI UI */
 };
 

--- a/tests/integration/test_max_filesize.py
+++ b/tests/integration/test_max_filesize.py
@@ -1,0 +1,77 @@
+"""--max-filesize skips regular files above the threshold (the mirror of
+--min-filesize); the default (no limit) skips nothing.
+
+The bound is exclusive on both sides - a file *at* the limit is scanned, the
+same way --min-filesize keeps a file at exactly the floor.
+"""
+
+import os
+
+from harness import DuperemoveTest
+
+
+class MaxFilesizeTest(DuperemoveTest):
+    def _seed(self):
+        self.write("tree/small", b"x" * 500)
+        self.mkrand("tree/huge", 200000)
+        return self.path("tree")
+
+    def _scan_paths(self, *extra):
+        """Scan the seeded tree and return the basenames it stored."""
+        self.scan(self._seed(), *extra)
+        self.assertDmOk()
+        return sorted(os.path.basename(r[0])
+                      for r in self.hf_query("select filename from files"))
+
+    def test_default_has_no_upper_bound(self):
+        self.assertEqual(["huge", "small"], self._scan_paths())
+
+    def test_skips_above_threshold(self):
+        self.assertEqual(["small"], self._scan_paths("--max-filesize", "1K"))
+
+    def test_suffix_is_parsed(self):
+        # 1M is above both files, so the option is a no-op - which is the point:
+        # it proves the suffix parsed rather than landing on some tiny value.
+        self.assertEqual(["huge", "small"],
+                         self._scan_paths("--max-filesize", "1M"))
+
+    def test_boundary_is_exclusive(self):
+        # A file of exactly SIZE bytes is kept; one byte more is not.
+        self.write("t/at", b"y" * 4096)
+        self.write("t/over", b"y" * 4097)
+        self.scan(self.path("t"), "--max-filesize", "4096")
+        self.assertDmOk()
+        self.assertEqual(
+            ["at"], sorted(os.path.basename(r[0])
+                           for r in self.hf_query("select filename from files")))
+
+    def test_below_min_filesize_is_rejected(self):
+        self.scan(self._seed(), "--max-filesize", "1K", "--min-filesize", "2K")
+        self.assertNotEqual(self.rc, 0)
+        self.assertIn("--max-filesize", self.out)
+        self.assertIn("--min-filesize", self.out)
+
+    def test_zero_is_rejected(self):
+        self.scan(self._seed(), "--max-filesize", "0")
+        self.assertNotEqual(self.rc, 0)
+        self.assertIn("--max-filesize", self.out)
+
+    def test_the_skip_is_accounted_for(self):
+        # Its own bucket, reported like --min-filesize's: a config choice, not
+        # an error, so it must not land in the problem count.
+        self.dm("-r", "--max-filesize=1K", "-v", self._seed(), quiet=False)
+        self.assertDmOk()
+        self.assertIn("above --max-filesize", self.out)
+
+    def test_replay_applies_the_stored_limit(self):
+        # Stored like --min-filesize, so a bare replay honours it: the second
+        # run must not pick the big file up.
+        d = self._seed()
+        self.dm("-r", "--max-filesize=1K", d)
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"))
+
+        self.mkrand("tree/huge2", 200000)
+        self.dm()                                  # bare replay
+        self.assertDmOk()
+        self.assertEqual(1, self.hf_count("files"))

--- a/tests/integration/test_self_describing.py
+++ b/tests/integration/test_self_describing.py
@@ -56,6 +56,7 @@ class SelfDescribingConfigTest(DuperemoveTest):
         # adding a new one without wiring persist_scan_config fails here.
         d = self._seed_tree(contents=b"x" * 16384)
         self.dm("-rd", "--skip-zeroes", "--min-filesize=8192",
+                "--max-filesize=1M",
                 "--dedupe-options=nosame,only_whole_files", d)
         self.assertDmOk()
         self.assertEqual(self._opt("opt_run_dedupe"), 1)
@@ -65,6 +66,7 @@ class SelfDescribingConfigTest(DuperemoveTest):
         self.assertEqual(self._opt("opt_dedupe_same_file"), 0)   # nosame
         self.assertEqual(self._opt("opt_do_block_hash"), 0)      # not requested
         self.assertEqual(self._opt("opt_min_filesize"), 8192)
+        self.assertEqual(self._opt("opt_max_filesize"), 1024 * 1024)
 
     def test_bare_run_without_stored_config_errors(self):
         # Fresh hashfile, no arguments: nothing to replay.


### PR DESCRIPTION
Closes #204.

Skip regular files larger than *SIZE*. Default `0` = no upper bound, so a run that doesn't ask for it is unchanged.

## What was touched

Mirrors `--min-filesize` at every point the issue lists:

| | |
|---|---|
| `src/opt.{h,c}` | `uint64_t max_filesize`, default `0` |
| `src/oans.c` | `--max-filesize=SIZE` long option via `parse_size()`, usage line, replay copy/store, replayed-options summary string |
| `src/file_scan.{c,h}` | symmetric size check next to min's, and its own `SCAN_SKIP_TOO_LARGE` bucket |
| `src/dbfile.{c,h}` | `opt_max_filesize` store/load |
| `docs/man/oans.md` | entry next to `--min-filesize` (multi-paragraph, so with the blank line + `<!-- -->` guard); `make doc` regenerated |

**No `DB_FILE_MINOR` bump** — `opt_max_filesize` is additive. An old hashfile has no such row, `get_config_int64()` leaves the caller's value alone, and the default `0` is exactly the behavior those runs had. An old binary ignores the extra key.

## Two judgment calls

- **Its own skip bucket** rather than folding into `too_small`. Both are non-error buckets (a config choice doing its job), so they stay out of the problem count, but "812 skipped" is only readable if it says which knob did it.
- **`--max-filesize` below `--min-filesize` is rejected** at parse time. The alternative — scanning zero files and exiting 0 — is the silent-misconfiguration failure mode `--exclude` matching nothing already warns about.

Boundary matches min's: the comparison is `>`, so a file of exactly *SIZE* bytes is scanned (min uses `<`, keeping a file at exactly the floor).

The semantics note from the issue is documented, not "fixed": a file hashed earlier and later excluded keeps its rows until it is deleted, because pruning is deliberately stat-based (`test_prune_is_stat_based_not_scope_based`). Same as `--min-filesize` today.

## Tests

New `tests/integration/test_max_filesize.py`: default is unbounded, skips above the threshold, `10M`-style suffix parsing end to end, the exclusive boundary (4096 kept / 4097 skipped), `max < min` rejected, `0` rejected, the skip is reported under `-v`, and a bare `--hashfile` replay applies the stored limit.

`test_self_describing.py::test_all_sticky_options_round_trip` — the backstop that fails when a new scan-shaping option isn't persisted — extended to cover it.

## Gate

`scripts/verify.sh` green (219 tests, valgrind smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)