### PR TITLE
Escape control characters in every printed file name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,18 +410,34 @@ the admin's terminal, so **every path oans prints goes through
 the UTF-8 C1 controls become `\t`/`\n`/`\r`/`\xNN`. A `\r` in a name rewrites
 the line above it (the summary, a progress row); `ESC[2J` clears the screen.
 
+- **`make lint` enforces it — `scripts/lint-escape.py`.** The rule is otherwise
+  prose, and prose rots: it was violated **eleven** times in the commit that
+  introduced it, three found by review and eight more by the lint. It flags a
+  path-shaped identifier passed to a printf-family macro; waive with
+  `escape-ok: <why>` (the only legitimate reason so far is the hashfile path,
+  which is oans's own argument rather than something found in a walk). Modelled
+  on `lint-longpath.py`, and wired into the same `make lint` CI job.
 - **Escape at the print site, never in the stored string.** The path is what
   oans opens, stats and stores; only the display copy is escaped. The idiom is
-  `_cleanup_(freep) char *disp = path_for_display(p);` then `disp ? disp : p` —
-  deliberately not a macro, since a `_cleanup_` inside a statement expression is
-  freed before the `printf` reads it.
-- **On the hot path, allocate inside the branch that prints.** `check_file()`
-  runs per file; `probe_fs()` runs per root, so it escapes once at the top.
-- Worst-case expansion is `SANITIZE_CTRL_MAX` (4) bytes per input byte — both
-  fixed-buffer callers (the progress row, `print_dupes_table`) size for it.
-  `sanitize_ctrl()` truncates at the last *complete* escape, never half of one.
-- `--json` (`print_json_str`) escapes the same set as `\u00NN`; that is the
-  supported machine-readable output, so nothing there is left raw either.
+  `declare_display_path(disp, p);` then print `disp` — a *declaration* macro, in
+  the shape of `declare_alloc_tracking()`. It cannot be a statement expression
+  (`({ ... })` ends the cleanup scope, so the string is freed before `printf`
+  reads it) and it cannot use a fixed thread-local buffer like `pretty_size()`
+  does, because a path may exceed `PATH_MAX` (#117) and a truncated one names a
+  different file.
+- **On the hot path, escape inside the branch that prints, under the same guard
+  the print macro has.** `check_file()` and `is_excluded()` run per directory
+  entry, so their `-v` skip messages sit inside `if (verbose)` — `vprintf`'s own
+  guard is too late, the allocation would already have happened. `probe_fs()`
+  runs per root, so it escapes once at the top.
+- **One classifier, many renderings.** `ctrl_seq_len()` is the single definition
+  of *which* bytes are dangerous; `sanitize_ctrl()` spells them `\xNN` and
+  `print_json_str()` spells them `\u00NN`. Adding U+2028 or another C1 encoding
+  is then one edit, not two that can drift.
+- Every real name takes the `has_ctrl()` fast path — one exact-sized `strdup`
+  instead of a 4x over-allocation and a per-byte loop — and the progress row
+  skips the copy entirely. Worst-case expansion is `SANITIZE_CTRL_MAX` (4) bytes
+  per input byte; `sanitize_ctrl()` truncates at the last *complete* escape.
 - Pinned by `tests/integration/test_escape_names.py` (non-tty, asserts no raw
   `\x1b`/`\r`/`\x07`/`\x7f` reaches either stream in any report mode) and
   `test_progress_tty.py::test_a_crafted_name_cannot_inject_ansi_into_the_block`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,32 @@ roots are known (`apply_storage_defaults()` in `oans.c`).
   timer, replaying the stored config. Guide: `docs/nas-quickstart.md`.
 - The `fdupes` mode was **removed** — don't reintroduce it.
 
+## File names are untrusted input (#202)
+
+Anyone who can create a file inside a scanned tree picks bytes oans writes to
+the admin's terminal, so **every path oans prints goes through
+`sanitize_ctrl()`/`path_for_display()`** (`src/util.c`) — C0 controls, DEL and
+the UTF-8 C1 controls become `\t`/`\n`/`\r`/`\xNN`. A `\r` in a name rewrites
+the line above it (the summary, a progress row); `ESC[2J` clears the screen.
+
+- **Escape at the print site, never in the stored string.** The path is what
+  oans opens, stats and stores; only the display copy is escaped. The idiom is
+  `_cleanup_(freep) char *disp = path_for_display(p);` then `disp ? disp : p` —
+  deliberately not a macro, since a `_cleanup_` inside a statement expression is
+  freed before the `printf` reads it.
+- **On the hot path, allocate inside the branch that prints.** `check_file()`
+  runs per file; `probe_fs()` runs per root, so it escapes once at the top.
+- Worst-case expansion is `SANITIZE_CTRL_MAX` (4) bytes per input byte — both
+  fixed-buffer callers (the progress row, `print_dupes_table`) size for it.
+  `sanitize_ctrl()` truncates at the last *complete* escape, never half of one.
+- `--json` (`print_json_str`) escapes the same set as `\u00NN`; that is the
+  supported machine-readable output, so nothing there is left raw either.
+- Pinned by `tests/integration/test_escape_names.py` (non-tty, asserts no raw
+  `\x1b`/`\r`/`\x07`/`\x7f` reaches either stream in any report mode) and
+  `test_progress_tty.py::test_a_crafted_name_cannot_inject_ansi_into_the_block`.
+  A test that only checks a plain name proves nothing — assert on the *bytes*,
+  with `text=False`.
+
 ## --exclude matching (src/glob.{c,h})
 
 `.gitignore` syntax — the one git/ripgrep/fd use — not POSIX `fnmatch`. Bare

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,16 @@ integration-valgrind: oans
 	fi; \
 	echo "valgrind: no findings"
 
-# Guard the long-path invariant (#117): no syscall may take a scanned file's
-# path as a single argument, or it silently ENAMETOOLONGs and drops the file.
-# See scripts/lint-longpath.py for the waiver syntax.
+# Source invariants that a compiler cannot express, each with its own waiver
+# syntax (see the scripts):
+#   longpath (#117) - no syscall may take a scanned file's path as a single
+#     argument, or it silently ENAMETOOLONGs and the file is dropped;
+#   escape (#202) - no scanned file's name may be printed unescaped, or a
+#     crafted name rewrites the terminal.
 .PHONY: lint
 lint:
 	@python3 scripts/lint-longpath.py
+	@python3 scripts/lint-escape.py
 
 .PHONY: check
 check: lint test integration

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -524,6 +524,22 @@ This \f[I]N\f[R] is a lower\-level fiemap diagnostic \(em the change in
 bytes the filesystem reports as shared \(em and counts the surviving
 copy as shared too, so for pairs it is about twice \f[B]Reclaimed\f[R].
 Scripts that parsed this line from upstream duperemove continue to work.
+.SS File names in output
+A file name is untrusted input: anyone who can create a file inside a
+scanned tree chooses bytes that \f[CR]oans\f[R] then writes to your
+terminal.
+So wherever a path is printed \(em reports, the \f[B]\-L\f[R] listing,
+\f[B]\-\-stats\f[R], error messages and the live progress display \(em
+control characters in it are escaped: tab, newline and carriage return
+as \f[CR]\(rst\f[R], \f[CR]\(rsn\f[R], \f[CR]\(rsr\f[R], every other C0
+control, DEL and the C1 controls as \f[CR]\(rsxNN\f[R].
+Valid UTF\-8 is untouched, so ordinary names print exactly as they are.
+Escaping is unconditional, whether or not output is a terminal.
+.PP
+The escape is meant to be read, not parsed back into a path: a name
+containing a literal backslash is passed through unchanged.
+\f[B]\-\-json\f[R] escapes the same characters as \f[CR]\(rsu00NN\f[R],
+per JSON.
 .PP
 On a \f[B]compressed\f[R] btrfs, \f[B]Reclaimed\f[R] is a
 \f[I]logical\f[R] figure: dedupe shares logical extents but frees

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -442,6 +442,20 @@ reports as shared — and counts the surviving copy as shared too, so for pairs 
 is about twice **Reclaimed**. Scripts that parsed this line from upstream
 duperemove continue to work.
 
+## File names in output
+
+A file name is untrusted input: anyone who can create a file inside a scanned
+tree chooses bytes that `oans` then writes to your terminal. So wherever a path
+is printed — reports, the **-L** listing, **\--stats**, error messages and the
+live progress display — control characters in it are escaped: tab, newline and
+carriage return as `\t`, `\n`, `\r`, every other C0 control, DEL and the C1
+controls as `\xNN`. Valid UTF-8 is untouched, so ordinary names print exactly as
+they are. Escaping is unconditional, whether or not output is a terminal.
+
+The escape is meant to be read, not parsed back into a path: a name containing a
+literal backslash is passed through unchanged. **\--json** escapes the same
+characters as `\u00NN`, per JSON.
+
 On a **compressed** btrfs, **Reclaimed** is a *logical* figure: dedupe shares
 logical extents but frees compressed blocks, so the real on-disk saving is
 smaller, roughly by your compression ratio. For ground truth compare `compsize`

--- a/scripts/lint-escape.py
+++ b/scripts/lint-escape.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Guard the escaped-output invariant (issue #202).
+
+A file name is untrusted input: anyone who can create a file inside a scanned
+tree chooses the bytes oans writes to the administrator's terminal. A `\\r` in a
+name rewrites the line above it - the summary, a progress row - so a name can
+spoof "Reclaimed 9 TiB"; an `ESC[2J` clears the screen. So every path oans
+prints goes through sanitize_ctrl()/path_for_display(), usually via the
+declare_display_path() macro.
+
+That rule is prose, and prose rots: three print sites were missed in the very
+commit that introduced it. This turns it into a build failure.
+
+A print call is flagged when a path-typed identifier is passed to one of the
+printf-family macros:
+
+    eprintf("cannot open %s\\n", path)          -> flagged
+    declare_display_path(disp, path);
+    eprintf("cannot open %s\\n", disp)          -> fine
+    printf("%s\\n", extent->e_file->filename)   -> flagged
+
+"Path-typed" is by name (PATH_NAMES below), which is what makes this a cheap
+regex lint rather than a type system. It is deliberately narrow: it catches the
+shapes this codebase actually writes, not every conceivable one.
+
+Waive a line by putting a comment containing
+
+    escape-ok: <why this string can never be a scanned file's name>
+
+on that line or one of the 3 lines above it. Keep the reason concrete -- it is
+the only record of why the exemption is safe. The usual reason is that the
+string is oans's own argument (a hashfile path) rather than something found
+during a walk.
+
+Run standalone or via `make lint`. Exits 1 on any unwaived call.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# The print macros in src/debug.h, plus bare printf for the report paths that
+# do not route through them.
+PRINT_CALLS = ("printf", "eprintf", "vprintf", "qprintf", "dprintf",
+               "g_string_append_printf")
+
+# Identifiers that hold a path taken from the scanned tree. Names, not types --
+# see the module docstring.
+PATH_NAMES = (
+    r"path", r"in_path", r"child", r"filename", r"name",
+    r"\w+->path", r"\w+->filename", r"\w+->d_name", r"\w+\.path",
+    r"\w+->e_file->filename", r"roots\[\w+\]", r"sc->roots\[\w+\]",
+    r"top\[\w+\]\.path", r"excludes\[\w+\]", r"sc\.excludes\[\w+\]",
+    r"sc->excludes\[\w+\]",
+)
+
+# util.c defines the escapers; tests.c #includes every other .c file, so it
+# would double-report all of them.
+SKIP_FILES = {"util.c", "tests.c"}
+
+WAIVER = re.compile(r"escape-ok:\s*(\S.*?)\s*$")
+WAIVER_LOOKBACK = 3
+
+_PRINT_RE = re.compile(
+    r"(?<![_A-Za-z0-9])(" + "|".join(PRINT_CALLS) + r")\s*\(")
+_ARG_RE = re.compile(
+    r"(?<![_A-Za-z0-9.>\[])(" + "|".join(PATH_NAMES) + r")\s*(?=[,)])")
+# Whatever declare_display_path() introduced is escaped by construction, even
+# when it is spelled with an otherwise path-shaped name like `name`.
+_SAFE_RE = re.compile(r"declare_display_path\s*\(\s*(\w+)\s*,")
+
+
+def strip_noise(src: str) -> str:
+    """Blank out comments and string literals, preserving line structure.
+
+    A format string mentioning a path, or prose in a comment, is not an
+    argument; without this the linter is too noisy to keep enabled.
+    """
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        two = src[i:i + 2]
+        if two == "/*":
+            j = src.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            out.append("".join(c if c == "\n" else " " for c in src[i:j]))
+            i = j
+        elif two == "//":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+        elif src[i] in "\"'":
+            quote, j = src[i], i + 1
+            while j < n and src[j] != quote:
+                j += 2 if src[j] == "\\" else 1
+            j = min(j + 1, n)
+            out.append("".join(c if c == "\n" else " " for c in src[i:j]))
+            i = j
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+
+def call_spans(code: str):
+    """Yield (start_line, end_line, argument_text) for each print call.
+
+    A print call's arguments routinely wrap over several lines, so the whole
+    parenthesised argument list is one unit -- matching line by line would miss
+    every wrapped path argument, which is most of them.
+    """
+    for m in _PRINT_RE.finditer(code):
+        depth, i, n = 1, m.end(), len(code)
+        while i < n and depth:
+            if code[i] == "(":
+                depth += 1
+            elif code[i] == ")":
+                depth -= 1
+            i += 1
+        yield (code.count("\n", 0, m.start()),
+               code.count("\n", 0, i),
+               code[m.end():i - 1])
+
+
+def is_waived(raw_lines: list[str], first: int, last: int) -> bool:
+    lo = max(0, first - WAIVER_LOOKBACK)
+    return any(WAIVER.search(line) for line in raw_lines[lo:last + 1])
+
+
+def check_file(path: Path) -> list[tuple[int, str, str]]:
+    text = path.read_text()
+    raw = text.splitlines()
+    code = strip_noise(text)
+    safe = set(_SAFE_RE.findall(code))
+    hits = []
+
+    for first, last, args in call_spans(code):
+        m = next((m for m in _ARG_RE.finditer(args)
+                  if m.group(1) not in safe), None)
+        if m and not is_waived(raw, first, last):
+            hits.append((first + 1, f"{m.group(1)} printed unescaped",
+                         raw[first].strip()))
+    return hits
+
+
+def main() -> int:
+    src = Path(__file__).resolve().parent.parent / "src"
+    files = sorted(p for p in src.glob("*.c") if p.name not in SKIP_FILES)
+    total = 0
+
+    for path in files:
+        for line, why, text in check_file(path):
+            print(f"{path}:{line}: {why}\n    {text}", file=sys.stderr)
+            total += 1
+
+    if total:
+        print(f"\nlint-escape: {total} unescaped path print(s). Use "
+              f"declare_display_path(), or waive with 'escape-ok: <why>'.",
+              file=sys.stderr)
+        return 1
+    print(f"lint-escape: {len(files)} files clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -97,6 +97,8 @@ static void report_db_open_error(const char *filename, sqlite3 *db)
 
 	/* longpath-ok: the hashfile directory, named by the user, never scanned. */
 	if (stat(dir, &st) != 0 && errno == ENOENT) {
+		/* escape-ok: the hashfile is oans's own --hashfile argument,
+		 * not a name found in a scanned tree. */
 		eprintf("Error: cannot open hashfile \"%s\": directory \"%s\" "
 			"does not exist.\n", filename, dir);
 		if (filename[0] == '~')
@@ -109,6 +111,8 @@ static void report_db_open_error(const char *filename, sqlite3 *db)
 	}
 	/* longpath-ok: the hashfile directory. */
 	if (stat(dir, &st) == 0 && !S_ISDIR(st.st_mode)) {
+		/* escape-ok: the hashfile is oans's own --hashfile argument,
+		 * not a name found in a scanned tree. */
 		eprintf("Error: cannot open hashfile \"%s\": \"%s\" is not a "
 			"directory.\n", filename, dir);
 		return;
@@ -122,12 +126,16 @@ static void report_db_open_error(const char *filename, sqlite3 *db)
 	if (stat(filename, &st) == 0 && access(filename, R_OK | W_OK) != 0) {
 		struct passwd *pw = getpwuid(st.st_uid);
 
+		/* escape-ok: the hashfile is oans's own --hashfile argument,
+		 * not a name found in a scanned tree. */
 		eprintf("Error: cannot open hashfile \"%s\": permission denied.\n"
 			"       It is owned by %s; run oans as that user "
 			"(e.g. with sudo).\n", filename,
 			pw ? pw->pw_name : "another user");
 		return;
 	}
+	/* escape-ok: the hashfile is oans's own --hashfile argument,
+	 * not a name found in a scanned tree. */
 	eprintf("Error opening hashfile \"%s\": %s\n", filename,
 		sqlite3_errmsg(db));
 }
@@ -255,6 +263,8 @@ static int dbfile_check(sqlite3 *db, struct dbfile_config *cfg)
 	 */
 	app_id = (int)dbfile_query_u64(db, "PRAGMA application_id;");
 	if (app_id != OANS_APP_ID) {
+		/* escape-ok: the hashfile is oans's own --hashfile argument,
+		 * not a name found in a scanned tree. */
 		eprintf("Hashfile %s is not an oans hashfile "
 			"(application_id 0x%08x); refusing to use it\n", path,
 			(unsigned)app_id);
@@ -269,6 +279,8 @@ static int dbfile_check(sqlite3 *db, struct dbfile_config *cfg)
 
 
 	if (strncasecmp(cfg->hash_type, HASH_TYPE, 8)) {
+		/* escape-ok: the hashfile is oans's own --hashfile argument,
+		 * not a name found in a scanned tree. */
 		eprintf("Error: Hashfile %s uses \"%.*s\" for checksums "
 			"but we are using %.*s.\nYou are probably "
 			"using a hashfile generated from an old version, "
@@ -2326,7 +2338,11 @@ int dbfile_remove_file(struct dbhandle *db, const char *filename)
 	int ret;
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.delete_file;
 
-	dprintf("Remove file \"%s\" from the db\n", filename);
+	if (debug) {
+		declare_display_path(disp, filename);
+
+		dprintf("Remove file \"%s\" from the db\n", disp);
+	}
 
 	ret = sqlite3_bind_int64(stmt, 1, csum_path(filename));
 	if (ret) {

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -270,10 +270,10 @@ static void add_dedupe_request(struct dedupe_ctxt *ctxt,
 	same->dest_count++;
 
 	if (debug) {
-		_cleanup_(freep) char *disp = path_for_display(file->filename);
+		declare_display_path(disp, file->filename);
 
 		dprintf("add ioctl request %s, off: %llu, dest: %d\n",
-			disp ? disp : file->filename,
+			disp,
 			(unsigned long long)req->req_loff, same->dest_count);
 	}
 }

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -32,6 +32,7 @@
 #include "filerec.h"
 #include "dedupe.h"
 #include "debug.h"
+#include "util.h"
 
 /*
  * Used to determine if requests must be aligned with the underlying block size
@@ -268,8 +269,13 @@ static void add_dedupe_request(struct dedupe_ctxt *ctxt,
 	info->bytes_deduped = 0;
 	same->dest_count++;
 
-	dprintf("add ioctl request %s, off: %llu, dest: %d\n", file->filename,
-		(unsigned long long)req->req_loff, same->dest_count);
+	if (debug) {
+		_cleanup_(freep) char *disp = path_for_display(file->filename);
+
+		dprintf("add ioctl request %s, off: %llu, dest: %d\n",
+			disp ? disp : file->filename,
+			(unsigned long long)req->req_loff, same->dest_count);
+	}
 }
 
 /*

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1080,8 +1080,13 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 
 	if (S_ISREG(st->stx_mode) && options.max_filesize &&
 	    st->stx_size > options.max_filesize) {
-		vprintf("Skipping file above --max-filesize: %s (%llu > %"PRIu64")\n",
-			path, st->stx_size, options.max_filesize);
+		if (verbose) {
+			declare_display_path(disp, path);
+
+			vprintf("Skipping file above --max-filesize: %s "
+				"(%llu > %"PRIu64")\n", disp, st->stx_size,
+				options.max_filesize);
+		}
 		filescan_count_skip(SCAN_SKIP_TOO_LARGE);
 		return false;
 	}

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -663,7 +663,11 @@ static int is_excluded(const char *name, bool is_dir)
 	if (!excludes || !glob_set_match(excludes, name, is_dir, &which))
 		return 0;
 
-	vprintf("Excluding: %s (matches %s)\n", name, which);
+	if (verbose) {
+		declare_display_path(disp, name);
+
+		vprintf("Excluding: %s (matches %s)\n", disp, which);
+	}
 	return 1;
 }
 
@@ -917,8 +921,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 	/* Every message below names the path, and this runs once per root (or
 	 * per fs), not per file - so escape it once here rather than in each
 	 * branch. */
-	_cleanup_(freep) char *disp = path_for_display(path);
-	const char *dpath = disp ? disp : path;
+	declare_display_path(dpath, path);
 
 	struct libmnt_fs *dev = NULL;
 
@@ -1049,19 +1052,27 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	}
 
 	if (!S_ISREG(st->stx_mode) && !S_ISDIR(st->stx_mode)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		/* check_file() runs per directory entry, and escaping
+		 * allocates - so pay it only when -v will actually print.
+		 * Same for every other skip message in this function. */
+		if (verbose) {
+			declare_display_path(disp, path);
 
-		vprintf("Skipping non-regular/non-directory file %s\n",
-			disp ? disp : path);
+			vprintf("Skipping non-regular/non-directory file %s\n",
+				disp);
+		}
 		filescan_count_skip(SCAN_SKIP_NOT_REGULAR);
 		return false;
 	}
 
 	if (S_ISREG(st->stx_mode) && st->stx_size < options.min_filesize) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		if (verbose) {
+			declare_display_path(disp, path);
 
-		vprintf("Skipping file below --min-filesize: %s (%llu < %"PRIu64")\n",
-			disp ? disp : path, st->stx_size, options.min_filesize);
+			vprintf("Skipping file below --min-filesize: %s "
+				"(%llu < %"PRIu64")\n", disp, st->stx_size,
+				options.min_filesize);
+		}
 		filescan_count_skip(SCAN_SKIP_TOO_SMALL);
 		return false;
 	}
@@ -1090,9 +1101,11 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	 */
 	if (locked_fs.is_btrfs && options.skip_readonly_subvols &&
 	    dev_is_readonly_subvol(stx_to_dev(st), path)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		if (verbose) {
+			declare_display_path(disp, path);
 
-		vprintf("Skipping read-only subvolume: %s\n", disp ? disp : path);
+			vprintf("Skipping read-only subvolume: %s\n", disp);
+		}
 		return false;
 	}
 
@@ -1133,11 +1146,11 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		 * rejected root does not pollute the lock for later roots.
 		 */
 		if (!probe.supported) {
-			_cleanup_(freep) char *disp = path_for_display(path);
+			declare_display_path(disp, path);
 
 			eprintf("Skipping %s: its filesystem is not btrfs or XFS, "
 				"which oans needs to deduplicate.\n",
-				disp ? disp : path);
+				disp);
 			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return seed_reject(parent_checked);
 		}
@@ -1159,9 +1172,9 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 			return seed_reject(parent_checked);
 
 		if (uuid_compare(probe.uuid, locked_fs.uuid) != 0) {
-			_cleanup_(freep) char *disp = path_for_display(path);
+			declare_display_path(disp, path);
 
-			eprintf("%s lives on fs ", disp ? disp : path);
+			eprintf("%s lives on fs ", disp);
 			debug_print_uuid(probe.uuid);
 			eprintf(" will we are locked on fs ");
 			debug_print_uuid(locked_fs.uuid);
@@ -1229,12 +1242,12 @@ static int get_dirent_type(struct dirent *entry, int fd, const char *path)
 	 */
 	ret = statx(fd, entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS, &st);
 	if (ret || !(st.stx_mask & STATX_BASIC_STATS)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
-		_cleanup_(freep) char *dname = path_for_display(entry->d_name);
+		declare_display_path(disp, path);
+		declare_display_path(dname, entry->d_name);
 
 		eprintf("Error %d: %s while getting type of file %s/%s. "
 			"Skipping.\n", errno, strerror(errno),
-			disp ? disp : path, dname ? dname : entry->d_name);
+			disp, dname);
 		filescan_count_errno_skip(errno);
 		return DT_UNKNOWN;
 	}
@@ -1324,9 +1337,9 @@ static void fileq_push(const char *path, struct statx *st)
 	struct scan_item *it = malloc(sizeof(*it) + n);
 
 	if (!it) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
-		eprintf("scan: out of memory queuing %s\n", disp ? disp : path);
+		eprintf("scan: out of memory queuing %s\n", disp);
 		return;
 	}
 	it->st = *st;
@@ -1346,10 +1359,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 	/* Report before allocating anything: malloc() may leave errno set even
 	 * when it succeeds, which would misattribute the opendir failure. */
 	if (dirp == NULL) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
 		eprintf("Error %d: %s while opening directory %s\n",
-			errno, strerror(errno), disp ? disp : path);
+			errno, strerror(errno), disp);
 		filescan_count_errno_skip(errno);
 		return;
 	}
@@ -1372,10 +1385,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 	dirlen = strlen(path);
 	child = calloc(1, dirlen + 1 + NAME_MAX + 1);
 	if (child == NULL) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
 		eprintf("Out of memory while scanning directory %s\n",
-			disp ? disp : path);
+			disp);
 		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return;
 	}
@@ -1392,11 +1405,11 @@ static void process_dir(const char *path, struct dbhandle *db)
 		entry = readdir(dirp);
 		if (!entry) {
 			if (errno) {
-				_cleanup_(freep) char *disp = path_for_display(path);
+				declare_display_path(disp, path);
 
 				eprintf("Error %d: %s while reading directory %s\n",
 					errno, strerror(errno),
-					disp ? disp : path);
+					disp);
 				filescan_count_errno_skip(errno);
 			}
 			break;
@@ -1428,12 +1441,12 @@ static void process_dir(const char *path, struct dbhandle *db)
 		 * child buffer can never overflow. */
 		namelen = strlen(entry->d_name);
 		if (namelen > NAME_MAX) {
-			_cleanup_(freep) char *disp = path_for_display(path);
-			_cleanup_(freep) char *dname = path_for_display(entry->d_name);
+			declare_display_path(disp, path);
+			declare_display_path(dname, entry->d_name);
 
 			eprintf("Skipping \"%s/%s\": name length %zu exceeds NAME_MAX (%d)\n",
-				disp ? disp : path,
-				dname ? dname : entry->d_name, namelen, NAME_MAX);
+				disp,
+				dname, namelen, NAME_MAX);
 			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			continue;
 		}
@@ -1448,10 +1461,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 		 */
 		if (statx(dirfd(dirp), entry->d_name, 0, STATX_BASIC_STATS, &st) ||
 		    !(st.stx_mask & STATX_BASIC_STATS)) {
-			_cleanup_(freep) char *disp = path_for_display(child);
+			declare_display_path(disp, child);
 
 			eprintf("Failed to stat %s: %s\n",
-				disp ? disp : child, strerror(errno));
+				disp, strerror(errno));
 			filescan_count_errno_skip(errno);
 			continue;
 		}
@@ -1719,8 +1732,12 @@ static bool resume_scan(struct dbhandle *db, int64_t fileid, uint64_t size,
 	resume->off = cp.loff;
 	resume->ext_loff = cp.ext_loff;
 	resume->ext_len = cp.ext_len;
-	vprintf("Resuming %s at %"PRIu64" of %"PRIu64" bytes\n",
-		name, cp.loff, size);
+	if (verbose) {
+		declare_display_path(disp, name);
+
+		vprintf("Resuming %s at %"PRIu64" of %"PRIu64" bytes\n",
+			disp, cp.loff, size);
+	}
 	return true;
 }
 
@@ -1846,11 +1863,11 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		_cleanup_(closefd) int fd;
 		fd = longpath_open(path, O_RDONLY);
 		if (fd == -1) {
-			_cleanup_(freep) char *disp = path_for_display(path);
+			declare_display_path(disp, path);
 
 			eprintf("Error %d: %s while opening file \"%s\". "
 				"Skipping.\n", errno, strerror(errno),
-				disp ? disp : path);
+				disp);
 			filescan_count_errno_skip(errno);
 			return 0;
 		}
@@ -1863,11 +1880,11 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		 */
 		ret = lookup_btrfs_subvol(fd, &(dbfile.subvol));
 		if (ret) {
-			_cleanup_(freep) char *disp = path_for_display(path);
+			declare_display_path(disp, path);
 
 			eprintf("Error %d: %s while finding subvol for file "
 				"\"%s\". Skipping.\n", ret, strerror(ret),
-				disp ? disp : path);
+				disp);
 			return 0;
 		}
 
@@ -1907,10 +1924,10 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	dbfile.ino = st->stx_ino;
 	dbfile.size = st->stx_size;
 	if (file_set_filename(&dbfile, path)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
 		eprintf("Out of memory storing \"%s\". Skipping.\n",
-			disp ? disp : path);
+			disp);
 		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return 0;
 	}
@@ -1996,22 +2013,22 @@ int scan_file(char *in_path, struct dbhandle *db)
 		 * this is instead of leaving the user with a bare ENAMETOOLONG.
 		 */
 		if (errno == ENAMETOOLONG) {
-			_cleanup_(freep) char *disp = path_for_display(in_path);
+			declare_display_path(disp, in_path);
 
 			eprintf("Skipping %s: its absolute path exceeds PATH_MAX (%d). "
 				"Files *below* a reachable root may be any depth; "
 				"only the root itself is limited. Scan a shorter "
 				"ancestor, or bind-mount this directory somewhere "
-				"shorter.\n", disp ? disp : in_path, PATH_MAX);
+				"shorter.\n", disp, PATH_MAX);
 			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			nr_roots_unusable++;
 			return 0;
 		}
-		_cleanup_(freep) char *disp = path_for_display(in_path);
+		declare_display_path(disp, in_path);
 
 		eprintf("Error %d: %s while getting path to file %s. "
 			"Skipping.\n",
-			errno, strerror(errno), disp ? disp : in_path);
+			errno, strerror(errno), disp);
 		filescan_count_errno_skip(errno);
 		nr_roots_unusable++;
 		return 0;
@@ -2020,11 +2037,11 @@ int scan_file(char *in_path, struct dbhandle *db)
 	/* longpath-ok: `path` is the realpath'd root, so it fits by construction. */
 	ret = statx(0, path, 0, STATX_BASIC_STATS, &st);
 	if (ret || !(st.stx_mask & STATX_BASIC_STATS)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
 		eprintf("Error %d: %s while stating file %s. "
 			"Skipping.\n",
-			errno, strerror(errno), disp ? disp : path);
+			errno, strerror(errno), disp);
 		filescan_count_errno_skip(errno);
 		nr_roots_unusable++;
 		return 0;
@@ -2265,11 +2282,11 @@ static bool adopt_resume(struct scan_ctxt *ctxt, struct file_to_scan *file,
 		e = get_extent(ctxt->fiemap, r->off, &ctxt->extent_cursor);
 		if (!e || e->fe_logical != r->ext_loff ||
 		    e->fe_length != r->ext_len) {
-			_cleanup_(freep) char *disp = path_for_display(file->path);
+			declare_display_path(disp, file->path);
 
 			vprintf("%s: extent layout changed since the checkpoint "
 				"at %"PRIu64" bytes; hashing from the start\n",
-				disp ? disp : file->path, r->off);
+				disp, r->off);
 			scan_resume_drop(r);
 			ctxt->extent_cursor = 0;
 
@@ -2909,11 +2926,11 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 
 	ctxt.fd = longpath_open(file->path, O_RDONLY);
 	if (ctxt.fd == -1) {
-		_cleanup_(freep) char *disp = path_for_display(file->path);
+		declare_display_path(disp, file->path);
 
 		eprintf("csum_whole_file: Error %d: %s while opening file \"%s\". "
 			"Skipping.\n", errno, strerror(errno),
-			disp ? disp : file->path);
+			disp);
 		filescan_count_errno_skip(errno);
 		return;
 	}
@@ -2978,10 +2995,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		ret = fill_buffer(&ctxt, buffer);
 		if (ret < 0) {
 			ret = errno;
-			_cleanup_(freep) char *disp = path_for_display(file->path);
+			declare_display_path(disp, file->path);
 
 			eprintf("Unable to read file %s: %s\n",
-				disp ? disp : file->path, strerror(ret));
+				disp, strerror(ret));
 			filescan_count_errno_skip(ret);
 			return;
 		}
@@ -3005,10 +3022,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 					    ctxt.off + bytes_processed,
 					    &hashes);
 			if (ret) {
-				_cleanup_(freep) char *disp = path_for_display(file->path);
+				declare_display_path(disp, file->path);
 
 				eprintf("Unable to process %s's last block\n",
-					disp ? disp : file->path);
+					disp);
 				return;
 			}
 
@@ -3045,11 +3062,11 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 
 		ret = write_checkpoint(&hashes, &ctxt, file->mtime);
 		if (ret) {
-			_cleanup_(freep) char *disp = path_for_display(file->path);
+			declare_display_path(disp, file->path);
 
 			eprintf("%s: could not checkpoint at %"PRIu64" bytes; "
 				"an interrupted run will rehash it from the "
-				"start.\n", disp ? disp : file->path,
+				"start.\n", disp,
 				(uint64_t)ctxt.off);
 			checkpoints_enabled = false;
 			continue;
@@ -3059,11 +3076,11 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		/* Test hook: stand in for the kill this exists to survive. */
 		if (checkpoint_stop_after &&
 		    ++checkpoints >= checkpoint_stop_after) {
-			_cleanup_(freep) char *disp = path_for_display(file->path);
+			declare_display_path(disp, file->path);
 
 			vprintf("%s: stopping after %u checkpoints at %"PRIu64
 				" bytes (DUPEREMOVE_CHECKPOINT_STOP)\n",
-				disp ? disp : file->path, checkpoints,
+				disp, checkpoints,
 				(uint64_t)ctxt.off);
 			return;
 		}
@@ -3075,12 +3092,12 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * store a hash that matches nothing.
 	 */
 	if (ctxt.off != ctxt.filesize) {
-		_cleanup_(freep) char *disp = path_for_display(file->path);
+		declare_display_path(disp, file->path);
 
 		eprintf("%s: size changed while hashing (read %"PRIu64" bytes, "
 			"expected %"PRIu64"). Skipped - it is probably still "
 			"being written; the next run will hash it.\n",
-			disp ? disp : file->path, (uint64_t)ctxt.off,
+			disp, (uint64_t)ctxt.off,
 			(uint64_t)ctxt.filesize);
 		return;
 	}

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -914,18 +914,23 @@ static int probe_fs(char *path, struct fs_probe *probe)
 	_cleanup_(mnt_unref_table_cleanup) struct libmnt_table *tb = NULL;
 	_cleanup_(closefd) int fd = longpath_open(path, O_RDONLY);
 	_cleanup_(freep) char *uuid_found = NULL;
+	/* Every message below names the path, and this runs once per root (or
+	 * per fs), not per file - so escape it once here rather than in each
+	 * branch. */
+	_cleanup_(freep) char *disp = path_for_display(path);
+	const char *dpath = disp ? disp : path;
 
 	struct libmnt_fs *dev = NULL;
 
 	if (fd == -1) {
-		eprintf("Cannot open %s: %s\n", path, strerror(errno));
+		eprintf("Cannot open %s: %s\n", dpath, strerror(errno));
 		filescan_count_errno_skip(errno);
 		return 1;
 	}
 
 	if (fstatfs(fd, &fs)) {
 		eprintf("Error %d: %s while checking fs type on %s\n",
-			errno, strerror(errno), path);
+			errno, strerror(errno), dpath);
 		filescan_count_errno_skip(errno);
 		return 1;
 	}
@@ -933,11 +938,11 @@ static int probe_fs(char *path, struct fs_probe *probe)
 	probe->supported = is_fs_supported(&fs);
 
 	if (probe->is_btrfs) {
-		dprintf("probe_fs: %s lives on btrfs\n", path);
+		dprintf("probe_fs: %s lives on btrfs\n", dpath);
 		ret = btrfs_get_fsuuid(fd, &probe->uuid);
 		if (ret) {
 			eprintf("%s: btrfs_get_fsuuid failed\n",
-				path);
+				dpath);
 			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
@@ -946,7 +951,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		char *first_device;
 		struct fsuuid2 fsuuid = {0,};
 
-		dprintf("probe_fs: %s do not live on btrfs\n", path);
+		dprintf("probe_fs: %s do not live on btrfs\n", dpath);
 
 		/*
 		 * Preferred path: ask the filesystem for its UUID directly
@@ -964,7 +969,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		ret = statx(fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS, &st);
 		if (ret) {
 			eprintf("Failed to stat %s: %s\n",
-					path, strerror(errno));
+					dpath, strerror(errno));
 			filescan_count_errno_skip(errno);
 			return 1;
 		}
@@ -972,7 +977,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		if (st.stx_dev_major == 0) {
 			dprintf("%s lives on an unsupported filesystem, skipping. "
 				"Please fill a bug if you think this is a mistake.\n",
-					path);
+					dpath);
 			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
@@ -987,7 +992,7 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		dev = mnt_table_find_devno(tb, stx_to_dev(&st), MNT_ITER_FORWARD);
 		if (!dev) {
 			eprintf("%s: unable to find the mount infos\n",
-					path);
+					dpath);
 			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return 1;
 		}
@@ -1044,14 +1049,19 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	}
 
 	if (!S_ISREG(st->stx_mode) && !S_ISDIR(st->stx_mode)) {
-		vprintf("Skipping non-regular/non-directory file %s\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		vprintf("Skipping non-regular/non-directory file %s\n",
+			disp ? disp : path);
 		filescan_count_skip(SCAN_SKIP_NOT_REGULAR);
 		return false;
 	}
 
 	if (S_ISREG(st->stx_mode) && st->stx_size < options.min_filesize) {
+		_cleanup_(freep) char *disp = path_for_display(path);
+
 		vprintf("Skipping file below --min-filesize: %s (%llu < %"PRIu64")\n",
-			path, st->stx_size, options.min_filesize);
+			disp ? disp : path, st->stx_size, options.min_filesize);
 		filescan_count_skip(SCAN_SKIP_TOO_SMALL);
 		return false;
 	}
@@ -1080,7 +1090,9 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 	 */
 	if (locked_fs.is_btrfs && options.skip_readonly_subvols &&
 	    dev_is_readonly_subvol(stx_to_dev(st), path)) {
-		vprintf("Skipping read-only subvolume: %s\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		vprintf("Skipping read-only subvolume: %s\n", disp ? disp : path);
 		return false;
 	}
 
@@ -1121,8 +1133,11 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		 * rejected root does not pollute the lock for later roots.
 		 */
 		if (!probe.supported) {
+			_cleanup_(freep) char *disp = path_for_display(path);
+
 			eprintf("Skipping %s: its filesystem is not btrfs or XFS, "
-				"which oans needs to deduplicate.\n", path);
+				"which oans needs to deduplicate.\n",
+				disp ? disp : path);
 			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
 			return seed_reject(parent_checked);
 		}
@@ -1144,7 +1159,9 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 			return seed_reject(parent_checked);
 
 		if (uuid_compare(probe.uuid, locked_fs.uuid) != 0) {
-			eprintf("%s lives on fs ", path);
+			_cleanup_(freep) char *disp = path_for_display(path);
+
+			eprintf("%s lives on fs ", disp ? disp : path);
 			debug_print_uuid(probe.uuid);
 			eprintf(" will we are locked on fs ");
 			debug_print_uuid(locked_fs.uuid);
@@ -1212,9 +1229,12 @@ static int get_dirent_type(struct dirent *entry, int fd, const char *path)
 	 */
 	ret = statx(fd, entry->d_name, AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS, &st);
 	if (ret || !(st.stx_mask & STATX_BASIC_STATS)) {
+		_cleanup_(freep) char *disp = path_for_display(path);
+		_cleanup_(freep) char *dname = path_for_display(entry->d_name);
+
 		eprintf("Error %d: %s while getting type of file %s/%s. "
-			"Skipping.\n",
-			errno, strerror(errno), path, entry->d_name);
+			"Skipping.\n", errno, strerror(errno),
+			disp ? disp : path, dname ? dname : entry->d_name);
 		filescan_count_errno_skip(errno);
 		return DT_UNKNOWN;
 	}
@@ -1304,7 +1324,9 @@ static void fileq_push(const char *path, struct statx *st)
 	struct scan_item *it = malloc(sizeof(*it) + n);
 
 	if (!it) {
-		eprintf("scan: out of memory queuing %s\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		eprintf("scan: out of memory queuing %s\n", disp ? disp : path);
 		return;
 	}
 	it->st = *st;
@@ -1324,8 +1346,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 	/* Report before allocating anything: malloc() may leave errno set even
 	 * when it succeeds, which would misattribute the opendir failure. */
 	if (dirp == NULL) {
+		_cleanup_(freep) char *disp = path_for_display(path);
+
 		eprintf("Error %d: %s while opening directory %s\n",
-			errno, strerror(errno), path);
+			errno, strerror(errno), disp ? disp : path);
 		filescan_count_errno_skip(errno);
 		return;
 	}
@@ -1348,7 +1372,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 	dirlen = strlen(path);
 	child = calloc(1, dirlen + 1 + NAME_MAX + 1);
 	if (child == NULL) {
-		eprintf("Out of memory while scanning directory %s\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		eprintf("Out of memory while scanning directory %s\n",
+			disp ? disp : path);
 		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return;
 	}
@@ -1365,8 +1392,11 @@ static void process_dir(const char *path, struct dbhandle *db)
 		entry = readdir(dirp);
 		if (!entry) {
 			if (errno) {
+				_cleanup_(freep) char *disp = path_for_display(path);
+
 				eprintf("Error %d: %s while reading directory %s\n",
-					errno, strerror(errno), path);
+					errno, strerror(errno),
+					disp ? disp : path);
 				filescan_count_errno_skip(errno);
 			}
 			break;
@@ -1398,8 +1428,12 @@ static void process_dir(const char *path, struct dbhandle *db)
 		 * child buffer can never overflow. */
 		namelen = strlen(entry->d_name);
 		if (namelen > NAME_MAX) {
+			_cleanup_(freep) char *disp = path_for_display(path);
+			_cleanup_(freep) char *dname = path_for_display(entry->d_name);
+
 			eprintf("Skipping \"%s/%s\": name length %zu exceeds NAME_MAX (%d)\n",
-				path, entry->d_name, namelen, NAME_MAX);
+				disp ? disp : path,
+				dname ? dname : entry->d_name, namelen, NAME_MAX);
 			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			continue;
 		}
@@ -1414,7 +1448,10 @@ static void process_dir(const char *path, struct dbhandle *db)
 		 */
 		if (statx(dirfd(dirp), entry->d_name, 0, STATX_BASIC_STATS, &st) ||
 		    !(st.stx_mask & STATX_BASIC_STATS)) {
-			eprintf("Failed to stat %s: %s\n", child, strerror(errno));
+			_cleanup_(freep) char *disp = path_for_display(child);
+
+			eprintf("Failed to stat %s: %s\n",
+				disp ? disp : child, strerror(errno));
 			filescan_count_errno_skip(errno);
 			continue;
 		}
@@ -1809,8 +1846,11 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		_cleanup_(closefd) int fd;
 		fd = longpath_open(path, O_RDONLY);
 		if (fd == -1) {
+			_cleanup_(freep) char *disp = path_for_display(path);
+
 			eprintf("Error %d: %s while opening file \"%s\". "
-				"Skipping.\n", errno, strerror(errno), path);
+				"Skipping.\n", errno, strerror(errno),
+				disp ? disp : path);
 			filescan_count_errno_skip(errno);
 			return 0;
 		}
@@ -1823,9 +1863,11 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 		 */
 		ret = lookup_btrfs_subvol(fd, &(dbfile.subvol));
 		if (ret) {
+			_cleanup_(freep) char *disp = path_for_display(path);
+
 			eprintf("Error %d: %s while finding subvol for file "
 				"\"%s\". Skipping.\n", ret, strerror(ret),
-				path);
+				disp ? disp : path);
 			return 0;
 		}
 
@@ -1865,7 +1907,10 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	dbfile.ino = st->stx_ino;
 	dbfile.size = st->stx_size;
 	if (file_set_filename(&dbfile, path)) {
-		eprintf("Out of memory storing \"%s\". Skipping.\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		eprintf("Out of memory storing \"%s\". Skipping.\n",
+			disp ? disp : path);
 		filescan_count_skip(SCAN_SKIP_UNREADABLE);
 		return 0;
 	}
@@ -1951,18 +1996,22 @@ int scan_file(char *in_path, struct dbhandle *db)
 		 * this is instead of leaving the user with a bare ENAMETOOLONG.
 		 */
 		if (errno == ENAMETOOLONG) {
+			_cleanup_(freep) char *disp = path_for_display(in_path);
+
 			eprintf("Skipping %s: its absolute path exceeds PATH_MAX (%d). "
 				"Files *below* a reachable root may be any depth; "
 				"only the root itself is limited. Scan a shorter "
 				"ancestor, or bind-mount this directory somewhere "
-				"shorter.\n", in_path, PATH_MAX);
+				"shorter.\n", disp ? disp : in_path, PATH_MAX);
 			filescan_count_skip(SCAN_SKIP_PATH_TOO_LONG);
 			nr_roots_unusable++;
 			return 0;
 		}
+		_cleanup_(freep) char *disp = path_for_display(in_path);
+
 		eprintf("Error %d: %s while getting path to file %s. "
 			"Skipping.\n",
-			errno, strerror(errno), in_path);
+			errno, strerror(errno), disp ? disp : in_path);
 		filescan_count_errno_skip(errno);
 		nr_roots_unusable++;
 		return 0;
@@ -1971,9 +2020,11 @@ int scan_file(char *in_path, struct dbhandle *db)
 	/* longpath-ok: `path` is the realpath'd root, so it fits by construction. */
 	ret = statx(0, path, 0, STATX_BASIC_STATS, &st);
 	if (ret || !(st.stx_mask & STATX_BASIC_STATS)) {
+		_cleanup_(freep) char *disp = path_for_display(path);
+
 		eprintf("Error %d: %s while stating file %s. "
 			"Skipping.\n",
-			errno, strerror(errno), path);
+			errno, strerror(errno), disp ? disp : path);
 		filescan_count_errno_skip(errno);
 		nr_roots_unusable++;
 		return 0;
@@ -2214,9 +2265,11 @@ static bool adopt_resume(struct scan_ctxt *ctxt, struct file_to_scan *file,
 		e = get_extent(ctxt->fiemap, r->off, &ctxt->extent_cursor);
 		if (!e || e->fe_logical != r->ext_loff ||
 		    e->fe_length != r->ext_len) {
+			_cleanup_(freep) char *disp = path_for_display(file->path);
+
 			vprintf("%s: extent layout changed since the checkpoint "
 				"at %"PRIu64" bytes; hashing from the start\n",
-				file->path, r->off);
+				disp ? disp : file->path, r->off);
 			scan_resume_drop(r);
 			ctxt->extent_cursor = 0;
 
@@ -2856,8 +2909,11 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 
 	ctxt.fd = longpath_open(file->path, O_RDONLY);
 	if (ctxt.fd == -1) {
+		_cleanup_(freep) char *disp = path_for_display(file->path);
+
 		eprintf("csum_whole_file: Error %d: %s while opening file \"%s\". "
-			"Skipping.\n", errno, strerror(errno), file->path);
+			"Skipping.\n", errno, strerror(errno),
+			disp ? disp : file->path);
 		filescan_count_errno_skip(errno);
 		return;
 	}
@@ -2922,8 +2978,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		ret = fill_buffer(&ctxt, buffer);
 		if (ret < 0) {
 			ret = errno;
+			_cleanup_(freep) char *disp = path_for_display(file->path);
+
 			eprintf("Unable to read file %s: %s\n",
-				file->path, strerror(ret));
+				disp ? disp : file->path, strerror(ret));
 			filescan_count_errno_skip(ret);
 			return;
 		}
@@ -2947,7 +3005,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 					    ctxt.off + bytes_processed,
 					    &hashes);
 			if (ret) {
-				eprintf("Unable to process %s's last block\n", file->path);
+				_cleanup_(freep) char *disp = path_for_display(file->path);
+
+				eprintf("Unable to process %s's last block\n",
+					disp ? disp : file->path);
 				return;
 			}
 
@@ -2984,9 +3045,12 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 
 		ret = write_checkpoint(&hashes, &ctxt, file->mtime);
 		if (ret) {
+			_cleanup_(freep) char *disp = path_for_display(file->path);
+
 			eprintf("%s: could not checkpoint at %"PRIu64" bytes; "
 				"an interrupted run will rehash it from the "
-				"start.\n", file->path, (uint64_t)ctxt.off);
+				"start.\n", disp ? disp : file->path,
+				(uint64_t)ctxt.off);
 			checkpoints_enabled = false;
 			continue;
 		}
@@ -2995,9 +3059,12 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 		/* Test hook: stand in for the kill this exists to survive. */
 		if (checkpoint_stop_after &&
 		    ++checkpoints >= checkpoint_stop_after) {
+			_cleanup_(freep) char *disp = path_for_display(file->path);
+
 			vprintf("%s: stopping after %u checkpoints at %"PRIu64
 				" bytes (DUPEREMOVE_CHECKPOINT_STOP)\n",
-				file->path, checkpoints, (uint64_t)ctxt.off);
+				disp ? disp : file->path, checkpoints,
+				(uint64_t)ctxt.off);
 			return;
 		}
 	}
@@ -3008,10 +3075,13 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * store a hash that matches nothing.
 	 */
 	if (ctxt.off != ctxt.filesize) {
+		_cleanup_(freep) char *disp = path_for_display(file->path);
+
 		eprintf("%s: size changed while hashing (read %"PRIu64" bytes, "
 			"expected %"PRIu64"). Skipped - it is probably still "
 			"being written; the next run will hash it.\n",
-			file->path, (uint64_t)ctxt.off, (uint64_t)ctxt.filesize);
+			disp ? disp : file->path, (uint64_t)ctxt.off,
+			(uint64_t)ctxt.filesize);
 		return;
 	}
 

--- a/src/filerec.c
+++ b/src/filerec.c
@@ -256,12 +256,11 @@ int filerec_open(struct filerec *file, bool quiet)
 		if (fd == -1) {
 			ret = errno;
 			if (ret != ENOENT || !quiet) {
-				_cleanup_(freep) char *disp =
-					path_for_display(file->filename);
+				declare_display_path(disp, file->filename);
 
 				eprintf("Error %d: %s while opening \"%s\"\n",
 					ret, strerror(ret),
-					disp ? disp : file->filename);
+					disp);
 			}
 			goto out_unlock;
 		}

--- a/src/filerec.c
+++ b/src/filerec.c
@@ -255,9 +255,14 @@ int filerec_open(struct filerec *file, bool quiet)
 		fd = longpath_open(file->filename, O_RDONLY);
 		if (fd == -1) {
 			ret = errno;
-			if (ret != ENOENT || !quiet)
+			if (ret != ENOENT || !quiet) {
+				_cleanup_(freep) char *disp =
+					path_for_display(file->filename);
+
 				eprintf("Error %d: %s while opening \"%s\"\n",
-					ret, strerror(ret), file->filename);
+					ret, strerror(ret),
+					disp ? disp : file->filename);
+			}
 			goto out_unlock;
 		}
 

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -34,6 +34,7 @@
 #include "dbfile.h"
 #include "memstats.h"
 #include "debug.h"
+#include "util.h"
 #include "progress.h"
 #include "threads.h"
 #include "tsan.h"
@@ -96,9 +97,13 @@ static void record_match(struct results_tree *res, unsigned char *digest,
 		exit(ENOMEM);
 	}
 
-	dprintf("Duplicated extent of %llu blocks in files:\n%s\t\t%s\n",
-		(unsigned long long)len / blocksize, orig->filename,
-		walk->filename);
+	if (debug) {
+		declare_display_path(dorig, orig->filename);
+		declare_display_path(dwalk, walk->filename);
+
+		dprintf("Duplicated extent of %llu blocks in files:\n%s\t\t%s\n",
+			(unsigned long long)len / blocksize, dorig, dwalk);
+	}
 
 	dprintf("%llu-%llu\t\t%llu-%llu\n",
 		(unsigned long long)soff[0] / blocksize,
@@ -319,8 +324,12 @@ static void search_file_extents(struct filerec *file, struct results_tree *dupe_
 	if (ret || !num_extents)
 		return;
 
-	dprintf("search_file_extents: %s (size=%"PRIu64" ret %d num_extents: "
-		"%u\n", file->filename, file->size, ret, num_extents);
+	if (debug) {
+		declare_display_path(disp, file->filename);
+
+		dprintf("search_file_extents: %s (size=%"PRIu64" ret %d num_extents: "
+			"%u\n", disp, file->size, ret, num_extents);
+	}
 	for(i = 0; i < num_extents; i++) {
 		extent = &extents[i];
 		dprintf("search_file_extents:   nondupe extent # %d loff %"

--- a/src/oans.c
+++ b/src/oans.c
@@ -81,13 +81,12 @@ struct dbfile_config dbfile_cfg;
 
 static void print_file(char *filename, char *ino, char *subvol)
 {
-	_cleanup_(freep) char *disp = path_for_display(filename);
-	const char *name = disp ? disp : filename;
+	declare_display_path(disp, filename);
 
 	if (verbose)
-		printf("%s\t%s\t%s\n", name, ino, subvol);
+		printf("%s\t%s\t%s\n", disp, ino, subvol);
 	else
-		printf("%s\n", name);
+		printf("%s\n", disp);
 }
 
 /* Human duration for the timing lines: ms under a second, else seconds. */
@@ -267,25 +266,25 @@ static int print_hashfile_stats(char *filename)
 		if (dbfile_load_scan_config(db, &sc) > 0) {
 			char *opts = scan_config_options_str(&sc);
 
+			/* escape-ok: the hashfile is oans's own --hashfile
+			 * argument, not a name found in a scanned tree. */
 			printf("\n%s%sstored scan%s   %s(replayed by: oans --hashfile=%s)%s\n",
 			       col_bold, col_blue, col_reset, col_dim, filename, col_reset);
 			printf("  %soptions%s         %s\n", col_dim, col_reset, opts);
 			free(opts);
 			for (i = 0; i < sc.nroots; i++) {
-				_cleanup_(freep) char *disp =
-					path_for_display(sc.roots[i]);
+				declare_display_path(disp, sc.roots[i]);
 
 				printf("  %s%s%s %s\n", col_dim,
 				       i == 0 ? "paths      " : "           ",
-				       col_reset, disp ? disp : sc.roots[i]);
+				       col_reset, disp);
 			}
 			for (i = 0; i < sc.nexcludes; i++) {
-				_cleanup_(freep) char *disp =
-					path_for_display(sc.excludes[i]);
+				declare_display_path(disp, sc.excludes[i]);
 
 				printf("  %s%s%s %s\n", col_dim,
 				       i == 0 ? "excludes   " : "           ",
-				       col_reset, disp ? disp : sc.excludes[i]);
+				       col_reset, disp);
 			}
 			fflush(stdout);
 			scan_config_free(&sc);
@@ -389,11 +388,11 @@ static int print_hashfile_stats(char *filename)
 		snprintf(szb, sizeof(szb), "%s x %"PRIu64, human_size(top[i].size),
 			 top[i].count);
 		snprintf(wb, sizeof(wb), "%s", human_size(top[i].waste));
-		_cleanup_(freep) char *disp = top[i].path ?
-			path_for_display(top[i].path) : NULL;
+		const char *raw = top[i].path ? top[i].path : "";
+		declare_display_path(example, raw);
 
 		printf("    %-18s %s%10s%s  %s\n", szb, col_dim, wb, col_reset,
-		       disp ? disp : (top[i].path ? top[i].path : ""));
+		       example);
 		free(top[i].path);
 	}
 	fflush(stdout);
@@ -412,17 +411,20 @@ static void print_json_str(const char *s)
 {
 	putchar('"');
 	for (; *s; s++) {
-		unsigned char c = (unsigned char)*s;
+		unsigned char c = (unsigned char)*s, cp;
+		/* Same policy as sanitize_ctrl(), a different rendering: JSON
+		 * spells a dangerous byte \u00NN. Asking one classifier keeps
+		 * the two from drifting apart. */
+		size_t n = ctrl_seq_len((const unsigned char *)s, &cp);
 
-		if (c == '"' || c == '\\')
+		if (n) {
+			printf("\\u%04x", cp);
+			s += n - 1;
+		} else if (c == '"' || c == '\\') {
 			printf("\\%c", c);
-		else if (c < 0x20 || c == 0x7f)
-			printf("\\u%04x", c);
-		else if (c == 0xc2 && (unsigned char)s[1] >= 0x80 &&
-			 (unsigned char)s[1] <= 0x9f)
-			printf("\\u%04x", (unsigned char)*++s);	/* a C1 control */
-		else
+		} else {
 			putchar(c);
+		}
 	}
 	putchar('"');
 }
@@ -706,10 +708,10 @@ static int rm_db_files(int numfiles, char **files)
 		if (dbfile_remove_file(db, name)) {
 			ret = -1;
 		} else if (verbose) {
-			_cleanup_(freep) char *disp = path_for_display(name);
+			declare_display_path(disp, name);
 
 			vprintf("Removed \"%s\" from hashfile.\n",
-				disp ? disp : name);
+				disp);
 		}
 	}
 	return ret;
@@ -800,10 +802,10 @@ enum {
 static int add_one_stdin_file(char *path, void *db)
 {
 	if (scan_file(path, db)) {
-		_cleanup_(freep) char *disp = path_for_display(path);
+		declare_display_path(disp, path);
 
 		eprintf("Error: cannot add %s into the lookup list\n",
-			disp ? disp : path);
+			disp);
 		return 1;
 	}
 	return 0;
@@ -1693,8 +1695,11 @@ static int apply_scan_config(const struct scan_config *sc)
 		eprintf("         Re-run once with -d and the paths to update "
 			"it:\n           oans -%sd --hashfile=%s",
 			sc->recurse ? "r" : "", options.hashfile);
-		for (i = 0; i < sc->nroots; i++)
-			eprintf(" %s", sc->roots[i]);
+		for (i = 0; i < sc->nroots; i++) {
+			declare_display_path(root, sc->roots[i]);
+
+			eprintf(" %s", root);
+		}
 		eprintf("\n");
 	}
 
@@ -1721,11 +1726,10 @@ static int drop_missing_roots(struct scan_config *sc, int *dropped)
 		if (stat(sc->roots[i], &st) == 0) {
 			sc->roots[live++] = sc->roots[i];
 		} else {
-			_cleanup_(freep) char *disp =
-				path_for_display(sc->roots[i]);
+			declare_display_path(disp, sc->roots[i]);
 
 			eprintf("Warning: stored path \"%s\" no longer exists, "
-				"skipping.\n", disp ? disp : sc->roots[i]);
+				"skipping.\n", disp);
 			free(sc->roots[i]);
 			(*dropped)++;
 		}
@@ -1765,9 +1769,11 @@ static void persist_scan_config(struct dbhandle *db, char **roots, int nroots)
 		 * and the "all roots gone" guard never fires, because the root
 		 * was never stored to go missing.
 		 */
+		declare_display_path(root, roots[i]);
+
 		eprintf("Warning: not storing root \"%s\" in the hashfile: %s. "
 			"A later replay of this hashfile will not cover it.\n",
-			roots[i], strerror(errno));
+			root, strerror(errno));
 	}
 
 	sc.run_dedupe = options.run_dedupe;

--- a/src/oans.c
+++ b/src/oans.c
@@ -81,10 +81,13 @@ struct dbfile_config dbfile_cfg;
 
 static void print_file(char *filename, char *ino, char *subvol)
 {
+	_cleanup_(freep) char *disp = path_for_display(filename);
+	const char *name = disp ? disp : filename;
+
 	if (verbose)
-		printf("%s\t%s\t%s\n", filename, ino, subvol);
+		printf("%s\t%s\t%s\n", name, ino, subvol);
 	else
-		printf("%s\n", filename);
+		printf("%s\n", name);
 }
 
 /* Human duration for the timing lines: ms under a second, else seconds. */
@@ -268,14 +271,22 @@ static int print_hashfile_stats(char *filename)
 			       col_bold, col_blue, col_reset, col_dim, filename, col_reset);
 			printf("  %soptions%s         %s\n", col_dim, col_reset, opts);
 			free(opts);
-			for (i = 0; i < sc.nroots; i++)
+			for (i = 0; i < sc.nroots; i++) {
+				_cleanup_(freep) char *disp =
+					path_for_display(sc.roots[i]);
+
 				printf("  %s%s%s %s\n", col_dim,
 				       i == 0 ? "paths      " : "           ",
-				       col_reset, sc.roots[i]);
-			for (i = 0; i < sc.nexcludes; i++)
+				       col_reset, disp ? disp : sc.roots[i]);
+			}
+			for (i = 0; i < sc.nexcludes; i++) {
+				_cleanup_(freep) char *disp =
+					path_for_display(sc.excludes[i]);
+
 				printf("  %s%s%s %s\n", col_dim,
 				       i == 0 ? "excludes   " : "           ",
-				       col_reset, sc.excludes[i]);
+				       col_reset, disp ? disp : sc.excludes[i]);
+			}
 			fflush(stdout);
 			scan_config_free(&sc);
 		}
@@ -378,8 +389,11 @@ static int print_hashfile_stats(char *filename)
 		snprintf(szb, sizeof(szb), "%s x %"PRIu64, human_size(top[i].size),
 			 top[i].count);
 		snprintf(wb, sizeof(wb), "%s", human_size(top[i].waste));
+		_cleanup_(freep) char *disp = top[i].path ?
+			path_for_display(top[i].path) : NULL;
+
 		printf("    %-18s %s%10s%s  %s\n", szb, col_dim, wb, col_reset,
-		       top[i].path ? top[i].path : "");
+		       disp ? disp : (top[i].path ? top[i].path : ""));
 		free(top[i].path);
 	}
 	fflush(stdout);
@@ -402,8 +416,11 @@ static void print_json_str(const char *s)
 
 		if (c == '"' || c == '\\')
 			printf("\\%c", c);
-		else if (c < 0x20)
+		else if (c < 0x20 || c == 0x7f)
 			printf("\\u%04x", c);
+		else if (c == 0xc2 && (unsigned char)s[1] >= 0x80 &&
+			 (unsigned char)s[1] <= 0x9f)
+			printf("\\u%04x", (unsigned char)*++s);	/* a C1 control */
 		else
 			putchar(c);
 	}
@@ -686,10 +703,14 @@ static int rm_db_files(int numfiles, char **files)
 			continue;
 		}
 
-		if (dbfile_remove_file(db, name))
+		if (dbfile_remove_file(db, name)) {
 			ret = -1;
-		else
-			vprintf("Removed \"%s\" from hashfile.\n", name);
+		} else if (verbose) {
+			_cleanup_(freep) char *disp = path_for_display(name);
+
+			vprintf("Removed \"%s\" from hashfile.\n",
+				disp ? disp : name);
+		}
 	}
 	return ret;
 }
@@ -779,7 +800,10 @@ enum {
 static int add_one_stdin_file(char *path, void *db)
 {
 	if (scan_file(path, db)) {
-		eprintf("Error: cannot add %s into the lookup list\n", path);
+		_cleanup_(freep) char *disp = path_for_display(path);
+
+		eprintf("Error: cannot add %s into the lookup list\n",
+			disp ? disp : path);
 		return 1;
 	}
 	return 0;
@@ -1697,8 +1721,11 @@ static int drop_missing_roots(struct scan_config *sc, int *dropped)
 		if (stat(sc->roots[i], &st) == 0) {
 			sc->roots[live++] = sc->roots[i];
 		} else {
+			_cleanup_(freep) char *disp =
+				path_for_display(sc->roots[i]);
+
 			eprintf("Warning: stored path \"%s\" no longer exists, "
-				"skipping.\n", sc->roots[i]);
+				"skipping.\n", disp ? disp : sc->roots[i]);
 			free(sc->roots[i]);
 			(*dropped)++;
 		}

--- a/src/progress.c
+++ b/src/progress.c
@@ -470,7 +470,10 @@ static bool slot_is_idle(struct pscan_thread *t)
 static void print_thread_progress(struct pscan_thread *t, unsigned int slot)
 {
 	char buf[BUF_LEN];
-	char path[PATH_MAX + 4], clean[PATH_MAX + 1];
+	/* An escaped path can be several times its own length, and the row is
+	 * ellipsized to the terminal width afterwards anyway - so size `clean`
+	 * for the worst case rather than truncate a name into a different one. */
+	char path[PATH_MAX + 4], clean[SANITIZE_CTRL_MAX * PATH_MAX + 1];
 	char m_plain[160], m_col[512];
 	const char *word = status_word(t->status);
 	const char *wcol = status_color(t->status);

--- a/src/progress.c
+++ b/src/progress.c
@@ -474,6 +474,7 @@ static void print_thread_progress(struct pscan_thread *t, unsigned int slot)
 	 * ellipsized to the terminal width afterwards anyway - so size `clean`
 	 * for the worst case rather than truncate a name into a different one. */
 	char path[PATH_MAX + 4], clean[SANITIZE_CTRL_MAX * PATH_MAX + 1];
+	const char *src = t->file_path;
 	char m_plain[160], m_col[512];
 	const char *word = status_word(t->status);
 	const char *wcol = status_color(t->status);
@@ -529,9 +530,18 @@ static void print_thread_progress(struct pscan_thread *t, unsigned int slot)
 	 */
 	termw = (int)(w_col == UINT_MAX ? 80 : w_col);
 	avail = termw - WORKER_LEFT_W - (int)strlen(m_plain) - 2;	/* -2: gap before metrics */
-	/* Never emit raw control bytes from a filename to the terminal (#353). */
-	sanitize_ctrl(t->file_path, clean, sizeof(clean));
-	ellipsize_path(clean, path, sizeof(path), avail);
+	/*
+	 * Never emit raw control bytes from a filename to the terminal (#353).
+	 * This runs per worker row per redraw (~10 Hz), so a name that needs
+	 * nothing done to it - every real one - skips the copy entirely.
+	 * Escape before ellipsizing, not after: escaping widens the string, so
+	 * budgeting on the raw path could wrap the row.
+	 */
+	if (has_ctrl(t->file_path)) {
+		sanitize_ctrl(t->file_path, clean, sizeof(clean));
+		src = clean;
+	}
+	ellipsize_path(src, path, sizeof(path), avail);
 
 	snprintf(buf, BUF_LEN, "%s%3u%s  %s%-*s%s  %s  %s",
 		 col_dim, slot, col_reset,

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -152,9 +152,7 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
 		printf("Start\t\tFilename\n");
 		list_for_each_entry(extent, &dext->de_extents, e_list) {
 			const char *name = extent->e_file->filename;
-			/* sanitize_ctrl() never expands: its worst case is two
-			 * input bytes -> one '?'. */
-			size_t need = strlen(name) + 1;
+			size_t need = SANITIZE_CTRL_MAX * strlen(name) + 1;
 
 			if (need > clean_sz) {
 				char *grown = realloc(clean, need);
@@ -548,9 +546,16 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			}
 		}
 
-		vprintf("[%p] Add extent for file \"%s\" at offset %s (%d)\n",
-			g_thread_self(), extent->e_file->filename,
-			pretty_size(extent->e_loff), extent->e_file->fd);
+		if (verbose) {
+			_cleanup_(freep) char *disp =
+				path_for_display(extent->e_file->filename);
+
+			vprintf("[%p] Add extent for file \"%s\" at offset %s (%d)\n",
+				g_thread_self(),
+				disp ? disp : extent->e_file->filename,
+				pretty_size(extent->e_loff),
+				extent->e_file->fd);
+		}
 
 		if (ctxt == NULL) {
 			if (tgt_extent == NULL) {
@@ -669,6 +674,9 @@ run_dedupe:
 		 */
 		if (ctxt->num_queued) {
 			if (verbose) {
+				_cleanup_(freep) char *disp = path_for_display(
+					ctxt->ioctl_file->filename);
+
 				g_mutex_lock(&console_mutex);
 				printf("[%p] Dedupe %u extents (id: ",
 				       g_thread_self(), ctxt->num_queued);
@@ -677,7 +685,7 @@ run_dedupe:
 				       "\"%s\"\n",
 				       pretty_size(ctxt->orig_file_off),
 				       pretty_size(ctxt->orig_len),
-				       ctxt->ioctl_file->filename);
+				       disp ? disp : ctxt->ioctl_file->filename);
 				g_mutex_unlock(&console_mutex);
 			}
 

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -116,16 +116,6 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
 	struct dupe_extents *dext;
 	struct extent *extent;
 	char *kind;
-	/*
-	 * Grown to fit the longest path in the report rather than fixed at
-	 * PATH_MAX: a path may now exceed it (#117), and this report is what a
-	 * user feeds back to -R. A fixed buffer truncated such a path to a
-	 * string that still looked valid but named the parent directory, making
-	 * two distinct members of a group print identically. One buffer for the
-	 * whole report, not one allocation per printed line.
-	 */
-	_cleanup_(freep) char *clean = NULL;
-	size_t clean_sz = 0;
 
 	if (whole_file)
 		kind = "files";
@@ -151,24 +141,17 @@ void print_dupes_table(struct results_tree *res, bool whole_file)
 		printf("\n");
 		printf("Start\t\tFilename\n");
 		list_for_each_entry(extent, &dext->de_extents, e_list) {
-			const char *name = extent->e_file->filename;
-			size_t need = SANITIZE_CTRL_MAX * strlen(name) + 1;
+			/*
+			 * Sized to the whole escaped name rather than a fixed
+			 * buffer: a path may exceed PATH_MAX (#117), and this
+			 * report is what a user feeds back to -R - truncating
+			 * one to a valid-looking parent directory made two
+			 * distinct members of a group print identically.
+			 */
+			declare_display_path(name, extent->e_file->filename);
 
-			if (need > clean_sz) {
-				char *grown = realloc(clean, need);
-
-				if (!grown) {
-					eprintf("Memory allocation failed\n");
-					return;
-				}
-				clean = grown;
-				clean_sz = need;
-			}
-			/* Default (non-quiet) output: keep control bytes in a
-			 * filename from reaching the terminal (#353). */
-			sanitize_ctrl(name, clean, clean_sz);
 			printf("%s\t\"%s\"\n",
-			       pretty_size(extent->e_loff), clean);
+			       pretty_size(extent->e_loff), name);
 		}
 
 		node = rb_next(node);
@@ -229,10 +212,13 @@ static void process_dedupe_results(struct dedupe_ctxt *ctxt,
 				status_str = strerror(-target_status);
 			atomic_fetch_add(&dedupe_dest_errors, 1);
 		}
-		vprintf("[%p] Dedupe for file \"%s\" had status (%d) "
-			"\"%s\".\n",
-			g_thread_self(), f->filename, target_status,
-			status_str);
+		if (verbose) {
+			declare_display_path(disp, f->filename);
+
+			vprintf("[%p] Dedupe for file \"%s\" had status (%d) "
+				"\"%s\".\n", g_thread_self(), disp,
+				target_status, status_str);
+		}
 	}
 }
 
@@ -328,9 +314,12 @@ static void clean_deduped(struct dupe_extents **ret_dext,
 		    disk_extent_grew(dext, extent))
 			continue;
 
-		dprintf("Remove extent (\"%s\", %"PRIu64", %"PRIu64")\n",
-			extent->e_file->filename, extent_poff(extent),
-			extent_plen(extent));
+		if (debug) {
+			declare_display_path(disp, extent->e_file->filename);
+
+			dprintf("Remove extent (\"%s\", %"PRIu64", %"PRIu64")\n",
+				disp, extent_poff(extent), extent_plen(extent));
+		}
 
 		g_mutex_lock(&mutex);
 		/* Cascades to a full free once fewer than two members remain. */
@@ -532,13 +521,18 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 			     (uint64_t)st.st_size != len :
 			     (uint64_t)st.st_size + 4095 < extent->e_loff + len)) {
 				atomic_fetch_add(&dedupe_dest_changed, 1);
-				vprintf("%s: size changed since the scan (now "
-					"%llu bytes, needs at least %llu). "
-					"Skipped - the next scan will re-hash "
-					"it.\n",
-					extent->e_file->filename,
-					(unsigned long long)st.st_size,
-					(unsigned long long)(extent->e_loff + len));
+				if (verbose) {
+					declare_display_path(disp,
+						extent->e_file->filename);
+
+					vprintf("%s: size changed since the "
+						"scan (now %llu bytes, needs at "
+						"least %llu). Skipped - the next "
+						"scan will re-hash it.\n", disp,
+						(unsigned long long)st.st_size,
+						(unsigned long long)
+						(extent->e_loff + len));
+				}
 				/* stays on open_files; closed with the group */
 				if (ctxt && last)
 					goto run_dedupe;
@@ -547,12 +541,11 @@ static int dedupe_extent_list(struct dupe_extents *dext,
 		}
 
 		if (verbose) {
-			_cleanup_(freep) char *disp =
-				path_for_display(extent->e_file->filename);
+			declare_display_path(disp, extent->e_file->filename);
 
 			vprintf("[%p] Add extent for file \"%s\" at offset %s (%d)\n",
 				g_thread_self(),
-				disp ? disp : extent->e_file->filename,
+				disp,
 				pretty_size(extent->e_loff),
 				extent->e_file->fd);
 		}
@@ -674,8 +667,7 @@ run_dedupe:
 		 */
 		if (ctxt->num_queued) {
 			if (verbose) {
-				_cleanup_(freep) char *disp = path_for_display(
-					ctxt->ioctl_file->filename);
+				declare_display_path(disp, ctxt->ioctl_file->filename);
 
 				g_mutex_lock(&console_mutex);
 				printf("[%p] Dedupe %u extents (id: ",
@@ -685,7 +677,7 @@ run_dedupe:
 				       "\"%s\"\n",
 				       pretty_size(ctxt->orig_file_off),
 				       pretty_size(ctxt->orig_len),
-				       disp ? disp : ctxt->ioctl_file->filename);
+				       disp);
 				g_mutex_unlock(&console_mutex);
 			}
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -458,12 +458,32 @@ MU_TEST(test_sanitize_ctrl) {
 	sanitize_ctrl("ab\x1b" "cd", six, sizeof(six));
 	mu_check(strcmp(six, "ab") == 0);
 
+	/* ctrl_seq_len() is the one classifier; has_ctrl() the fast path out. */
+	unsigned char cp = 0;
+
+	mu_check(ctrl_seq_len((const unsigned char *)"a", &cp) == 0);
+	mu_check(ctrl_seq_len((const unsigned char *)"\x1b", &cp) == 1 && cp == 0x1b);
+	mu_check(ctrl_seq_len((const unsigned char *)"\x7f", &cp) == 1 && cp == 0x7f);
+	/* A C1 costs two input bytes and is named by its code point. */
+	mu_check(ctrl_seq_len((const unsigned char *)"\xc2\x9f", &cp) == 2 && cp == 0x9f);
+	/* 0xc2 not followed by a continuation byte is ordinary UTF-8 lead. */
+	mu_check(ctrl_seq_len((const unsigned char *)"\xc2\xa9", &cp) == 0);
+
+	mu_check(!has_ctrl("plain.txt"));
+	mu_check(!has_ctrl("café-Β.txt"));
+	mu_check(!has_ctrl(""));
+	mu_check(has_ctrl("a\rb"));
+	mu_check(has_ctrl("Te\xc2\x9ft"));
+
 	/* path_for_display() always has room for the whole escaped path. */
 	char *dup = path_for_display("a\x1b" "b\x7f");
 	mu_check(dup && strcmp(dup, "a\\x1bb\\x7f") == 0);
 	free(dup);
 	dup = path_for_display("");
 	mu_check(dup && strcmp(dup, "") == 0);
+	free(dup);
+	dup = path_for_display("café-Β.txt");	/* the fast path: unchanged */
+	mu_check(dup && strcmp(dup, "café-Β.txt") == 0);
 	free(dup);
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -436,18 +436,35 @@ MU_TEST(test_sanitize_ctrl) {
 	sanitize_ctrl("café-Β.txt", out, sizeof(out));   /* é=C3A9, Β=CE92 */
 	mu_check(strcmp(out, "café-Β.txt") == 0);
 
-	/* C0 control and DEL become '?'. */
-	sanitize_ctrl("a\tb\nc\x7f", out, sizeof(out));
-	mu_check(strcmp(out, "a?b?c?") == 0);
+	/* Whitespace controls keep their familiar spelling... */
+	sanitize_ctrl("a\tb\nc\rd", out, sizeof(out));
+	mu_check(strcmp(out, "a\\tb\\nc\\rd") == 0);
 
-	/* C1 control U+009F (UTF-8 C2 9F) becomes a single '?' (#353). */
+	/* ... every other C0 control, and DEL, is named by its byte. */
+	sanitize_ctrl("esc\x1b[2Jx\x07\x7f", out, sizeof(out));
+	mu_check(strcmp(out, "esc\\x1b[2Jx\\x07\\x7f") == 0);
+
+	/* C1 control U+009F (UTF-8 C2 9F): named by its code point, not by
+	 * either of the two bytes that spell it (#353). */
 	sanitize_ctrl("Te\xc2\x9ft", out, sizeof(out));
-	mu_check(strcmp(out, "Te?t") == 0);
+	mu_check(strcmp(out, "Te\\x9ft") == 0);
 
-	/* Truncation stays NUL-terminated and within bounds. */
+	/* Truncation stays NUL-terminated and within bounds, and never splits an
+	 * escape: "ab" + a 4-byte escape does not fit in 6, so it stops at "ab". */
 	char small[4];
 	sanitize_ctrl("abcdef", small, sizeof(small));
 	mu_check(strcmp(small, "abc") == 0);
+	char six[6];
+	sanitize_ctrl("ab\x1b" "cd", six, sizeof(six));
+	mu_check(strcmp(six, "ab") == 0);
+
+	/* path_for_display() always has room for the whole escaped path. */
+	char *dup = path_for_display("a\x1b" "b\x7f");
+	mu_check(dup && strcmp(dup, "a\\x1bb\\x7f") == 0);
+	free(dup);
+	dup = path_for_display("");
+	mu_check(dup && strcmp(dup, "") == 0);
+	free(dup);
 }
 
 MU_TEST(test_progress_copy_path) {

--- a/src/util.c
+++ b/src/util.c
@@ -255,6 +255,35 @@ void debug_print_uuid(uuid_t uuid)
 	eprintf("%s", buf);
 }
 
+/*
+ * Render one control byte into `buf` (at least SANITIZE_CTRL_MAX bytes) and
+ * return how many characters it took. Not NUL-terminated.
+ */
+static size_t escape_ctrl_byte(unsigned char c, char *buf)
+{
+	static const char hex[] = "0123456789abcdef";
+	char shorthand;
+
+	switch (c) {
+	case '\t': shorthand = 't'; break;
+	case '\n': shorthand = 'n'; break;
+	case '\r': shorthand = 'r'; break;
+	default:   shorthand = 0;   break;
+	}
+
+	if (shorthand) {
+		buf[0] = '\\';
+		buf[1] = shorthand;
+		return 2;
+	}
+
+	buf[0] = '\\';
+	buf[1] = 'x';
+	buf[2] = hex[c >> 4];
+	buf[3] = hex[c & 0xf];
+	return 4;
+}
+
 void sanitize_ctrl(const char *in, char *out, size_t out_sz)
 {
 	const unsigned char *p = (const unsigned char *)in;
@@ -263,16 +292,38 @@ void sanitize_ctrl(const char *in, char *out, size_t out_sz)
 	if (out_sz == 0)
 		return;
 
-	while (*p && o + 1 < out_sz) {
+	while (*p) {
+		char esc[SANITIZE_CTRL_MAX];
+		size_t n;
+
 		if (*p < 0x20 || *p == 0x7f) {
-			out[o++] = '?';
+			n = escape_ctrl_byte(*p, esc);
 			p++;
 		} else if (p[0] == 0xc2 && p[1] >= 0x80 && p[1] <= 0x9f) {
-			out[o++] = '?';
+			/* A C1 control, which UTF-8 spells in two bytes; name
+			 * it by its code point, not by either byte. */
+			n = escape_ctrl_byte(p[1], esc);
 			p += 2;
 		} else {
-			out[o++] = *p++;
+			esc[0] = (char)*p++;
+			n = 1;
 		}
+
+		/* Stop before splitting an escape rather than emitting half. */
+		if (o + n + 1 > out_sz)
+			break;
+		memcpy(out + o, esc, n);
+		o += n;
 	}
 	out[o] = '\0';
+}
+
+char *path_for_display(const char *path)
+{
+	size_t sz = SANITIZE_CTRL_MAX * strlen(path) + 1;
+	char *out = malloc(sz);
+
+	if (out)
+		sanitize_ctrl(path, out, sz);
+	return out;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -262,19 +262,11 @@ void debug_print_uuid(uuid_t uuid)
 static size_t escape_ctrl_byte(unsigned char c, char *buf)
 {
 	static const char hex[] = "0123456789abcdef";
-	char shorthand;
 
 	switch (c) {
-	case '\t': shorthand = 't'; break;
-	case '\n': shorthand = 'n'; break;
-	case '\r': shorthand = 'r'; break;
-	default:   shorthand = 0;   break;
-	}
-
-	if (shorthand) {
-		buf[0] = '\\';
-		buf[1] = shorthand;
-		return 2;
+	case '\t': memcpy(buf, "\\t", 2); return 2;
+	case '\n': memcpy(buf, "\\n", 2); return 2;
+	case '\r': memcpy(buf, "\\r", 2); return 2;
 	}
 
 	buf[0] = '\\';
@@ -282,6 +274,32 @@ static size_t escape_ctrl_byte(unsigned char c, char *buf)
 	buf[2] = hex[c >> 4];
 	buf[3] = hex[c & 0xf];
 	return 4;
+}
+
+size_t ctrl_seq_len(const unsigned char *p, unsigned char *cp)
+{
+	if (*p < 0x20 || *p == 0x7f) {
+		*cp = *p;
+		return 1;
+	}
+	/* A C1 control, which UTF-8 spells in two bytes; name it by its code
+	 * point, not by either byte. */
+	if (p[0] == 0xc2 && p[1] >= 0x80 && p[1] <= 0x9f) {
+		*cp = p[1];
+		return 2;
+	}
+	return 0;
+}
+
+bool has_ctrl(const char *s)
+{
+	const unsigned char *p = (const unsigned char *)s;
+	unsigned char cp;
+
+	for (; *p; p++)
+		if (ctrl_seq_len(p, &cp))
+			return true;
+	return false;
 }
 
 void sanitize_ctrl(const char *in, char *out, size_t out_sz)
@@ -293,36 +311,54 @@ void sanitize_ctrl(const char *in, char *out, size_t out_sz)
 		return;
 
 	while (*p) {
-		char esc[SANITIZE_CTRL_MAX];
-		size_t n;
+		unsigned char cp;
+		size_t n = ctrl_seq_len(p, &cp);
 
-		if (*p < 0x20 || *p == 0x7f) {
-			n = escape_ctrl_byte(*p, esc);
-			p++;
-		} else if (p[0] == 0xc2 && p[1] >= 0x80 && p[1] <= 0x9f) {
-			/* A C1 control, which UTF-8 spells in two bytes; name
-			 * it by its code point, not by either byte. */
-			n = escape_ctrl_byte(p[1], esc);
-			p += 2;
+		if (!n) {
+			/* Copy the whole run of safe bytes at once - which for
+			 * a real name is the entire string. */
+			const unsigned char *run = p;
+			size_t len;
+
+			do {
+				p++;
+			} while (*p && !ctrl_seq_len(p, &cp));
+
+			len = (size_t)(p - run);
+			if (len > out_sz - o - 1)
+				len = out_sz - o - 1;
+			memcpy(out + o, run, len);
+			o += len;
+			if (o + 1 == out_sz)
+				break;		/* buffer full */
 		} else {
-			esc[0] = (char)*p++;
-			n = 1;
-		}
+			char esc[SANITIZE_CTRL_MAX];
+			size_t len = escape_ctrl_byte(cp, esc);
 
-		/* Stop before splitting an escape rather than emitting half. */
-		if (o + n + 1 > out_sz)
-			break;
-		memcpy(out + o, esc, n);
-		o += n;
+			/* Stop before splitting an escape rather than emitting
+			 * half of one. */
+			if (o + len + 1 > out_sz)
+				break;
+			memcpy(out + o, esc, len);
+			o += len;
+			p += n;
+		}
 	}
 	out[o] = '\0';
 }
 
 char *path_for_display(const char *path)
 {
-	size_t sz = SANITIZE_CTRL_MAX * strlen(path) + 1;
-	char *out = malloc(sz);
+	size_t sz;
+	char *out;
 
+	/* Every real name takes this exit: one exact-sized copy instead of a
+	 * 4x over-allocation and a per-byte loop. */
+	if (!has_ctrl(path))
+		return strdup(path);
+
+	sz = SANITIZE_CTRL_MAX * strlen(path) + 1;
+	out = malloc(sz);
 	if (out)
 		sanitize_ctrl(path, out, sz);
 	return out;

--- a/src/util.h
+++ b/src/util.h
@@ -122,11 +122,37 @@ static inline void closefd(int *fd)
 void debug_print_uuid(uuid_t uuid);
 
 /*
- * Copy `in` to `out` (up to out_sz bytes, always NUL-terminated), replacing
- * terminal control characters with '?': C0 controls (< 0x20), DEL (0x7f), and
- * the two-byte UTF-8 encodings of the C1 controls (U+0080..U+009F). Some
- * terminals act on these when a filename is printed verbatim (#353).
+ * Copy `in` to `out` (up to out_sz bytes, always NUL-terminated), escaping the
+ * bytes a terminal would act on rather than print: C0 controls (< 0x20), DEL
+ * (0x7f), and the two-byte UTF-8 encodings of the C1 controls (U+0080..U+009F).
+ * Tab, newline and carriage return become `\t`, `\n`, `\r`; everything else
+ * becomes `\xNN`. Valid multi-byte UTF-8 passes through untouched.
+ *
+ * File names are untrusted input - anyone who can create a file inside a
+ * scanned tree chooses bytes that reach the administrator's terminal - and a
+ * crafted name can corrupt the display, overwrite the line above it with a
+ * `\r`, or spoof output entirely (#353, #202). So a name is escaped wherever it
+ * is printed, tty or not: machine consumers use --json.
+ *
+ * The escape is for reading, not for round-tripping: a backslash in the name
+ * itself is passed through, so `\x07` in the output may be either the byte or
+ * those four characters. Nothing here is meant to be parsed back into a path;
+ * a name that needs no escaping is unchanged, which is every real one.
+ *
+ * An escape is never split across the end of the buffer: `out` is truncated at
+ * the last complete one that fit.
  */
 void sanitize_ctrl(const char *in, char *out, size_t out_sz);
+
+/* Longest output sanitize_ctrl() can produce for one input byte ("\xNN"). */
+#define SANITIZE_CTRL_MAX	4
+
+/*
+ * sanitize_ctrl() into a freshly allocated string sized to hold the whole
+ * escaped path, for the print sites that have no buffer to spare and must not
+ * truncate. Returns NULL only if the allocation fails; callers print the raw
+ * pointer's fallback rather than losing the message.
+ */
+char *path_for_display(const char *path);
 
 #endif	/* __UTIL_H__ */

--- a/src/util.h
+++ b/src/util.h
@@ -122,11 +122,27 @@ static inline void closefd(int *fd)
 void debug_print_uuid(uuid_t uuid);
 
 /*
+ * Which bytes must never reach a terminal - the single definition of that
+ * policy, so it cannot drift between output formats. Returns how many input
+ * bytes the dangerous sequence occupies (1 for a C0 control or DEL, 2 for a C1
+ * control, which UTF-8 spells in two) and stores its code point in *cp; 0 for a
+ * byte that is safe to pass through, leaving *cp untouched.
+ *
+ * Every escaper renders the result its own way - sanitize_ctrl() as `\xNN`,
+ * --json as `\u00NN` - but they all ask this one question. Reading p[1] is safe
+ * on a NUL-terminated string: the terminator is not a C1 continuation byte.
+ */
+size_t ctrl_seq_len(const unsigned char *p, unsigned char *cp);
+
+/* True if `s` holds anything ctrl_seq_len() would flag - which no ordinary
+ * name does, so this is the fast path out of every escaper below. */
+bool has_ctrl(const char *s);
+
+/*
  * Copy `in` to `out` (up to out_sz bytes, always NUL-terminated), escaping the
- * bytes a terminal would act on rather than print: C0 controls (< 0x20), DEL
- * (0x7f), and the two-byte UTF-8 encodings of the C1 controls (U+0080..U+009F).
- * Tab, newline and carriage return become `\t`, `\n`, `\r`; everything else
- * becomes `\xNN`. Valid multi-byte UTF-8 passes through untouched.
+ * bytes a terminal would act on rather than print. Tab, newline and carriage
+ * return become `\t`, `\n`, `\r`; everything else ctrl_seq_len() flags becomes
+ * `\xNN`. Valid multi-byte UTF-8 passes through untouched.
  *
  * File names are untrusted input - anyone who can create a file inside a
  * scanned tree chooses bytes that reach the administrator's terminal - and a
@@ -150,9 +166,29 @@ void sanitize_ctrl(const char *in, char *out, size_t out_sz);
 /*
  * sanitize_ctrl() into a freshly allocated string sized to hold the whole
  * escaped path, for the print sites that have no buffer to spare and must not
- * truncate. Returns NULL only if the allocation fails; callers print the raw
- * pointer's fallback rather than losing the message.
+ * truncate - a path may exceed PATH_MAX (#117), and a truncated one names a
+ * different file. Returns NULL only if the allocation fails.
  */
 char *path_for_display(const char *path);
+
+/*
+ * Declare `var` as a display-safe view of the path `p`, valid to the end of the
+ * enclosing block:
+ *
+ *	declare_display_path(dpath, path);
+ *	eprintf("cannot open %s\n", dpath);
+ *
+ * A *declaration* macro, in the shape of declare_alloc_tracking() - deliberately
+ * not a statement expression, since `({ ... })` would end the cleanup scope and
+ * free the string before the printf could read it. So it has to sit where a
+ * declaration may, which every print site already is.
+ *
+ * `p` is evaluated twice; pass a plain lvalue. If the allocation fails `var` is
+ * the unescaped path - a message the admin can act on beats no message, and the
+ * memory to do better is already gone.
+ */
+#define declare_display_path(var, p)					\
+	_cleanup_(freep) char *var##_escaped = path_for_display(p);	\
+	const char *var = var##_escaped ? var##_escaped : (p)
 
 #endif	/* __UTIL_H__ */

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -283,13 +283,18 @@ class DuperemoveTest(unittest.TestCase):
 
     # -- running oans ------------------------------------------------
 
-    def dm(self, *args, hashfile=True, stdin=None, env=None, quiet=True):
+    def dm(self, *args, hashfile=True, stdin=None, env=None, quiet=True,
+           text=True):
         """Run oans; capture combined output in self.out and code in self.rc.
 
         Pass stdin=<str> to feed the process on standard input (e.g. a "-"
         file list), or env={...} to add environment variables for this run.
         Runs with -q by default (terse output); pass quiet=False to get the
         full human summary block (e.g. to assert on the 'Reclaimed' line).
+
+        text=False leaves self.out as raw bytes, for the tests that assert on
+        exactly which bytes reached the terminal (#202) - decoding would hide
+        the thing under test.
         """
         _settle_scratch()   # the tree must be on disk before oans maps it
         cmd = [DUPEREMOVE, "--io-threads=4"]
@@ -302,7 +307,7 @@ class DuperemoveTest(unittest.TestCase):
         if env:
             run_env = dict(os.environ, **env)
         proc = subprocess.run(cmd, input=stdin, stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT, text=True, env=run_env)
+                              stderr=subprocess.STDOUT, text=text, env=run_env)
         self.out = proc.stdout
         self.rc = proc.returncode
         return self.out

--- a/tests/integration/test_escape_names.py
+++ b/tests/integration/test_escape_names.py
@@ -12,30 +12,28 @@ but NUL and '/'.
 
 import json
 import os
-import subprocess
 import unittest
 
-from harness import DUPEREMOVE, DuperemoveTest, requires_reflink
+from harness import DuperemoveTest, requires_reflink
 
-# One name per trick: a carriage return that would rewrite the previous line, a
-# screen-clearing CSI, a BEL, and a DEL.
+# One name per trick, paired with how it must come out: a carriage return that
+# would rewrite the previous line, a screen-clearing CSI, a BEL, and a DEL. One
+# table so adding a trick is one edit, not two that can drift.
 EVIL_NAMES = [
-    b"cr\rSUCCESS-reclaimed-9-TiB.bin",
-    b"esc\x1b[2J\x1b[31mred.bin",
-    b"bel\x07.bin",
-    b"del\x7f.bin",
+    (b"cr\rSUCCESS-reclaimed-9-TiB.bin", b"cr\\rSUCCESS"),
+    (b"esc\x1b[2J\x1b[31mred.bin", b"esc\\x1b[2J"),
+    (b"bel\x07.bin", b"bel\\x07"),
+    (b"del\x7f.bin", b"del\\x7f"),
 ]
 
 
 class EscapeNamesTest(DuperemoveTest):
     def run_raw(self, *args, expect_ok=True):
         """Run oans with the output captured as raw bytes, not decoded text."""
-        p = subprocess.run(
-            [DUPEREMOVE, "--io-threads=4", "--hashfile", self.hf, *args],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out = self.dm(*args, quiet=False, text=False)
         if expect_ok:
-            self.assertEqual(p.returncode, 0, p.stderr.decode(errors="replace"))
-        return p.stdout + p.stderr
+            self.assertEqual(self.rc, 0, out.decode(errors="replace"))
+        return out
 
     def assertNoControlBytes(self, out):
         """No byte a terminal acts on, other than the newlines oans writes.
@@ -50,13 +48,21 @@ class EscapeNamesTest(DuperemoveTest):
 
     def _tree(self, size=200_000):
         """A tree of duplicate pairs, every one of them evilly named."""
+        # path() makes the *parent*; these names are bytes, so the tree is
+        # built by hand rather than through write()/mkdup().
         d = self.path("tree")
         os.makedirs(d, exist_ok=True)
-        for i, name in enumerate(EVIL_NAMES):
+        for name, _escaped in EVIL_NAMES:
             data = os.urandom(size)
             for side in (b"a-", b"b-"):
                 with open(os.path.join(d.encode(), side + name), "wb") as f:
                     f.write(data)
+        return d
+
+    def _scanned_tree(self, size=8192):
+        """A scanned evil tree, for the report modes that read the hashfile."""
+        d = self._tree(size=size)
+        self.run_raw("-r", d)
         return d
 
     @requires_reflink
@@ -64,10 +70,8 @@ class EscapeNamesTest(DuperemoveTest):
         out = self.run_raw("-rdv", self._tree())
         self.assertNoControlBytes(out)
         # The names are still identifiable, just spelled safely.
-        self.assertIn(b"cr\\rSUCCESS", out)
-        self.assertIn(b"esc\\x1b[2J", out)
-        self.assertIn(b"bel\\x07", out)
-        self.assertIn(b"del\\x7f", out)
+        for _name, escaped in EVIL_NAMES:
+            self.assertIn(escaped, out)
 
     def test_scan_and_listing_escape_names(self):
         d = self._tree(size=8192)
@@ -90,13 +94,11 @@ class EscapeNamesTest(DuperemoveTest):
         self.assertNoControlBytes(out)
 
     def test_stats_escapes_stored_paths(self):
-        d = self._tree(size=8192)
-        self.run_raw("-r", d)
+        self._scanned_tree()
         self.assertNoControlBytes(self.run_raw("--stats"))
 
     def test_json_report_escapes_and_stays_parseable(self):
-        d = self._tree(size=8192)
-        self.run_raw("-r", d)
+        self._scanned_tree()
         out = self.run_raw("--json")
         self.assertNoControlBytes(out)
         json.loads(out.decode())          # still one valid object

--- a/tests/integration/test_escape_names.py
+++ b/tests/integration/test_escape_names.py
@@ -1,0 +1,117 @@
+"""File names are untrusted input and must never reach the terminal raw (#202).
+
+Anyone who can create a file inside a scanned tree picks bytes that oans then
+prints to the administrator's terminal. A `\\r` overwrites the line above it (the
+summary, or the progress block); an ESC sequence can clear the screen, change
+colours, or - on some terminals - wedge them. So every path oans prints is
+escaped: reports, error messages, the -L listing and --stats.
+
+These names are made with bytes paths on purpose; btrfs and xfs accept any byte
+but NUL and '/'.
+"""
+
+import json
+import os
+import subprocess
+import unittest
+
+from harness import DUPEREMOVE, DuperemoveTest, requires_reflink
+
+# One name per trick: a carriage return that would rewrite the previous line, a
+# screen-clearing CSI, a BEL, and a DEL.
+EVIL_NAMES = [
+    b"cr\rSUCCESS-reclaimed-9-TiB.bin",
+    b"esc\x1b[2J\x1b[31mred.bin",
+    b"bel\x07.bin",
+    b"del\x7f.bin",
+]
+
+
+class EscapeNamesTest(DuperemoveTest):
+    def run_raw(self, *args, expect_ok=True):
+        """Run oans with the output captured as raw bytes, not decoded text."""
+        p = subprocess.run(
+            [DUPEREMOVE, "--io-threads=4", "--hashfile", self.hf, *args],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if expect_ok:
+            self.assertEqual(p.returncode, 0, p.stderr.decode(errors="replace"))
+        return p.stdout + p.stderr
+
+    def assertNoControlBytes(self, out):
+        """No byte a terminal acts on, other than the newlines oans writes.
+
+        Output is not a tty here, so oans emits no ANSI of its own - anything
+        left is from a file name.
+        """
+        for b in (b"\x1b", b"\r", b"\x07", b"\x7f"):
+            self.assertNotIn(b, out,
+                             f"raw {b!r} reached the terminal:\n"
+                             f"{out.decode(errors='replace')}")
+
+    def _tree(self, size=200_000):
+        """A tree of duplicate pairs, every one of them evilly named."""
+        d = self.path("tree")
+        os.makedirs(d, exist_ok=True)
+        for i, name in enumerate(EVIL_NAMES):
+            data = os.urandom(size)
+            for side in (b"a-", b"b-"):
+                with open(os.path.join(d.encode(), side + name), "wb") as f:
+                    f.write(data)
+        return d
+
+    @requires_reflink
+    def test_dedupe_report_and_summary_escape_names(self):
+        out = self.run_raw("-rdv", self._tree())
+        self.assertNoControlBytes(out)
+        # The names are still identifiable, just spelled safely.
+        self.assertIn(b"cr\\rSUCCESS", out)
+        self.assertIn(b"esc\\x1b[2J", out)
+        self.assertIn(b"bel\\x07", out)
+        self.assertIn(b"del\\x7f", out)
+
+    def test_scan_and_listing_escape_names(self):
+        d = self._tree(size=8192)
+        self.assertNoControlBytes(self.run_raw("-rv", d))
+        self.assertNoControlBytes(self.run_raw("-L"))
+
+    def test_error_messages_escape_names(self):
+        """The message about an unreadable file names it - safely."""
+        if os.geteuid() == 0:
+            self.skipTest("running as root defeats chmod 000")
+        d = self.path("tree")
+        os.makedirs(d, exist_ok=True)
+        victim = os.path.join(d.encode(), b"esc\x1b[2Jlocked.bin")
+        with open(victim, "wb") as f:
+            f.write(os.urandom(65536))
+        os.chmod(victim, 0)
+
+        out = self.run_raw("-rv", d)
+        self.assertIn(b"esc\\x1b[2Jlocked.bin", out)
+        self.assertNoControlBytes(out)
+
+    def test_stats_escapes_stored_paths(self):
+        d = self._tree(size=8192)
+        self.run_raw("-r", d)
+        self.assertNoControlBytes(self.run_raw("--stats"))
+
+    def test_json_report_escapes_and_stays_parseable(self):
+        d = self._tree(size=8192)
+        self.run_raw("-r", d)
+        out = self.run_raw("--json")
+        self.assertNoControlBytes(out)
+        json.loads(out.decode())          # still one valid object
+
+    def test_a_plain_name_is_printed_unchanged(self):
+        """The escape must be invisible for the names people actually have.
+
+        A duplicate pair, because a name only reaches the report when its file
+        is in a group.
+        """
+        self.mkdup("tree/café-Β a.bin", "tree/café-Β b.bin", 200_000)
+        out = self.run_raw("-rv", self.path("tree"))
+        self.assertIn("café-Β a.bin".encode(), out)
+        self.assertNotIn(b"\\x", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -181,6 +181,24 @@ class ProgressTtyTest(DuperemoveTest):
             any("2 permission denied" in ln for ln in screen),
             f"the scan-skip report was erased by the block:\n  {shown}")
 
+    def test_a_crafted_name_cannot_inject_ansi_into_the_block(self):
+        """The worker rows are drawn straight to the tty (#202).
+
+        The block's own ANSI is expected; what must never appear is a sequence
+        that came out of a file name. ESC[2J would clear the user's screen.
+        """
+        d = os.path.join(self.work, "tree")
+        os.makedirs(d, exist_ok=True)
+        for side in (b"a-", b"b-"):
+            with open(os.path.join(d.encode(),
+                                   side + b"esc\x1b[2J\x1b[31mred.bin"),
+                      "wb") as f:
+                f.write(b"z" * (4 * 1024 * 1024))
+
+        raw = _run_in_pty([DUPEREMOVE, "-dvr", "--hashfile", self.hf, d])
+        self.assertNotIn(b"\x1b[2J", raw, "a file name's ESC[2J reached the tty")
+        self.assertIn(b"esc\\x1b[2J", raw, "the name was not printed at all")
+
     # Depends on hashing outlasting one REDRAW_MS (100 ms) tick, so the row
     # exists at a redraw. Kept CPU-bound (4K blocks, partial mode) rather than
     # sized in bytes: a faster disk shrinks an I/O-bound run but not this one.


### PR DESCRIPTION
Closes #202.

## Problem

Only two sites escaped names (the progress row and the group report, both via `sanitize_ctrl()`). Everything else printed them raw: every `eprintf`/`vprintf` in `file_scan.c`, `filerec_open()`, the `-L` listing, `--stats` (stored roots/excludes and the top-group example), and the verbose dedupe lines in `run_dedupe.c`/`dedupe.c`.

Four of the six new integration tests fail on `v1.10.1`, so this was live: a name like `cr\rSUCCESS-reclaimed-9-TiB.bin` rewrites the line above it, and `esc\x1b[2J…` clears the admin's screen.

## Fix

One escaping core in `src/util.c`, applied at every site that prints a path.

- **`sanitize_ctrl()` now uses C escapes** — `\t`, `\n`, `\r`, and `\xNN` for every other C0 control, DEL, and the UTF-8 C1 controls — instead of collapsing each to `?`. An error message has to name a file the admin can go and find; `?` can't distinguish two names, let alone say what was in one. Valid multi-byte UTF-8 still passes through untouched.
- **`path_for_display()`** is the allocating form, for the sites that have no buffer to spare and must not truncate (paths can exceed `PATH_MAX`, #117).
- **`--json`**: `print_json_str()` already escaped C0 as `\u00NN`; DEL and the C1 controls now join it.

Worst-case expansion is `SANITIZE_CTRL_MAX` (4) per byte; both fixed-buffer callers are resized for it, and `sanitize_ctrl()` truncates at the last *complete* escape rather than emitting half of one.

### Two judgment calls

**No `DISP(path)` macro.** The obvious statement-expression wrapper is a use-after-free — a `_cleanup_` variable inside `({ … })` is freed at the end of the expression, before `printf` reads the pointer. So each site takes an explicit `_cleanup_(freep) char *disp = path_for_display(p);` and prints `disp ? disp : p` (an OOM message the admin can act on beats no message). It is more lines, but it is correct and it does not add TLS or a lifetime rule.

**All the sites, not the handful.** The issue suggests preferring a few central sites over hunting every call. But the acceptance criterion is that no raw control byte reaches stdout/stderr in any mode, and "Failed to stat <name>" is the same attack as the progress row. On the per-file hot path (`check_file()`) the allocation is inside the branch that prints, so a clean run allocates nothing new; `probe_fs()` runs once per root, so it escapes once at the top and its eight messages share it.

## Tests

- **Unit** (`src/tests.c`): the new spelling, C1 collapse, truncation not splitting an escape, and `path_for_display()`.
- **`tests/integration/test_escape_names.py`** (new): a tree whose every file is named with `\r`, `ESC[2J`, BEL or DEL, captured as **raw bytes** (`text=False` — decoding the output would hide exactly what is being tested). Asserts no `\x1b`/`\r`/`\x07`/`\x7f` reaches either stream across `-rdv`, `-L`, `--stats`, `--json` and the unreadable-file error path, that the names are still identifiable in escaped form, and that a plain `café-Β` name is printed byte-identical.
- **`test_progress_tty.py`**: a crafted name must not put `ESC[2J` into the pty stream.

## Gate

`scripts/verify.sh` green (218 tests, valgrind smoke). The new tests also run clean under `tests/valgrind-wrap.sh` — no findings from the added allocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)