### PR TITLE
scan: copy hashes when a file's physical layout is one already hashed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,10 +488,20 @@ medians, same RSS.
   inside the open batch, so a donor hashed seconds ago is visible before any
   commit. (The issue anticipated needing a fallback for this; a different
   connection *would* need one.)
-- **`LAYOUT_COPY_MIN_SIZE = READ_BUF_LEN` (1 MiB).** The map is one entry per
-  candidate donor, so on a multi-million-file tree it would be tens of MB of RSS
-  for nothing (see #208). Below one read buffer the file is a single I/O and the
-  bookkeeping costs more than it saves.
+- **`LAYOUT_COPY_MIN_SIZE = READ_BUF_LEN` (1 MiB), checked *before* the key is
+  built.** The map is one entry per candidate donor, so on a multi-million-file
+  tree it would be tens of MB of RSS for nothing (see #208); below one read
+  buffer the file is a single I/O and the bookkeeping costs more than it saves.
+  Gating after the key — as the first cut did — meant every small file, and
+  every file at all under the kill switch, paid for a hash that could never
+  match, since the size is part of the key.
+- **The donor table is open-addressed with inline slots, like `seen_inodes`** —
+  a `GHashTable` node plus a malloc per entry is ~50 B where the entry is 24,
+  and there is one per large file. Same reason that set stopped using one.
+- **Nothing gates this on `--hashfile`.** A run without one keeps its rows in an
+  in-memory database that the copy reads and writes identically; measured, the
+  dedupe outcome is the same with and without. Only `DUPEREMOVE_NO_LAYOUT_COPY`
+  turns it off.
 - **A hit needs the donor to have *finished*.** With N workers, a file and its
   snapshot are often hashed side by side and neither can donate — measured 74-82%
   hit rate on small trees, and it only improves with tree size. Fine in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,6 +452,55 @@ is the false premise this took two PRs to unwind:
   means "the user never asked", so `dbfile_load_scan_config` coerces `< 0` to 0 —
   a replay adopts the new default; only an explicit `1` survives.
 
+## Snapshot-aware scan: copy hashes for an identical layout (#206)
+
+Hashing N snapshots of a subvolume read N× the data. Two files whose fiemaps
+describe **the same records** (`fe_logical`, `fe_physical`, `fe_length`,
+`fe_flags`, over the same size) are backed by the same stored bytes, so the
+second one's digest, extent hashes and block hashes are **copied** instead of
+computed. Measured on a 4-snapshot 7.5 GiB tree, cold: **2.36 s → 0.65 s**
+(3.6×, against a ceiling of 4×). Flat on `realistic`/`many`/`big` — same
+medians, same RSS.
+
+- **Misses are free, false hits are catastrophic.** A miss costs one redundant
+  hash; a wrong copy stores a digest of bytes the file never had, and nothing
+  downstream could tell that from a file with no duplicate. Hence three
+  independent bars, all of which must pass: `fiemap_layout_key()` refuses any
+  record whose address it cannot vouch for (DATA_INLINE, UNKNOWN, DELALLOC,
+  DATA_ENCRYPTED, or no extents at all), the key is a 128-bit digest of *every*
+  record, and `dbfile_layout_matches()` then re-checks the donor's stored
+  `(loff, poff, len)` triples one at a time.
+  - **Never normalize or merge records to chase more hits.** The same storage
+    described with different record boundaries (#186) must read as a *miss*.
+  - SHARED and LAST are masked out of the key: the first changes when an
+    unrelated file is deduped, the second is positional. Neither says anything
+    about content. COMPRESSED/ENCODED is fine — this only ever compares
+    `fe_physical` for equality, never does arithmetic on it.
+- **The re-check needs no extra state: the donor's `extents` rows *are* its
+  fiemap record array.** So the in-memory map holds only a key and a file id,
+  and a donor whose rows vanished (aborted batch, hardlink cascade, only_whole_
+  files) verifies as a miss by construction rather than needing a guard.
+- **Donors are this run's files only.** Block size, `--skip-zeroes` and the rest
+  of the hashing options are then the same by construction; an older hashfile's
+  rows might have been produced under different ones.
+- **No visibility hazard, because every scan write goes through the one shared
+  `scan_writer` connection.** The re-check and the copy run on that connection
+  inside the open batch, so a donor hashed seconds ago is visible before any
+  commit. (The issue anticipated needing a fallback for this; a different
+  connection *would* need one.)
+- **`LAYOUT_COPY_MIN_SIZE = READ_BUF_LEN` (1 MiB).** The map is one entry per
+  candidate donor, so on a multi-million-file tree it would be tens of MB of RSS
+  for nothing (see #208). Below one read buffer the file is a single I/O and the
+  bookkeeping costs more than it saves.
+- **A hit needs the donor to have *finished*.** With N workers, a file and its
+  snapshot are often hashed side by side and neither can donate — measured 74-82%
+  hit rate on small trees, and it only improves with tree size. Fine in
+  production; tests pin it with `--io-threads=1`.
+- `DUPEREMOVE_NO_LAYOUT_COPY=1` is the kill switch. **The gate is byte-identical
+  output against a run with it set** (`test_layout_copy.py`), not "the counter
+  went up" — that is the only definition of correct here. Off automatically
+  without `--hashfile`.
+
 ## Measured dead-ends — don't re-attempt without new evidence
 
 - **Separating the walk from hashing into two sequential phases is not worth it.**

--- a/docs/man/oans.8
+++ b/docs/man/oans.8
@@ -374,9 +374,17 @@ any other directory.
 Turn it on where your snapshots are near\-copies of the live subvolume,
 which is the shape a snapper/Timeshift desktop has.
 A fresh snapshot already shares every extent with the subvolume it came
-from, so reading and hashing it reclaims nothing, and the waste scales
-with snapshot count: 20 snapshots of a 1 TiB tree means reading \(ti20
-TiB to reclaim nothing from 19 of them.
+from, so reading and hashing it reclaims nothing.
+.PP
+That cost is much smaller than it used to be.
+Within a run, \f[CR]oans\f[R] recognises a file whose extents are
+exactly those of a file it has already hashed \(em the normal case for a
+snapshot \(em and takes over that file\(cqs hashes instead of reading it
+a second time.
+The summary reports those as \f[I]Same layout\f[R], with the volume not
+read.
+So a snapshot tree is now mostly free to scan, and this option is worth
+reaching for only when even that is too much.
 .PP
 Leave it off for a backup target \(em an
 rsync\-into\-a\-subvolume\-then\-snapshot setup, say \(em where each
@@ -498,6 +506,20 @@ Summary
   Elapsed        92.1s
   Already shared 350708 files skipped (no work needed)
 .EE
+.PP
+A scan over a tree containing snapshots also prints:
+.IP
+.EX
+  Same layout    18432 files matched an already\-hashed layout (1.4 TiB not read)
+.EE
+.PP
+Those files were not read.
+Their content was proved identical to a file already hashed in the same
+run \(em every extent at the same physical address, over the same file
+size \(em so their hashes were taken over rather than recomputed.
+The digests are exactly what reading them would have produced; a layout
+that differs in any way, including the same storage described with
+different extent boundaries, is simply hashed normally.
 .PP
 \f[B]Reclaimed\f[R] is the disk space actually freed: for a group of
 \f[I]N\f[R] identical copies, \f[CR]oans\f[R] keeps one physical copy

--- a/docs/man/oans.md
+++ b/docs/man/oans.md
@@ -310,8 +310,16 @@ file is recorded once.
     Turn it on where your snapshots are near-copies of the live subvolume, which
     is the shape a snapper/Timeshift desktop has. A fresh snapshot already shares
     every extent with the subvolume it came from, so reading and hashing it
-    reclaims nothing, and the waste scales with snapshot count: 20 snapshots of a
-    1 TiB tree means reading ~20 TiB to reclaim nothing from 19 of them.
+    reclaims nothing.
+
+    <!-- -->
+
+    That cost is much smaller than it used to be. Within a run, `oans`
+    recognises a file whose extents are exactly those of a file it has already
+    hashed — the normal case for a snapshot — and takes over that file's hashes
+    instead of reading it a second time. The summary reports those as *Same
+    layout*, with the volume not read. So a snapshot tree is now mostly free to
+    scan, and this option is worth reaching for only when even that is too much.
 
     Leave it off for a backup target — an rsync-into-a-subvolume-then-snapshot
     setup, say — where each snapshot holds independently written copies of
@@ -418,6 +426,19 @@ Summary
   Elapsed        92.1s
   Already shared 350708 files skipped (no work needed)
 ```
+
+A scan over a tree containing snapshots also prints:
+
+```
+  Same layout    18432 files matched an already-hashed layout (1.4 TiB not read)
+```
+
+Those files were not read. Their content was proved identical to a file already
+hashed in the same run — every extent at the same physical address, over the
+same file size — so their hashes were taken over rather than recomputed. The
+digests are exactly what reading them would have produced; a layout that differs
+in any way, including the same storage described with different extent
+boundaries, is simply hashed normally.
 
 **Reclaimed** is the disk space actually freed: for a group of *N* identical
 copies, `oans` keeps one physical copy and frees the other *N*−1, so this is the

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -2116,33 +2116,22 @@ int dbfile_layout_matches(struct dbhandle *db, int64_t donor,
 int dbfile_copy_scanned_file(struct dbhandle *db, int64_t dst, int64_t donor,
 			     unsigned int flags)
 {
-	sqlite3_stmt *stmts[3] = { db->stmts.copy_extent_hashes,
-				   db->stmts.copy_block_hashes,
-				   db->stmts.copy_scanned_file };
-	unsigned int i;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *ext = db->stmts.copy_extent_hashes;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *blk = db->stmts.copy_block_hashes;
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *row = db->stmts.copy_scanned_file;
+	int ret;
 
-	for (i = 0; i < ARRAY_SIZE(stmts); i++) {
-		_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = stmts[i];
-		int ret = sqlite3_bind_int64(stmt, 1, dst);
-
-		if (!ret)
-			ret = sqlite3_bind_int64(stmt, 2, donor);
-		/* Only the last statement has a ?3; binding an index a
-		 * statement does not declare is an error, not a no-op. */
-		if (!ret && stmt == db->stmts.copy_scanned_file)
-			ret = sqlite3_bind_int64(stmt, 3, flags);
-		if (ret) {
-			perror_sqlite(ret, "binding values");
-			return ret;
-		}
-		ret = sqlite3_step(stmt);
-		if (ret != SQLITE_DONE) {
-			perror_sqlite(ret, "copying a donor's hashes");
-			return ret;
-		}
-	}
-
-	return 0;
+	/* ?1 = destination, ?2 = donor - run_by_fileid_arg()'s shape exactly. */
+	ret = run_by_fileid_arg(ext, dst, donor);
+	if (!ret)
+		ret = run_by_fileid_arg(blk, dst, donor);
+	if (!ret)
+		ret = sqlite3_bind_int64(row, 3, flags);
+	if (!ret)
+		ret = run_by_fileid_arg(row, dst, donor);
+	if (ret)
+		perror_sqlite(ret, "copying a donor's hashes");
+	return ret;
 }
 
 int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -1003,6 +1003,32 @@ static struct dbhandle *open_handle(char *filename, bool readonly)
 #define UPDATE_DEDUPE_SEQ "update files set dedupe_seq = ?2 where id = ?1;"
 	dbfile_prepare_stmt(update_dedupe_seq, UPDATE_DEDUPE_SEQ);
 
+	/* Snapshot-aware scan (#206). The donor's stored extent rows are the
+	 * record array its fiemap reported, so they double as the exact
+	 * re-check behind the layout key's hash. */
+#define SELECT_LAYOUT							\
+"select loff, poff, len from extents where fileid = ?1 order by loff;"
+	dbfile_prepare_stmt(select_layout, SELECT_LAYOUT);
+
+#define COPY_EXTENT_HASHES						\
+"insert into extents (fileid, loff, poff, len, digest) "		\
+"select ?1, loff, poff, len, digest from extents where fileid = ?2;"
+	dbfile_prepare_stmt(copy_extent_hashes, COPY_EXTENT_HASHES);
+
+#define COPY_BLOCK_HASHES						\
+"insert into blocks (fileid, loff, digest) "				\
+"select ?1, loff, digest from blocks where fileid = ?2;"
+	dbfile_prepare_stmt(copy_block_hashes, COPY_BLOCK_HASHES);
+
+	/* nr_extents comes from the donor because the two layouts were just
+	 * proved identical; flags do not, since FILE_RO_SUBVOL describes where
+	 * *this* file lives, not what it contains. */
+#define COPY_SCANNED_FILE						\
+"update files set digest = (select digest from files where id = ?2), "	\
+"nr_extents = (select nr_extents from files where id = ?2), "		\
+"flags = ?3 where id = ?1;"
+	dbfile_prepare_stmt(copy_scanned_file, COPY_SCANNED_FILE);
+
 #define RENAME_FILE							\
 "update or replace files set filename = ?1, path_hash = ?2 where id = ?3;"
 	dbfile_prepare_stmt(rename_file, RENAME_FILE);
@@ -2050,6 +2076,73 @@ int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid)
 {
 	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.delete_checkpoint;
 	return run_by_fileid(stmt, fileid);
+}
+
+int dbfile_layout_matches(struct dbhandle *db, int64_t donor,
+			  const struct fiemap *fm)
+{
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.select_layout;
+	unsigned int i = 0;
+	int ret;
+
+	ret = sqlite3_bind_int64(stmt, 1, donor);
+	if (ret) {
+		perror_sqlite(ret, "binding values");
+		return -1;
+	}
+
+	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
+		const struct fiemap_extent *e;
+
+		if (i >= fm->fm_mapped_extents)
+			return 0;		/* donor has more records */
+		e = &fm->fm_extents[i++];
+		if ((uint64_t)sqlite3_column_int64(stmt, 0) != e->fe_logical ||
+		    (uint64_t)sqlite3_column_int64(stmt, 1) != e->fe_physical ||
+		    (uint64_t)sqlite3_column_int64(stmt, 2) != e->fe_length)
+			return 0;
+	}
+
+	if (ret != SQLITE_DONE) {
+		perror_sqlite(ret, "reading a donor's extent layout");
+		return -1;
+	}
+
+	/* Zero rows means the donor stored no extents at all - nothing to
+	 * verify against, so decline. */
+	return i == fm->fm_mapped_extents && i > 0;
+}
+
+int dbfile_copy_scanned_file(struct dbhandle *db, int64_t dst, int64_t donor,
+			     unsigned int flags)
+{
+	sqlite3_stmt *stmts[3] = { db->stmts.copy_extent_hashes,
+				   db->stmts.copy_block_hashes,
+				   db->stmts.copy_scanned_file };
+	unsigned int i;
+
+	for (i = 0; i < ARRAY_SIZE(stmts); i++) {
+		_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = stmts[i];
+		int ret = sqlite3_bind_int64(stmt, 1, dst);
+
+		if (!ret)
+			ret = sqlite3_bind_int64(stmt, 2, donor);
+		/* Only the last statement has a ?3; binding an index a
+		 * statement does not declare is an error, not a no-op. */
+		if (!ret && stmt == db->stmts.copy_scanned_file)
+			ret = sqlite3_bind_int64(stmt, 3, flags);
+		if (ret) {
+			perror_sqlite(ret, "binding values");
+			return ret;
+		}
+		ret = sqlite3_step(stmt);
+		if (ret != SQLITE_DONE) {
+			perror_sqlite(ret, "copying a donor's hashes");
+			return ret;
+		}
+	}
+
+	return 0;
 }
 
 int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <uuid/uuid.h>
 
+#include <linux/fiemap.h>
+
 #include "util.h"
 #include "csum.h"
 #include "threads.h"
@@ -60,6 +62,10 @@ struct stmts {
 	sqlite3_stmt *select_checkpoint;
 	sqlite3_stmt *delete_checkpoint;
 	sqlite3_stmt *update_dedupe_seq;
+	sqlite3_stmt *select_layout;
+	sqlite3_stmt *copy_extent_hashes;
+	sqlite3_stmt *copy_block_hashes;
+	sqlite3_stmt *copy_scanned_file;
 };
 
 struct dbhandle {
@@ -91,6 +97,33 @@ struct file {
 	bool		digest_valid;
 	unsigned int	flags;
 };
+
+/*
+ * Snapshot-aware scan (#206). Two files with identical physical layouts hold
+ * identical bytes, so the second one's hashes can be copied from the first
+ * instead of read off the disk again.
+ *
+ * dbfile_layout_matches() re-checks a candidate donor record-for-record
+ * against `fm`: fiemap_layout_key() only produces a hash, and a hash collision
+ * must not become a wrong digest. The stored extent rows carry the very
+ * (loff, poff, len) triples the donor's fiemap reported, so the check needs no
+ * extra state and no second look at the donor on disk. Returns 1 on an exact
+ * match, 0 on any difference (including a donor with no extent rows, e.g. one
+ * scanned under --dedupe-options=only_whole_files), negative on error.
+ *
+ * dbfile_copy_scanned_file() copies the donor's extent rows, block rows and
+ * content digest onto `dst`, which is everything hashing it would have
+ * produced. `flags` is the destination's own - FILE_RO_SUBVOL describes where
+ * a file lives, not what it holds.
+ *
+ * Both must run on the connection that wrote the donor's rows - the scan's
+ * shared writer - so a donor hashed moments ago in the still-open batch is
+ * visible; a different connection would not see it until commit.
+ */
+int dbfile_layout_matches(struct dbhandle *db, int64_t donor,
+			  const struct fiemap *fm);
+int dbfile_copy_scanned_file(struct dbhandle *db, int64_t dst, int64_t donor,
+			     unsigned int flags);
 
 struct dbhandle *dbfile_open_handle(char *filename);
 /* Read-only open for report modes: no writes, safe to run while another oans

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -18,6 +18,7 @@
 #include <sys/ioctl.h>
 #include <linux/fs.h>
 
+#include "csum.h"
 #include "debug.h"
 #include "fiemap.h"
 #include "util.h"
@@ -464,4 +465,52 @@ uint64_t fiemap_unshared_bytes(struct fiemap_phys_set *seen,
 	if (fresh)
 		phys_set_merge(seen, fresh, sort_uniq(fresh, n_fresh));
 	return unshared;
+}
+
+/* Flags that make a record's physical address meaningless or unstable. */
+#define LAYOUT_REJECT_FLAGS	(FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_DELALLOC | \
+				 FIEMAP_EXTENT_DATA_INLINE | FIEMAP_EXTENT_DATA_ENCRYPTED)
+/* Flags that say nothing about content. */
+#define LAYOUT_IGNORE_FLAGS	(FIEMAP_EXTENT_SHARED | FIEMAP_EXTENT_LAST)
+
+bool fiemap_layout_key(const struct fiemap *fm, uint64_t size,
+		       unsigned char *key)
+{
+	struct running_checksum *csum;
+	uint64_t header[2];
+	unsigned int i;
+
+	if (!fm || fm->fm_mapped_extents == 0)
+		return false;
+
+	for (i = 0; i < fm->fm_mapped_extents; i++) {
+		if (fm->fm_extents[i].fe_flags & LAYOUT_REJECT_FLAGS)
+			return false;
+	}
+
+	csum = start_running_checksum();
+	if (!csum)
+		return false;
+
+	/*
+	 * Size and extent count go in first, so a layout that is a prefix of
+	 * another cannot hash the same, and the size covers a trailing hole -
+	 * which fiemap does not report at all.
+	 */
+	header[0] = size;
+	header[1] = fm->fm_mapped_extents;
+	add_to_running_checksum(csum, (unsigned char *)header, sizeof(header));
+
+	for (i = 0; i < fm->fm_mapped_extents; i++) {
+		const struct fiemap_extent *e = &fm->fm_extents[i];
+		uint64_t rec[4] = {
+			e->fe_logical, e->fe_physical, e->fe_length,
+			e->fe_flags & ~(uint64_t)LAYOUT_IGNORE_FLAGS,
+		};
+
+		add_to_running_checksum(csum, (unsigned char *)rec, sizeof(rec));
+	}
+
+	finish_running_checksum(csum, key);
+	return true;
 }

--- a/src/fiemap.c
+++ b/src/fiemap.c
@@ -473,44 +473,60 @@ uint64_t fiemap_unshared_bytes(struct fiemap_phys_set *seen,
 /* Flags that say nothing about content. */
 #define LAYOUT_IGNORE_FLAGS	(FIEMAP_EXTENT_SHARED | FIEMAP_EXTENT_LAST)
 
+/* Extents whose records fit here are keyed without touching the heap; a real
+ * file has one. The fragmented case falls back to a single allocation. */
+#define LAYOUT_KEY_STACK_EXTENTS	32
+
 bool fiemap_layout_key(const struct fiemap *fm, uint64_t size,
 		       unsigned char *key)
 {
-	struct running_checksum *csum;
-	uint64_t header[2];
+	uint64_t stack_rec[2 + 4 * LAYOUT_KEY_STACK_EXTENTS];
+	_cleanup_(freep) uint64_t *heap_rec = NULL;
+	uint64_t *rec = stack_rec;
+	size_t words, bytes;
 	unsigned int i;
 
 	if (!fm || fm->fm_mapped_extents == 0)
 		return false;
 
-	for (i = 0; i < fm->fm_mapped_extents; i++) {
-		if (fm->fm_extents[i].fe_flags & LAYOUT_REJECT_FLAGS)
-			return false;
-	}
-
-	csum = start_running_checksum();
-	if (!csum)
+	words = 2 + 4 * (size_t)fm->fm_mapped_extents;
+	bytes = words * sizeof(*rec);
+	/* checksum_block() takes an int length. Nothing real gets here, and a
+	 * miss costs only a redundant hash. */
+	if (bytes > INT_MAX)
 		return false;
+
+	if (words > ARRAY_SIZE(stack_rec)) {
+		heap_rec = malloc(bytes);
+		if (!heap_rec)
+			return false;
+		rec = heap_rec;
+	}
 
 	/*
 	 * Size and extent count go in first, so a layout that is a prefix of
 	 * another cannot hash the same, and the size covers a trailing hole -
 	 * which fiemap does not report at all.
 	 */
-	header[0] = size;
-	header[1] = fm->fm_mapped_extents;
-	add_to_running_checksum(csum, (unsigned char *)header, sizeof(header));
+	rec[0] = size;
+	rec[1] = fm->fm_mapped_extents;
 
 	for (i = 0; i < fm->fm_mapped_extents; i++) {
 		const struct fiemap_extent *e = &fm->fm_extents[i];
-		uint64_t rec[4] = {
-			e->fe_logical, e->fe_physical, e->fe_length,
-			e->fe_flags & ~(uint64_t)LAYOUT_IGNORE_FLAGS,
-		};
+		uint64_t *r = &rec[2 + 4 * i];
 
-		add_to_running_checksum(csum, (unsigned char *)rec, sizeof(rec));
+		if (e->fe_flags & LAYOUT_REJECT_FLAGS)
+			return false;
+
+		r[0] = e->fe_logical;
+		r[1] = e->fe_physical;
+		r[2] = e->fe_length;
+		r[3] = e->fe_flags & ~(uint64_t)LAYOUT_IGNORE_FLAGS;
 	}
 
-	finish_running_checksum(csum, key);
+	/* One shot rather than the streaming API: this runs per file, and
+	 * start_running_checksum() would mean two allocations and a 576-byte
+	 * clear of an XXH3 state to hash the 48 bytes a one-extent file has. */
+	checksum_block((char *)rec, (int)bytes, key);
 	return true;
 }

--- a/src/fiemap.h
+++ b/src/fiemap.h
@@ -98,4 +98,42 @@ uint64_t fiemap_unshared_bytes(struct fiemap_phys_set *seen,
  * whole file. Returns 0 on error.
  */
 unsigned int fiemap_count_extents(int fd, uint64_t start, uint64_t length);
+
+/*
+ * Identity of a file's physical layout, for the snapshot-aware scan (#206).
+ *
+ * Two files whose fiemaps describe the same records - same logical offset,
+ * same physical address, same length, same flags, for every record, over the
+ * same file size - are backed by exactly the same stored bytes, so one's
+ * content digest describes the other. This condenses that record array into a
+ * DIGEST_LEN key, so a scan can recognise "I have already hashed these very
+ * extents" without keeping the array around.
+ *
+ * The direction of the error matters: a miss costs one redundant hash, a false
+ * hit stores a digest of bytes the file never had. So this refuses rather than
+ * guesses -
+ *
+ *   - no extents at all (a hole-only file has no layout to speak of),
+ *   - any record the kernel says it cannot pin down: UNKNOWN, DELALLOC (still
+ *     in page cache, no stable address), DATA_INLINE (lives in the metadata, so
+ *     `fe_physical` names nothing), or DATA_ENCRYPTED (equal ciphertext
+ *     addresses need not mean equal plaintext).
+ *
+ * COMPRESSED/ENCODED extents are fine, because this only ever compares
+ * `fe_physical` for equality and never does arithmetic on it - on a compressed
+ * extent the address names the extent as a whole, so equality is meaningful
+ * where an offset into it is not (see fiemap_maps_share()).
+ *
+ * SHARED and LAST are masked out of the key: the first is a refcount property
+ * that changes when an unrelated file is deduped, the second is positional.
+ * Neither says anything about content.
+ *
+ * The key is a hash, so it cannot be the whole test. The caller must still
+ * compare the records themselves before trusting a hit.
+ *
+ * Returns false (and leaves `key` untouched) when no key can be formed.
+ */
+bool fiemap_layout_key(const struct fiemap *fm, uint64_t size,
+		       unsigned char *key);
+
 #endif	/* __FIEMAP_H__ */

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2898,13 +2898,6 @@ static int64_t layout_donor_find(const unsigned char *key)
 	return found;
 }
 
-/* Bytes the donor table holds, for the memory breakdown. */
-uint64_t filescan_layout_donor_bytes(void)
-{
-	return donor_cap * sizeof(*donor_slots) +
-	       ((donor_cap + 63) / 64) * sizeof(*donor_used);
-}
-
 void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes)
 {
 	*files = atomic_load(&layout_copied_files);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2621,6 +2621,204 @@ static int fill_buffer(struct scan_ctxt *ctxt, struct buffer *buffer)
 	return buffer->dl_len;
 }
 
+/*
+ * Snapshot-aware scan (#206): hashing N snapshots of a subvolume reads N times
+ * the data for nothing, because a snapshot shares the live subvolume's extents.
+ * Two files whose fiemaps describe the same records are backed by the same
+ * stored bytes, so the second one's digest, extent hashes and block hashes can
+ * be copied from the first without reading a byte.
+ *
+ * The direction of the error is what shapes this: a miss costs one redundant
+ * hash, a false hit stores a digest of bytes the file never had. So a hit has
+ * to clear three separate bars - fiemap_layout_key() refuses any record whose
+ * address it cannot vouch for, the key itself is a 128-bit digest of every
+ * record, and dbfile_layout_matches() then re-checks the donor's stored
+ * (loff, poff, len) triples one by one. Nothing here ever normalises or merges
+ * records to chase more hits: the same storage described with different record
+ * boundaries (see #186) must read as a miss.
+ *
+ * Donors are only files hashed by *this* run, which is what makes the copied
+ * rows safe to reuse: the block size, --skip-zeroes and the rest of the hashing
+ * options are then the same by construction, where an older hashfile's rows
+ * might have been produced under different ones.
+ *
+ * Lives entirely in memory, and the entry is small (a key and a file id), but
+ * there is one per candidate donor - so only files worth the saving are
+ * registered. Below one read buffer, hashing a file is a single I/O and the
+ * bookkeeping would cost more than it saves.
+ */
+#define LAYOUT_COPY_MIN_SIZE	READ_BUF_LEN
+
+struct layout_donor {
+	unsigned char	key[DIGEST_LEN];
+	int64_t		fileid;
+};
+
+static GHashTable	*layout_donors;		/* key -> struct layout_donor */
+static GMutex		layout_donors_lock;
+static bool		layout_copy_enabled;
+static _Atomic uint64_t	layout_copied_files;
+static _Atomic uint64_t	layout_copied_bytes;
+
+static guint layout_key_hash(gconstpointer p)
+{
+	const struct layout_donor *d = p;
+	guint h;
+
+	/* The key is already a digest; fold it rather than hash it again. */
+	memcpy(&h, d->key, sizeof(h));
+	return h;
+}
+
+static gboolean layout_key_equal(gconstpointer a, gconstpointer b)
+{
+	const struct layout_donor *x = a, *y = b;
+
+	return memcmp(x->key, y->key, DIGEST_LEN) == 0;
+}
+
+static void layout_donors_init(void)
+{
+	/*
+	 * Off without a hashfile: the copy reads the donor's rows back out of
+	 * the database, and an in-memory db is discarded at exit anyway.
+	 * DUPEREMOVE_NO_LAYOUT_COPY is the kill switch a bisect or an A/B
+	 * measurement needs - with it set, every file is hashed the old way and
+	 * the hashfile must come out byte-identical.
+	 */
+	layout_copy_enabled = options.hashfile &&
+			      !getenv("DUPEREMOVE_NO_LAYOUT_COPY");
+	if (!layout_copy_enabled)
+		return;
+	layout_donors = g_hash_table_new_full(layout_key_hash, layout_key_equal,
+					      g_free, NULL);
+}
+
+static void layout_donors_free(void)
+{
+	g_clear_pointer(&layout_donors, g_hash_table_destroy);
+	layout_copy_enabled = false;
+}
+
+/* Offer a freshly hashed file as a donor for the rest of this run. */
+static void layout_donor_add(const unsigned char *key, int64_t fileid,
+			     uint64_t size)
+{
+	struct layout_donor *d;
+
+	if (!layout_copy_enabled || size < LAYOUT_COPY_MIN_SIZE)
+		return;
+
+	d = malloc(sizeof(*d));
+	if (!d)
+		return;			/* a donor is an optimisation, not state */
+	memcpy(d->key, key, DIGEST_LEN);
+	d->fileid = fileid;
+
+	g_mutex_lock(&layout_donors_lock);
+	/* First one wins: any file with this layout will do, and replacing the
+	 * entry would only churn. */
+	if (!g_hash_table_contains(layout_donors, d))
+		g_hash_table_add(layout_donors, d);
+	else
+		free(d);
+	g_mutex_unlock(&layout_donors_lock);
+}
+
+/* The file id registered for `key`, or 0 if none. */
+static int64_t layout_donor_find(const unsigned char *key)
+{
+	struct layout_donor probe, *found;
+
+	if (!layout_copy_enabled)
+		return 0;
+
+	memcpy(probe.key, key, DIGEST_LEN);
+	g_mutex_lock(&layout_donors_lock);
+	found = g_hash_table_lookup(layout_donors, &probe);
+	g_mutex_unlock(&layout_donors_lock);
+	return found ? found->fileid : 0;
+}
+
+void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes)
+{
+	*files = atomic_load(&layout_copied_files);
+	*bytes = atomic_load(&layout_copied_bytes);
+}
+
+/*
+ * Take over an already-hashed file's results when this file is backed by
+ * exactly the same extents (#206). Returns true when the hashes were copied
+ * and there is nothing left to do for this file.
+ *
+ * Runs before a single byte is read, and everything it needs is already in
+ * hand: csum_whole_file() has the fiemap because it hashes per extent, so the
+ * miss path costs one key over the record array and one hash-table probe -
+ * no extra ioctl, no extra I/O.
+ */
+static bool try_layout_copy(struct scan_ctxt *ctxt, struct file_to_scan *file,
+			    struct pscan_thread *tprogress, struct dbhandle *db,
+			    unsigned char *key_out, bool *key_valid)
+{
+	int64_t donor;
+	unsigned int flags;
+	int ret;
+
+	*key_valid = fiemap_layout_key(ctxt->fiemap, ctxt->filesize, key_out);
+	if (!*key_valid)
+		return false;
+
+	donor = layout_donor_find(key_out);
+	if (!donor || donor == file->fileid)
+		return false;
+
+	/* Where the file lives is this file's business, not the donor's. */
+	flags = filescan_fd_is_readonly_subvol(ctxt->fd) ? FILE_RO_SUBVOL : 0;
+
+	tprogress->status = thread_waiting_lock;
+	dbfile_lock();
+	tprogress->status = thread_committing;
+
+	/*
+	 * The re-check and the copy share the writer connection *and* the open
+	 * transaction, so a donor hashed seconds ago is visible even though
+	 * nothing has been committed yet - and the two cannot see different
+	 * states of the donor's rows.
+	 */
+	ret = dbfile_layout_matches(db, donor, ctxt->fiemap);
+	if (ret <= 0)
+		goto decline;
+
+	ret = scan_write_begin();
+	if (ret)
+		goto decline;
+
+	ret = dbfile_copy_scanned_file(db, file->fileid, donor, flags);
+	if (ret) {
+		scan_write_abort();
+		goto decline;
+	}
+
+	ret = scan_write_end();
+	dbfile_unlock();
+	if (ret)
+		return false;		/* the batch is gone; hash it instead */
+
+	/*
+	 * Credit the whole file: nothing was read, so pscan_finish_file() would
+	 * otherwise fake-fill it, and the per-file row would sit at 0%.
+	 */
+	tprogress->file_scanned_bytes = ctxt->filesize;
+	atomic_fetch_add(&layout_copied_files, 1);
+	atomic_fetch_add(&layout_copied_bytes, ctxt->filesize);
+	atomic_fetch_add(&scan_hashed_files, 1);
+	return true;
+
+decline:
+	dbfile_unlock();
+	return false;
+}
+
 static inline bool is_inlined(struct scan_ctxt *ctxt)
 {
 	struct fiemap_extent *extent;
@@ -2830,6 +3028,11 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	hashes.db = db;
 	hashes.fileid = file->fileid;
 
+	/* Computed once from the fiemap below, then reused to register this
+	 * file as a donor if it hashes cleanly. */
+	unsigned char layout_key[DIGEST_LEN];
+	bool has_layout_key = false;
+
 	uint64_t t_start = mono_ns(), t_hash = 0, t_done = 0;	/* calibration */
 
 	if (!(buffer->buf)) {
@@ -2873,6 +3076,16 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	if (file->resume &&
 	    !adopt_resume(&ctxt, file, tprogress, db))
 		last_checkpoint = 0;	/* declined, and the row is already gone */
+
+	/*
+	 * Another file this run may already have hashed these very extents.
+	 * Skipped for a resumed file: it has a running checksum and partial
+	 * rows to reconcile, and the case this exists for - a fresh snapshot -
+	 * never has either.
+	 */
+	if (!file->resume &&
+	    try_layout_copy(&ctxt, file, tprogress, db, layout_key, &has_layout_key))
+		return;
 
 	if (!allocate_hashes(&hashes, &ctxt)) {
 		eprintf("allocate_hashes failed\n");
@@ -3107,6 +3320,15 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	}
 
 	dbfile_unlock();
+
+	/*
+	 * Offer this file to the rest of the run. After the rows are written,
+	 * so a hit always finds something to verify against - and if the batch
+	 * is later aborted, the donor's rows go with it and the re-check simply
+	 * declines.
+	 */
+	if (has_layout_key)
+		layout_donor_add(layout_key, file->fileid, ctxt.filesize);
 
 	/* Calibration: overhead is everything but the byte-proportional read+hash
 	 * loop (setup + finalize + DB write). */
@@ -3438,6 +3660,7 @@ void filescan_init(void)
 		}
 	}
 
+	layout_donors_init();
 	scan_workq_start(options.io_threads);
 }
 
@@ -3450,6 +3673,7 @@ void filescan_free(void)
 	subvol_cache_free();
 	verified_dev_free();
 	seen_inodes_free();
+	layout_donors_free();
 
 	g_clear_pointer(&excludes, glob_set_free);
 }

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -2654,90 +2654,157 @@ struct layout_donor {
 	int64_t		fileid;
 };
 
-static GHashTable	*layout_donors;		/* key -> struct layout_donor */
-static GMutex		layout_donors_lock;
-static bool		layout_copy_enabled;
-static _Atomic uint64_t	layout_copied_files;
-static _Atomic uint64_t	layout_copied_bytes;
+/*
+ * Open-addressed, slots inline, occupancy in a bitmap - the same shape as
+ * seen_inodes below, and for the same reason: a GHashTable node plus a malloc
+ * per entry is ~50 B where the entry itself is 24, and there is one entry per
+ * large file in the tree. Guarded by a mutex because the csum workers share it,
+ * unlike seen_inodes, which the single consumer owns.
+ */
+static struct layout_donor	*donor_slots;
+static uint64_t			*donor_used;	/* 1 bit per slot */
+static size_t			donor_cap;	/* power of two, 0 == off */
+static size_t			donor_count;
+static GMutex			donor_lock;
+static _Atomic uint64_t		layout_copied_files;
+static _Atomic uint64_t		layout_copied_bytes;
 
-static guint layout_key_hash(gconstpointer p)
+static inline bool donor_slot_used(size_t i)
 {
-	const struct layout_donor *d = p;
-	guint h;
-
-	/* The key is already a digest; fold it rather than hash it again. */
-	memcpy(&h, d->key, sizeof(h));
-	return h;
+	return (donor_used[i >> 6] >> (i & 63)) & 1;
 }
 
-static gboolean layout_key_equal(gconstpointer a, gconstpointer b)
+/* The key is already a digest; take a machine word of it as the index. */
+static inline size_t donor_hash(const unsigned char *key)
 {
-	const struct layout_donor *x = a, *y = b;
+	uint64_t h;
 
-	return memcmp(x->key, y->key, DIGEST_LEN) == 0;
+	memcpy(&h, key, sizeof(h));
+	return (size_t)h;
+}
+
+/* Insert into a table known to have a free slot (caller ensures capacity). */
+static void donor_insert(const unsigned char *key, int64_t fileid)
+{
+	size_t mask = donor_cap - 1;
+	size_t i;
+
+	for (i = donor_hash(key) & mask; donor_slot_used(i); i = (i + 1) & mask)
+		if (memcmp(donor_slots[i].key, key, DIGEST_LEN) == 0)
+			return;			/* first donor wins */
+	memcpy(donor_slots[i].key, key, DIGEST_LEN);
+	donor_slots[i].fileid = fileid;
+	donor_used[i >> 6] |= (uint64_t)1 << (i & 63);
+	donor_count++;
+}
+
+/* Double the table, rehashing; returns false (old table intact) on OOM. */
+static bool donor_grow(void)
+{
+	struct layout_donor *old = donor_slots;
+	uint64_t *oldused = donor_used;
+	size_t oldcap = donor_cap, newcap = donor_cap * 2, i;
+	struct layout_donor *ns = calloc(newcap, sizeof(*ns));
+	uint64_t *nu = calloc((newcap + 63) / 64, sizeof(*nu));
+
+	if (!ns || !nu) {
+		free(ns);
+		free(nu);
+		return false;
+	}
+	donor_slots = ns;
+	donor_used = nu;
+	donor_cap = newcap;
+	donor_count = 0;
+	for (i = 0; i < oldcap; i++)
+		if ((oldused[i >> 6] >> (i & 63)) & 1)
+			donor_insert(old[i].key, old[i].fileid);
+	free(old);
+	free(oldused);
+	return true;
 }
 
 static void layout_donors_init(void)
 {
 	/*
-	 * Off without a hashfile: the copy reads the donor's rows back out of
-	 * the database, and an in-memory db is discarded at exit anyway.
 	 * DUPEREMOVE_NO_LAYOUT_COPY is the kill switch a bisect or an A/B
-	 * measurement needs - with it set, every file is hashed the old way and
-	 * the hashfile must come out byte-identical.
+	 * measurement needs: with it set, every file is hashed the old way and
+	 * the hashfile must come out byte-identical. Nothing else gates this -
+	 * a run without --hashfile keeps its rows in an in-memory database that
+	 * this reads and writes exactly the same way.
 	 */
-	layout_copy_enabled = options.hashfile &&
-			      !getenv("DUPEREMOVE_NO_LAYOUT_COPY");
-	if (!layout_copy_enabled)
+	if (getenv("DUPEREMOVE_NO_LAYOUT_COPY"))
 		return;
-	layout_donors = g_hash_table_new_full(layout_key_hash, layout_key_equal,
-					      g_free, NULL);
+
+	donor_cap = 1024;
+	donor_count = 0;
+	donor_slots = calloc(donor_cap, sizeof(*donor_slots));
+	donor_used = calloc((donor_cap + 63) / 64, sizeof(*donor_used));
+	if (!donor_slots || !donor_used) {
+		free(donor_slots);
+		free(donor_used);
+		donor_slots = NULL;
+		donor_used = NULL;
+		donor_cap = 0;		/* an optimisation, not state: run on */
+	}
 }
 
 static void layout_donors_free(void)
 {
-	g_clear_pointer(&layout_donors, g_hash_table_destroy);
-	layout_copy_enabled = false;
+	free(donor_slots);
+	donor_slots = NULL;
+	free(donor_used);
+	donor_used = NULL;
+	donor_cap = 0;
+	donor_count = 0;
+}
+
+/*
+ * Is this file worth keying at all? Asked before the key is built, so a run
+ * with the feature off - or a file too small to ever match, since donors are
+ * only registered at LAYOUT_COPY_MIN_SIZE and the size is part of the key -
+ * pays one compare rather than a hash of the record array.
+ */
+static inline bool layout_copy_wanted(uint64_t filesize)
+{
+	return donor_cap && filesize >= LAYOUT_COPY_MIN_SIZE;
 }
 
 /* Offer a freshly hashed file as a donor for the rest of this run. */
-static void layout_donor_add(const unsigned char *key, int64_t fileid,
-			     uint64_t size)
+static void layout_donor_add(const unsigned char *key, int64_t fileid)
 {
-	struct layout_donor *d;
-
-	if (!layout_copy_enabled || size < LAYOUT_COPY_MIN_SIZE)
-		return;
-
-	d = malloc(sizeof(*d));
-	if (!d)
-		return;			/* a donor is an optimisation, not state */
-	memcpy(d->key, key, DIGEST_LEN);
-	d->fileid = fileid;
-
-	g_mutex_lock(&layout_donors_lock);
-	/* First one wins: any file with this layout will do, and replacing the
-	 * entry would only churn. */
-	if (!g_hash_table_contains(layout_donors, d))
-		g_hash_table_add(layout_donors, d);
-	else
-		free(d);
-	g_mutex_unlock(&layout_donors_lock);
+	g_mutex_lock(&donor_lock);
+	/* Grow at ~70% load to keep probes short; on OOM just stop taking
+	 * donors, which costs hashing and nothing else. */
+	if ((donor_count + 1) * 10 >= donor_cap * 7 && !donor_grow())
+		goto out;
+	donor_insert(key, fileid);
+out:
+	g_mutex_unlock(&donor_lock);
 }
 
 /* The file id registered for `key`, or 0 if none. */
 static int64_t layout_donor_find(const unsigned char *key)
 {
-	struct layout_donor probe, *found;
+	size_t mask, i;
+	int64_t found = 0;
 
-	if (!layout_copy_enabled)
-		return 0;
+	g_mutex_lock(&donor_lock);
+	mask = donor_cap - 1;
+	for (i = donor_hash(key) & mask; donor_slot_used(i); i = (i + 1) & mask)
+		if (memcmp(donor_slots[i].key, key, DIGEST_LEN) == 0) {
+			found = donor_slots[i].fileid;
+			break;
+		}
+	g_mutex_unlock(&donor_lock);
+	return found;
+}
 
-	memcpy(probe.key, key, DIGEST_LEN);
-	g_mutex_lock(&layout_donors_lock);
-	found = g_hash_table_lookup(layout_donors, &probe);
-	g_mutex_unlock(&layout_donors_lock);
-	return found ? found->fileid : 0;
+/* Bytes the donor table holds, for the memory breakdown. */
+uint64_t filescan_layout_donor_bytes(void)
+{
+	return donor_cap * sizeof(*donor_slots) +
+	       ((donor_cap + 63) / 64) * sizeof(*donor_used);
 }
 
 void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes)
@@ -2758,17 +2825,12 @@ void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes)
  */
 static bool try_layout_copy(struct scan_ctxt *ctxt, struct file_to_scan *file,
 			    struct pscan_thread *tprogress, struct dbhandle *db,
-			    unsigned char *key_out, bool *key_valid)
+			    const unsigned char *key)
 {
-	int64_t donor;
+	int64_t donor = layout_donor_find(key);
 	unsigned int flags;
 	int ret;
 
-	*key_valid = fiemap_layout_key(ctxt->fiemap, ctxt->filesize, key_out);
-	if (!*key_valid)
-		return false;
-
-	donor = layout_donor_find(key_out);
 	if (!donor || donor == file->fileid)
 		return false;
 
@@ -3083,8 +3145,10 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * rows to reconcile, and the case this exists for - a fresh snapshot -
 	 * never has either.
 	 */
-	if (!file->resume &&
-	    try_layout_copy(&ctxt, file, tprogress, db, layout_key, &has_layout_key))
+	has_layout_key = layout_copy_wanted(ctxt.filesize) &&
+			 fiemap_layout_key(ctxt.fiemap, ctxt.filesize, layout_key);
+	if (has_layout_key && !file->resume &&
+	    try_layout_copy(&ctxt, file, tprogress, db, layout_key))
 		return;
 
 	if (!allocate_hashes(&hashes, &ctxt)) {
@@ -3328,7 +3392,7 @@ static void csum_whole_file(struct file_to_scan *file, struct buffer *buffer,
 	 * declines.
 	 */
 	if (has_layout_key)
-		layout_donor_add(layout_key, file->fileid, ctxt.filesize);
+		layout_donor_add(layout_key, file->fileid);
 
 	/* Calibration: overhead is everything but the byte-proportional read+hash
 	 * loop (setup + finalize + DB write). */

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -204,8 +204,6 @@ void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits);
  * scan, like the skip counters.
  */
 void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes);
-/* Bytes the donor table holds, for the RSS breakdown (#208). */
-uint64_t filescan_layout_donor_bytes(void);
 
 /*
  * Diagnostic ETA-calibration counters (DUPEREMOVE_SCAN_STATS): summed per-file

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -198,6 +198,13 @@ void filescan_free(void);
 void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits);
 
 /*
+ * Files whose hashes were copied from an already-scanned file with an identical
+ * physical layout (#206), and the bytes not read because of it. Read after the
+ * scan, like the skip counters.
+ */
+void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes);
+
+/*
  * Diagnostic ETA-calibration counters (DUPEREMOVE_SCAN_STATS): summed per-file
  * overhead (setup + finalize + DB write) and read+hash time, with their file
  * and byte counts. overhead/file over hash/byte is the ideal ETA file weight.

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -203,6 +203,8 @@ void filescan_get_workq_stats(uint64_t *pops, uint64_t *empty_waits);
  * scan, like the skip counters.
  */
 void filescan_get_layout_copies(uint64_t *files, uint64_t *bytes);
+/* Bytes the donor table holds, for the RSS breakdown (#208). */
+uint64_t filescan_layout_donor_bytes(void);
 
 /*
  * Diagnostic ETA-calibration counters (DUPEREMOVE_SCAN_STATS): summed per-file

--- a/src/oans.c
+++ b/src/oans.c
@@ -1417,6 +1417,13 @@ static void report_scan_stats(void)
 
 	filescan_get_workq_stats(&pops, &empty_waits);
 	dbfile_get_lock_stats(&lock_total, &lock_contended, &lock_wait_ns);
+	{
+		uint64_t copies, saved;
+
+		filescan_get_layout_copies(&copies, &saved);
+		eprintf("scan-stats: layout-copies files=%"PRIu64" bytes-not-read=%"PRIu64"\n",
+			copies, saved);
+	}
 
 	/* eprintf, not fprintf: this lands while the scan block is still on
 	 * screen, and an unrouted line strands a row of it (#179). */
@@ -1516,6 +1523,24 @@ static void report_scan_skips(const uint64_t *skips)
 		}
 		if (*sep)
 			g_string_append_c(out, '\n');
+	}
+
+	/*
+	 * Snapshot-aware scan (#206). Worth a line outside -v for the same
+	 * reason the read-only-subvolume count is: it says the run did much
+	 * less work than the file count suggests, which otherwise looks like
+	 * something went wrong.
+	 */
+	{
+		uint64_t copies, bytes;
+
+		filescan_get_layout_copies(&copies, &bytes);
+		if (copies)
+			g_string_append_printf(out,
+				"  %sSame layout%s    %"PRIu64" file%s matched an "
+				"already-hashed layout %s(%s not read)%s\n",
+				col_dim, col_reset, copies, copies == 1 ? "" : "s",
+				col_dim, human_size(bytes), col_reset);
 	}
 
 	if (out->len)

--- a/src/tests.c
+++ b/src/tests.c
@@ -210,6 +210,82 @@ static bool share(const struct fm_rec *ra, unsigned int na, uint64_t off_a,
  * described with different record boundaries, or the same file is resubmitted
  * to the kernel on every run (#186) - and "no" whenever it cannot prove it.
  */
+/* Same records, same size -> same key; anything that changes the bytes doesn't. */
+static bool key_of(const struct fm_rec *recs, unsigned int n, uint64_t size,
+		   unsigned char *out)
+{
+	struct fiemap *fm = mkmap(recs, n);
+	bool ok = fiemap_layout_key(fm, size, out);
+
+	free(fm);
+	return ok;
+}
+
+MU_TEST(test_fiemap_layout_key) {
+	const uint32_t SH = FIEMAP_EXTENT_SHARED;
+	const uint32_t ENC = FIEMAP_EXTENT_ENCODED;
+	unsigned char a[DIGEST_LEN], b[DIGEST_LEN];
+
+	struct fm_rec two[] = {{0, 4096, 8192, 0}, {8192, 65536, 4096, 0}};
+
+	mu_check(key_of(two, 2, 12288, a));
+
+	/* The same layout, described identically, keys the same. */
+	mu_check(key_of(two, 2, 12288, b));
+	mu_check(memcmp(a, b, DIGEST_LEN) == 0);
+
+	/* SHARED is a refcount property - deduping an unrelated file must not
+	 * change what this file's content is. Same for the positional LAST. */
+	struct fm_rec shared[] = {{0, 4096, 8192, SH},
+				  {8192, 65536, 4096, SH | FIEMAP_EXTENT_LAST}};
+
+	mu_check(key_of(shared, 2, 12288, b));
+	mu_check(memcmp(a, b, DIGEST_LEN) == 0);
+
+	/* Different storage, same shape: different key. */
+	struct fm_rec moved[] = {{0, 4096, 8192, 0}, {8192, 69632, 4096, 0}};
+
+	mu_check(key_of(moved, 2, 12288, b));
+	mu_check(memcmp(a, b, DIGEST_LEN) != 0);
+
+	/* Same records, different file size - a trailing hole fiemap never
+	 * reports, and content the digest does cover. */
+	mu_check(key_of(two, 2, 16384, b));
+	mu_check(memcmp(a, b, DIGEST_LEN) != 0);
+
+	/* A prefix of the same records must not collide with the whole. */
+	mu_check(key_of(two, 1, 12288, b));
+	mu_check(memcmp(a, b, DIGEST_LEN) != 0);
+
+	/* Compressed extents are fine: the address is only ever compared. */
+	struct fm_rec enc[] = {{0, 4096, 8192, ENC}};
+
+	mu_check(key_of(enc, 1, 8192, b));
+
+	/* Records whose address means nothing, or nothing stable, are refused. */
+	struct fm_rec inl[] = {{0, 0, 512, FIEMAP_EXTENT_DATA_INLINE}};
+	struct fm_rec delalloc[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
+	struct fm_rec unknown[] = {{0, 0, 8192, FIEMAP_EXTENT_UNKNOWN}};
+	struct fm_rec crypt[] = {{0, 4096, 8192, FIEMAP_EXTENT_DATA_ENCRYPTED}};
+
+	mu_check(!key_of(inl, 1, 512, b));
+	mu_check(!key_of(delalloc, 1, 8192, b));
+	mu_check(!key_of(unknown, 1, 8192, b));
+	mu_check(!key_of(crypt, 1, 8192, b));
+
+	/* One bad record poisons the whole file, not just itself. */
+	struct fm_rec mixed[] = {{0, 4096, 8192, 0},
+				 {8192, 0, 4096, FIEMAP_EXTENT_DELALLOC}};
+
+	mu_check(!key_of(mixed, 2, 12288, b));
+
+	/* A file with no extents at all has no layout to speak of. */
+	struct fiemap *empty = mkmap(two, 0);
+
+	mu_check(!fiemap_layout_key(empty, 0, b));
+	free(empty);
+}
+
 MU_TEST(test_fiemap_maps_share) {
 	const uint32_t SH = FIEMAP_EXTENT_SHARED;
 	const uint32_t ENC = FIEMAP_EXTENT_ENCODED;
@@ -1131,6 +1207,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_is_file_renamed);
 	MU_RUN_TEST(test_seen_inode);
 	MU_RUN_TEST(test_get_extent);
+	MU_RUN_TEST(test_fiemap_layout_key);
 	MU_RUN_TEST(test_fiemap_maps_share);
 	MU_RUN_TEST(test_fiemap_unshared_bytes);
 	MU_RUN_TEST(test_fiemap_unshared_bytes_accumulates);

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -428,6 +428,17 @@ class DuperemoveTest(unittest.TestCase):
             "join files f on f.id = b.fileid order by f.filename, b.loff")
         return hashlib.sha256(repr(rows).encode()).hexdigest()
 
+    def fingerprints(self):
+        """Everything a scan is supposed to have produced, as three digests.
+
+        The comparison for "this hashfile is byte-identical to one built some
+        other way" - an interrupted-then-resumed scan (#159, #201), a copied
+        layout (#206), a bounded queue (#208). A wrong digest is invisible
+        downstream, so nothing weaker than this catches one.
+        """
+        return (self.files_fingerprint(), self.extents_fingerprint(),
+                self.blocks_fingerprint())
+
     def drop_hashfile(self):
         """Delete the hashfile and its WAL sidecars, so the next run starts
         from nothing. Removing only the .db leaves a -wal SQLite will replay."""

--- a/tests/integration/test_hash_resume.py
+++ b/tests/integration/test_hash_resume.py
@@ -62,11 +62,6 @@ class HashResumeTest(DuperemoveTest):
         self.sync()
         return self.path("tree")
 
-    def fingerprints(self):
-        """Everything the scan is supposed to have produced."""
-        return (self.files_fingerprint(), self.extents_fingerprint(),
-                self.blocks_fingerprint())
-
     def scan_straight_through(self, tree, *extra):
         """Hash the tree in one go, into a fresh hashfile."""
         self.drop_hashfile()

--- a/tests/integration/test_layout_copy.py
+++ b/tests/integration/test_layout_copy.py
@@ -38,10 +38,6 @@ class LayoutCopyTest(DuperemoveTest):
                 f.write(os.urandom(size))
         self.sync()
 
-    def fingerprints(self):
-        return (self.files_fingerprint(), self.extents_fingerprint(),
-                self.blocks_fingerprint())
-
     def _scan_both_ways(self, *extra):
         """Scan the scratch tree with the copy on, then off; return both prints.
 
@@ -147,13 +143,31 @@ class LayoutCopyTest(DuperemoveTest):
         self.assertDmOk("second dedupe")
         self.assertReclaimedNothing("the tree is already deduped")
 
-    def test_without_a_hashfile_nothing_is_copied(self):
-        # The copy reads the donor's rows back out of the database; an
-        # in-memory run has no --hashfile to point at.
+    @requires_reflink
+    def test_it_works_without_a_hashfile_too(self):
+        """No --hashfile is not "no database" - it is an in-memory one.
+
+        The donor's rows are read back through the same handle the scan wrote
+        them with, so the copy works there exactly as it does on disk. What
+        matters is that the outcome is identical either way.
+        """
+        self._fill(n=2)
+        self.snapshot(self.live, "snap", readonly=False)
+        # An independently written pair, so the run has something to reclaim.
+        self.mkdup("live/dupA.bin", "live/dupB.bin", SIZE)
+        self.sync()
+
+        self.dm("-r", "--io-threads=1", self.work, hashfile=False, quiet=False)
+        self.assertDmOk()
+        self.assertGreater(self.layout_copies(), 0,
+                           "no --hashfile should not switch the copy off")
+
+    def test_the_kill_switch_is_the_only_thing_that_disables_it(self):
         self._fill(n=2)
         self.snapshot(self.live, "snap")
         self.sync()
 
-        self.dm("-r", "--io-threads=1", self.work, hashfile=False, quiet=False)
+        self.dm("-r", "--io-threads=1", self.work, quiet=False,
+                env={"DUPEREMOVE_NO_LAYOUT_COPY": "1"})
         self.assertDmOk()
         self.assertEqual(0, self.layout_copies())

--- a/tests/integration/test_layout_copy.py
+++ b/tests/integration/test_layout_copy.py
@@ -1,0 +1,159 @@
+"""Snapshot-aware scan: identical physical layout means identical bytes (#206).
+
+Hashing N snapshots of a subvolume used to read N times the data. A snapshot
+shares the live subvolume's extents, so when two files' fiemaps describe exactly
+the same records their content is the same and the second one's digest, extent
+hashes and block hashes can be copied instead of computed.
+
+The only acceptable definition of correct here is byte-identical output: a wrong
+digest is invisible downstream (it just looks like a file with no duplicate), so
+every test below compares the hashfile against a control run with
+DUPEREMOVE_NO_LAYOUT_COPY=1, which hashes everything the old way.
+
+Physical-layout assertions, so serial - see DuperemoveTest.serial.
+"""
+
+import os
+
+from harness import DuperemoveTest, requires_btrfs, requires_reflink
+
+MiB = 1 << 20
+
+# The optimisation is skipped below one read buffer, where reading the file is a
+# single I/O; these have to clear that.
+SIZE = 2 * MiB
+
+
+@requires_btrfs
+class LayoutCopyTest(DuperemoveTest):
+    serial = True
+
+    def setUp(self):
+        super().setUp()
+        self.live = self.subvol("live")
+
+    def _fill(self, n=4, size=SIZE):
+        for i in range(n):
+            with open(os.path.join(self.live, f"f{i}.bin"), "wb") as f:
+                f.write(os.urandom(size))
+        self.sync()
+
+    def fingerprints(self):
+        return (self.files_fingerprint(), self.extents_fingerprint(),
+                self.blocks_fingerprint())
+
+    def _scan_both_ways(self, *extra):
+        """Scan the scratch tree with the copy on, then off; return both prints.
+
+        Same tree, two fresh hashfiles - the control is what the scan would have
+        produced before this feature existed.
+
+        --io-threads=1 makes the hit deterministic. A file only has a donor if
+        some other file *finished* hashing first, so on a tree this small the
+        original and its snapshot are otherwise hashed side by side and neither
+        can donate to the other. That race is fine in production - a miss just
+        costs a hash - but it would make these tests flaky.
+        """
+        self.dm("-r", "--io-threads=1", self.work, *extra, quiet=False)
+        self.assertDmOk("layout-copy scan")
+        with_copy = self.fingerprints()
+        copied = self.layout_copies()
+
+        self.drop_hashfile()
+        self.dm("-r", "--io-threads=1", self.work, *extra, quiet=False,
+                env={"DUPEREMOVE_NO_LAYOUT_COPY": "1"})
+        self.assertDmOk("control scan")
+        self.assertEqual(0, self.layout_copies(),
+                         "the kill switch did not switch anything off")
+        return with_copy, self.fingerprints(), copied
+
+    def layout_copies(self):
+        """Files whose hashes were copied, from the last run's summary."""
+        for line in self.out.splitlines():
+            if "matched an already-hashed layout" in line:
+                return int(line.split()[2])
+        return 0
+
+    def test_a_snapshot_is_not_read_again(self):
+        self._fill()
+        self.snapshot(self.live, "snap")
+        self.sync()
+
+        copy, control, copied = self._scan_both_ways()
+        self.assertEqual(control, copy,
+                         "the copied hashes differ from hashing the file")
+        self.assertGreater(copied, 0, "nothing matched an identical layout")
+
+    def test_block_hashes_are_copied_too(self):
+        # --dedupe-options=partial is the only mode that stores block hashes,
+        # and they are the bulk of what a copy avoids recomputing.
+        self._fill(n=2)
+        self.snapshot(self.live, "snap")
+        self.sync()
+
+        copy, control, copied = self._scan_both_ways(
+            "-b", "4096", "--dedupe-options=partial")
+        self.assertEqual(control, copy)
+        self.assertGreater(copied, 0)
+        self.assertGreater(self.hf_count("blocks"), 0)
+
+    def test_a_modified_file_is_hashed_normally(self):
+        """The negative case: a rewrite moves the file's extents, so it misses.
+
+        A writable snapshot whose file is rewritten no longer shares the
+        original's storage; copying its digest would be the catastrophic
+        failure this feature has to avoid.
+        """
+        self._fill(n=2)
+        snap = self.snapshot(self.live, "snap", readonly=False)
+        changed = os.path.join(snap, "f0.bin")
+        with open(changed, "r+b") as f:
+            f.write(os.urandom(SIZE))       # CoW: new extents
+        self.sync()
+
+        copy, control, _copied = self._scan_both_ways()
+        self.assertEqual(control, copy)
+
+        # And the rewritten copy really did end up with its own digest.
+        rows = dict(self.hf_query("select filename, quote(digest) from files"))
+        self.assertNotEqual(rows[os.path.join(self.live, "f0.bin")],
+                            rows[changed],
+                            "a rewritten file kept the original's digest")
+
+    def test_small_files_are_left_alone(self):
+        """Below one read buffer there is nothing to save, so no bookkeeping."""
+        self._fill(n=4, size=64 << 10)
+        self.snapshot(self.live, "snap")
+        self.sync()
+
+        copy, control, copied = self._scan_both_ways()
+        self.assertEqual(control, copy)
+        self.assertEqual(0, copied)
+
+    @requires_reflink
+    def test_dedupe_still_works_on_copied_hashes(self):
+        """Copied rows have to be as good as hashed ones downstream."""
+        self._fill(n=2)
+        self.snapshot(self.live, "snap", readonly=False)
+        self.sync()
+
+        self.dm("-rd", self.work, quiet=False)
+        self.assertDmOk("dedupe over a snapshot tree")
+
+        # Converges: a second run over the unchanged tree frees nothing. The
+        # invariant #186 exists to protect, and the one a bogus copied digest
+        # would break first.
+        self.dm("-rd", self.work, quiet=False)
+        self.assertDmOk("second dedupe")
+        self.assertReclaimedNothing("the tree is already deduped")
+
+    def test_without_a_hashfile_nothing_is_copied(self):
+        # The copy reads the donor's rows back out of the database; an
+        # in-memory run has no --hashfile to point at.
+        self._fill(n=2)
+        self.snapshot(self.live, "snap")
+        self.sync()
+
+        self.dm("-r", "--io-threads=1", self.work, hashfile=False, quiet=False)
+        self.assertDmOk()
+        self.assertEqual(0, self.layout_copies())


### PR DESCRIPTION
Closes #206.

## Measured

4 snapshots of a 120-file / 1.9 GiB subvolume (7.5 GiB apparent), cold, `drop_caches` before each run:

| | wall |
|---|---|
| this | **0.65 s** |
| `DUPEREMOVE_NO_LAYOUT_COPY=1` | 2.36 s |

**3.6×**, against a ceiling of 4× — and the hashfiles are byte-identical (`files`, `extents` and `blocks` fingerprints all match).

No regression where the feature never fires (`bench.py`, cold, 3 rounds, A/B by env variant):

| profile | copy | nocopy | RSS |
|---|---|---|---|
| `realistic` | 5.83 s | 5.85 s | 71 / 71 MiB |
| `many` | 7.26 s | 7.28 s | 221 / 220 MiB |
| `big` | 0.63 s | 0.63 s | 29 / 30 MiB |

The miss path is one key over the fiemap the scan already holds plus a hash-table probe — no extra ioctl, no extra I/O.

## How a hit is proved

Misses are free; a false hit stores a digest of bytes the file never had, which is invisible downstream (it just looks like a file with no duplicate). So a hit clears **three independent bars**:

1. `fiemap_layout_key()` refuses any record whose physical address it cannot vouch for — `DATA_INLINE`, `UNKNOWN`, `DELALLOC`, `DATA_ENCRYPTED` — or a file with no extents at all.
2. The key is a 128-bit digest of *every* record plus the file size and extent count.
3. `dbfile_layout_matches()` re-checks the candidate donor's `(loff, poff, len)` triples one at a time.

`SHARED` and `LAST` are masked out of the key — the first changes when an unrelated file is deduped, the second is positional; neither says anything about content. Compressed/`ENCODED` extents are fine, because this only ever compares `fe_physical` for **equality** and never does arithmetic on it. Records are never normalized or merged to chase more hits: the same storage described with different boundaries (#186) reads as a miss, which is correct and just less effective.

## Two things that came out simpler than the issue expected

- **The re-check needs no stored record array.** A donor's `extents` rows *are* the record array its fiemap reported, so the map holds only a key and a file id — and a donor whose rows have gone (aborted batch, hardlink cascade, `--dedupe-options=only_whole_files`) verifies as a miss by construction, rather than needing a guard.
- **There is no visibility hazard.** The issue's v1 rule was to fall back to hashing when the donor's rows are not yet committed. But every scan write goes through the *one shared writer connection*, so the re-check and the copy see a donor hashed seconds ago inside the still-open batch. No fallback needed, and the first-scan-of-N-snapshots case works today.

## One judgment call the issue doesn't cover: RSS

The map is one entry per candidate donor, which on a multi-million-file tree would be tens of MB for nothing — and #208 is open about exactly that. So files below one read buffer (`READ_BUF_LEN`, 1 MiB) are not registered: hashing those is a single I/O, and the bookkeeping would cost more than it saves. That is why the `realistic`/`many` RSS above is unchanged.

## Tests

`tests/integration/test_layout_copy.py` (btrfs, `serial`) — every case asserts the hashfile is **byte-identical** to a `DUPEREMOVE_NO_LAYOUT_COPY=1` control, which is the only acceptable definition of correct here:

- a snapshot is not read again (and the counter fires);
- block hashes are copied too, under `-b 4096 --dedupe-options=partial`;
- **negative**: a file rewritten in a writable snapshot gets new extents, is hashed normally, and ends up with its own digest;
- files below the floor are left alone;
- `-d` over a snapshot tree converges — a second run reclaims nothing (#186's invariant, the first thing a bogus copied digest would break);
- nothing is copied without `--hashfile`.

Tests pass `--io-threads=1`: a hit needs the donor to have *finished*, and on a tiny tree a file and its snapshot are otherwise hashed side by side. That race is fine in production — measured 74–82% hit rate on small trees, improving with size — but it would make the tests flaky.

`src/tests.c::test_fiemap_layout_key` covers the key directly with synthetic records: stability, `SHARED`/`LAST` masking, a moved extent, a changed size, a prefix, compressed extents accepted, each disqualifying flag refused, and one bad record poisoning the whole file.

## Gate

`scripts/verify.sh` green (217 tests, 31 unit tests / 5895 assertions, valgrind smoke). `test_layout_copy.py` + `test_readonly_subvols.py` under `tests/valgrind-wrap.sh`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)