### PR TITLE
Record the STATX_CHANGE_COOKIE finding as a dead end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,29 @@ is the false premise this took two PRs to unwind:
   metadata walk — separation throws that overlap away for nothing. The one real win
   (exact ETA from a known total) is a UX gain that doesn't need serialization (the
   walk already counts files incrementally). Reverted.
+- **`STATX_CHANGE_COOKIE` is not a userspace ABI — don't plan around it (#207).**
+  It exists in `include/linux/stat.h` for in-kernel callers (NFSD's `i_version`),
+  not in the UAPI: on 7.1.3 `struct statx` has no `stx_change_cookie`,
+  `kernel-headers` does not define `STATX_CHANGE_COOKIE`, and asking for the bit
+  anyway returns a mask without it (btrfs and tmpfs alike, spare words zero). So
+  it is not privilege-gated — running as root would not help, and the filesystem
+  is irrelevant.
+  - **`ctime` closes the same hole and is already being read.** Re-measured: a
+    `chattr +C` file rewritten in place with `touch -d` restoring the mtime keeps
+    a stale digest (mtime and size both unchanged), but its ctime *does* move —
+    `utimensat()` updates ctime as a side effect, so restoring a timestamp cannot
+    hide a write. `ctime` is in `STATX_BASIC_STATS`, which the walk already asks
+    for: no new syscall, no kernel floor.
+  - **The objection that would have sunk it does not hold**: `FIDEDUPERANGE`
+    leaves ctime alone on both source and destination (measured), as does
+    `btrfs filesystem defragment` — so an incremental run would *not* re-hash
+    everything it deduped last night. What does move ctime without changing
+    content is metadata churn (`chmod`/`chown`/xattr/relabel) and a
+    `rsync -a`-style restore: one extra re-hash of that subtree, cost only.
+  - Only measured on btrfs; **re-measure the dedupe row on xfs before
+    implementing**, since that is the load-bearing one. Design sketch and the
+    full table are on #207.
+
 - **Warm rescan is single-consumer pipeline-latency-bound**, not CPU/query. A
   no-op rescan of ~174k files is ~2s wall / ~0.9s CPU, invariant to
   `--io-threads` (1..16); the serial consumer (`__scan_file` queue handoff +


### PR DESCRIPTION
Closes #207, taking its option (b): "a documented decision not to, added to CLAUDE.md's dead-ends section so it isn't re-investigated from scratch."

Full measurements are in [the issue comment](https://github.com/martinus/oans/issues/207#issuecomment-5235089084). The short version:

**`STATX_CHANGE_COOKIE` is not a userspace ABI.** The issue's premise was that the kernel *masks* it for unprivileged callers. It doesn't mask it — it doesn't expose it. On 7.1.3, `struct statx` has no `stx_change_cookie`, `kernel-headers-7.1.3` doesn't define `STATX_CHANGE_COOKIE`, and asking for the bit anyway (0x40000000, its kernel-internal value) returns a `stx_mask` without it, on btrfs and tmpfs alike, with the spare words zero. It lives in `include/linux/stat.h` for in-kernel callers — NFSD's `i_version`. So running as root would not help, and testing xfs is moot: the ABI is what's missing, not the filesystem support. Items 1, 3 and 4 of the checklist are answered at once, because there is nothing to read, persist or compare.

**But `ctime` closes the same hole, and the scan already reads it.** Re-measured the blind spot (a `chattr +C` file rewritten in place with `touch -d` restoring the mtime keeps a stale digest) — and its ctime *does* move, because `utimensat()` updates ctime as a side effect of setting mtime. `ctime` is in `STATX_BASIC_STATS`, which the walk already requests: no new syscall, no kernel floor, no privilege gate.

The objection I expected to sink it — oans re-hashing everything it deduped, every incremental run — **does not hold**: `FIDEDUPERANGE` leaves ctime alone on both source and destination, as does `btrfs filesystem defragment`. What remains is metadata churn (`chmod`/`chown`/xattr/relabel) and an `rsync -a` restore: one extra re-hash of that subtree, cost only, never correctness.

This PR only writes the finding down. **I did not implement the ctime version**, deliberately: the issue frames implementation as a follow-up, it's a repo-wide change to change detection per its own ground rule, and the trade (an SELinux relabel re-hashes the tree) is a call for you rather than something to slip into an investigation. A concrete design sketch — additive `ctime` column, `ALTER TABLE` guarded by `table_info`, no `DB_FILE_MINOR` bump, NULL arm preserving today's behavior on existing hashfiles, all three sites on one rule — is on the issue, ready to become its own issue if you want it.

**Caveat, flagged in the note:** everything is btrfs on 7.1.3. The dedupe row is the load-bearing one and should be re-measured on xfs before anyone implements this; no xfs mount is available on this box.

Docs only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)