### PR TITLE
tests: skip the least-fragmented-target case when the fs won't fragment

### DIFF
--- a/tests/integration/test_cross_pass.py
+++ b/tests/integration/test_cross_pass.py
@@ -98,10 +98,19 @@ class CrossPassTest(DuperemoveTest):
             self.write(f"tree/{name}", data)
         self.sync()
 
+        # Whether flushed writes actually split extents is the allocator's
+        # call, not ours: xfs coalesces them behind delayed allocation and
+        # speculative preallocation, and btrfs under valgrind is slow enough to
+        # do the same. When it doesn't fragment there is no disagreement
+        # between the two candidate rules left to observe, so the run below
+        # would pass whichever rule target election used - i.e. prove nothing.
+        # Skip loudly rather than fail on a precondition, or assert nothing.
         frag = len(phys_extents(self.path("tree/c000")))
         tidy = len(phys_extents(self.path("tree/c001")))
-        self.assertGreater(frag, tidy,
-                           "setup failed: c000 was meant to be the fragmented one")
+        if frag <= tidy:
+            self.skipTest(f"this filesystem coalesced the flushed writes "
+                          f"({frag} extents vs {tidy}); nothing to tell the "
+                          f"two target rules apart")
         target_phys = phys_extents(self.path("tree/c001"))
 
         self.dm("-rd", *self.BOPT, self.path("tree"), env=self.ENV)


### PR DESCRIPTION
`test_cross_pass.py::test_target_is_the_least_fragmented_member_not_the_first` fails intermittently in CI:

```
AssertionError: 1 not greater than 1 : setup failed: c000 was meant to be the fragmented one
```

It is not caused by any change under test — it hit a **docs-only** PR (#214, CLAUDE.md and nothing else), and across the current batch it has failed on `build-and-test (xfs, gcc)`, `(xfs, clang)` and one `valgrind` shard, while passing on the same code elsewhere.

## Why

The test builds its fragmented copy with 64 KiB writes, each `flush()`ed and `fsync()`ed, then asserts that the copy really did end up more fragmented than the tidy one. Whether those writes split extents is the allocator's call, not the test's: xfs coalesces them behind delayed allocation and speculative preallocation, and btrfs under valgrind is slow enough to do the same.

The assertion's own message calls it what it is — `setup failed`. It is a **precondition**, not the property under test.

## Fix

When the filesystem coalesced the writes, there is no disagreement between the two candidate target rules left to observe: id order and extent order agree, so the run below would pass whichever rule target election used. The test proves nothing either way — which is a `skipTest`, not a `fail`. A failure says the code is wrong, and it isn't.

The skip carries both extent counts, so a filesystem that quietly stops exercising this shows up in the suite output (`skipped=N` with a reason) rather than passing silently.

The test still guards the real property — that the least-fragmented member is preferred as the dedupe target — wherever fragmentation is actually achievable, which is btrfs outside valgrind.

## Not done

I did not rewrite the setup to fragment deterministically (cloning 64 KiB ranges from separate donor files would do it on both filesystems, by construction). That is a bigger change to a test I did not otherwise touch, and it needs donors kept out of the scanned tree so they don't join the dedupe groups the test asserts on. Worth doing if this case is considered load-bearing on xfs; the skip makes the gap visible in the meantime.

`scripts/verify.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)