### PR TITLE
dedupe: don't abort when a group's last member is skipped at a batch boundary

### DIFF
--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -707,6 +707,27 @@ close_files:
 		}
 	}
 
+	/*
+	 * The loop can reach here with files still open, so close them before
+	 * asserting the list is empty (upstream #392, which aborted a whole run
+	 * on a large tree).
+	 *
+	 * close_files above reopens the target for the round that would follow,
+	 * and the member that round starts with may be both the last one and
+	 * one that gets skipped - it cannot be opened, it changed since the
+	 * scan, or it already shares the target's extents. Each of those paths
+	 * takes `if (ctxt && last) goto run_dedupe`, but a round that has only
+	 * just begun has no ctxt yet, so they fall out of the loop instead,
+	 * leaving the target behind (and the skipped member too, if it opened).
+	 *
+	 * A group therefore has to be big enough to fill an ioctl batch before
+	 * any of this is reachable: max_queable is one below
+	 * MAX_DEDUPES_PER_IOCTL, so the rounds restart at members 120, 239, ...
+	 * Snapshot and backup trees are exactly that shape - hundreds of
+	 * identical copies, some of which are routinely skipped.
+	 */
+	filerec_close_open_list(&open_files);
+
 	abort_on(ctxt != NULL);
 	abort_on(!RB_EMPTY_ROOT(&open_files.root));
 

--- a/tests/integration/test_large_group_dedupe.py
+++ b/tests/integration/test_large_group_dedupe.py
@@ -1,0 +1,87 @@
+"""A dedupe group larger than one ioctl batch (upstream #392).
+
+FIDEDUPERANGE takes at most MAX_DEDUPES_PER_IOCTL destinations, so a group with
+more members than that is deduped in rounds: dedupe_extent_list() fills a batch,
+runs it, closes every file, and reopens the target for the next round.
+
+The member that next round starts with may be one that gets skipped - it cannot
+be opened, it changed since the scan, or it already shares the target's extents.
+Each of those paths runs the group's dedupe early only `if (ctxt && last)`, and
+a round that has only just begun has no ctxt yet, so a skip there falls out of
+the loop with the reopened target still on the open list. That tripped an
+abort_on() and killed the whole run - not the group, the process - which is what
+upstream #392 reports from a 17 TB backup tree.
+
+Groups that big are the normal shape of a snapshot or backup tree, and a member
+being skipped is routine, so this is worth a test even though it takes 121 files
+to reach.
+"""
+
+import os
+import unittest
+
+from harness import DuperemoveTest, requires_reflink
+
+# src/dedupe.h. A group of exactly this many *destinations* plus the target
+# puts the last member at the start of round two, which is the case that used
+# to abort: one more file and round two has a ctxt by the time it is reached.
+MAX_DEDUPES_PER_IOCTL = 120
+
+# Above btrfs max_inline, so every copy has a physical extent to dedupe.
+SIZE = 64 << 10
+
+
+@requires_reflink
+class LargeGroupDedupeTest(DuperemoveTest):
+    def _make_group(self, n):
+        """n byte-identical files, independently written so none share yet."""
+        data = os.urandom(SIZE)
+        for i in range(n):
+            self.write(f"tree/f{i:03d}.bin", data)
+        self.sync()
+
+    def _last_group_member(self):
+        """The path of the member dedupe_extent_list() visits last.
+
+        GET_DUPLICATE_FILES orders a group `is_target desc, f.id`, and the
+        target is elected by fewest extents then lowest id - so with uniform
+        files the last member is simply the highest id. Reading it back beats
+        assuming a name, because ids follow the order files finish hashing.
+        """
+        return self.hf_scalar(
+            "select filename from files order by id desc limit 1")
+
+    @unittest.skipIf(os.geteuid() == 0,
+                     "chmod 000 does not stop root from opening the file, so "
+                     "the member under test would not be skipped")
+    def test_a_group_spanning_two_batches_survives_a_skipped_last_member(self):
+        self._make_group(MAX_DEDUPES_PER_IOCTL + 1)
+
+        # Scan while everything is readable, so all 121 land in one group.
+        self.dm("-r", "--io-threads=1", self.work)
+        self.assertDmOk("scan")
+
+        # Make exactly that member unopenable. Its row survives: pruning is
+        # stat-based and the file is still there, so the dedupe phase still
+        # loads it and only then finds it cannot be opened.
+        victim = self._last_group_member()
+        os.chmod(victim, 0)
+
+        self.dm("-dr", "--io-threads=1", self.work, quiet=False)
+        os.chmod(victim, 0o644)
+
+        # The exit code is the assertion. assertDmOk() would also reject the
+        # "Permission denied" line, which is the expected, reported outcome for
+        # the member we made unreadable - what must not happen is the process
+        # dying, and it printed a whole run's worth of output before it did, so
+        # only the status distinguishes the two.
+        self.assertEqual(0, self.rc,
+                         "dedupe of a group spanning two ioctl batches died: "
+                         + (f"signal {-self.rc}" if self.rc < 0
+                            else f"exit {self.rc}"))
+
+        # And it deduped rather than bailing out at the batch boundary: every
+        # member but the target and the unreadable one is freed.
+        self.assertEqual((MAX_DEDUPES_PER_IOCTL - 1) * SIZE,
+                         self.reclaimed_bytes(),
+                         "round one's members were not all deduped")


### PR DESCRIPTION
A dedupe group larger than one ioctl batch could kill the whole run with `SIGABRT`. Found while going through upstream's open issues; it is [markfasheh/duperemove#392](https://github.com/markfasheh/duperemove/issues/392), whose backtrace lands on these same two assertions.

## The bug

`FIDEDUPERANGE` takes at most `MAX_DEDUPES_PER_IOCTL` destinations, so a group bigger than that is deduped in rounds: `dedupe_extent_list()` fills a batch, runs it, closes every file, and reopens the target for the round that follows.

The member that next round starts with may be one that gets **skipped** — it cannot be opened, it changed since the scan, or it already shares the target's extents. All three paths run the group early only `if (ctxt && last)`, and a round that has only just begun has no `ctxt` yet. So a skip there falls out of the loop with the reopened target still on the open list, and

```c
abort_on(!RB_EMPTY_ROOT(&open_files.root));
```

kills the process — not the group, the run.

`max_queable` is one below `MAX_DEDUPES_PER_IOCTL`, so the rounds restart at members 120, 239, … A group has to be that big before any of this is reachable, which is why it has gone unnoticed: no synthetic profile builds groups of 121. Snapshot and backup trees are exactly that shape, and upstream's reporter hit it on a 17 TB XFS backup tree.

## The fix

Close the open list before asserting it is empty. `out:` already does precisely that (close, then assert the close emptied it); the two assertions just sat between the loop and it. `add_shared_extents_post()` opens the files it needs itself, so nothing downstream depends on them still being open.

## Reproduction

A group of `MAX_DEDUPES_PER_IOCTL + 1` identical files whose last member is unreadable. On v1.11.0, one file either side of that count is fine:

```
N=120 exit=0
N=121 exit=134   ERROR: src/run_dedupe.c:711
N=122 exit=0
```

`tests/integration/test_large_group_dedupe.py` pins it. It reads the victim's name back out of the hashfile rather than assuming one, because ids follow the order files finish hashing; it asserts on the **exit status**, since the abort printed a whole run's worth of output before dying and `assertDmOk()` would also reject the expected "Permission denied" line; and it skips under root, where `chmod 000` would not skip the member and the test would pass while testing nothing.

Verified it fails without the fix (`0 != -6 … died: signal 6`) and passes with it.

## Checks

- `scripts/verify.sh`: build clean, 242 tests, valgrind smoke — all pass
- `make integration-valgrind`: 242 tests, **no findings** (this touches file lifetimes in the UAF-prone area)
- `make lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)