### PR TITLE
Ctrl-C during hashing stops, instead of going on to the dedupe phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,19 @@ v1.10.1 persisted **0** files, this persists ~975, in ~70 ms.
   points: in-flight batches reap normally, `FIDEDUPERANGE` is atomic, and the
   generation-ordered watermark already guarantees `dedupe_seq` names only
   fully-processed generations.
+- **An interrupt during the *scan* skips the dedupe phase outright**
+  (`process_duplicates` returns right after the "Hashfile written" line), and
+  the run does not `dbfile_maybe_vacuum()` on the way out. The batch-loop check
+  above is too late: everything *before* it still ran — the deleted-file prune,
+  the find-dupes index build, the ~9 s group analysis — and then a VACUUM that
+  rewrites the whole file and cannot itself be interrupted. It deduped nothing
+  (the loop broke at once), so the only effect was a Ctrl-C that looked ignored
+  for minutes and then printed `Nothing to deduplicate`.
+  - **Wiping the progress block is part of it.** The scan hands its block to
+    the dedupe phase (`pscan_join(continues=true)`), so `dedupe_live` must also
+    test `!interrupted()` — without it the early return strands the worker rows
+    on screen for the rest of the session, which is #179 from the other side.
+    Pinned by `test_progress_tty.py::…_an_interrupted_scan_leaves_nothing_behind`.
 - **An interrupted run is not written to `run_history`** — it would read as a
   complete scan of the tree, skip counters and all. Exit is `128 + signo`, set
   last and only over a success.

--- a/src/oans.c
+++ b/src/oans.c
@@ -1396,11 +1396,24 @@ static void process_duplicates(struct dbhandle *db)
 	 *   - estimate the dup-group total so the bar and ETA have a scale.
 	 * The pdedupe_set_activity() calls are harmless no-ops without a live block.
 	 */
-	if (options.run_dedupe)
-		pdedupe_begin(passes);
-
 	if (options.hashfile)
 		qprintf("Hashfile \"%s\" written\n", options.hashfile);
+
+	/*
+	 * An interrupted scan stops here. The batch is already committed
+	 * (filescan_free, on the way out of scan_files), so everything below is
+	 * work for a run that is going to continue - and none of it is cheap on
+	 * a large hashfile: the prune walks every row, the index build is the
+	 * one deferred from the scan, and the group analysis is the query that
+	 * measured ~9 s on 2M files. Doing it anyway made Ctrl-C look ignored,
+	 * because the run visibly moved on to the dedupe phase and then claimed
+	 * "Nothing to deduplicate" when it had simply stopped looking.
+	 */
+	if (interrupted())
+		return;
+
+	if (options.run_dedupe)
+		pdedupe_begin(passes);
 
 	pdedupe_set_activity("checking for deleted files");
 	{
@@ -1660,9 +1673,15 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 		 * runs when deduping on an interactive, non-verbose tty. Tell the
 		 * scan to leave its worker block in place for it; otherwise (incl.
 		 * JSON mode) the area is wiped clean.
+		 *
+		 * An interrupted run has no dedupe phase to hand the block to
+		 * (process_duplicates returns before pdedupe_begin), so it must be
+		 * wiped here or the worker rows are stranded on screen - the #179
+		 * failure, which is what "a live block" and "a live printer" being
+		 * different things keeps producing.
 		 */
 		bool dedupe_live = options.run_dedupe && !verbose &&
-				   !options.progress_json &&
+				   !options.progress_json && !interrupted() &&
 				   isatty(STDOUT_FILENO);
 
 		pscan_join(dedupe_live);
@@ -2084,8 +2103,14 @@ int main(int argc, char **argv)
 		}
 	}
 
-	/* Reclaim space if a prune this run left the hashfile mostly free. */
-	if (options.hashfile)
+	/*
+	 * Reclaim space if a prune this run left the hashfile mostly free - but
+	 * never on the way out of a Ctrl-C. A VACUUM rewrites the whole file and
+	 * cannot be interrupted, so it is the longest thing an interrupted run
+	 * could still do, and the run that was asked to stop is the last one that
+	 * should do it. The next complete run compacts instead.
+	 */
+	if (options.hashfile && !interrupted())
 		dbfile_maybe_vacuum(db);
 
 	/*

--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -190,6 +190,30 @@ class ProgressTtyTest(DuperemoveTest):
             any("2 permission denied" in ln for ln in screen),
             f"the scan-skip report was erased by the block:\n  {shown}")
 
+    def test_an_interrupted_scan_leaves_nothing_behind_either(self):
+        """The same invariant, on the path that has no dedupe phase.
+
+        The scan hands its block straight to the dedupe phase rather than
+        wiping it (pscan_join(continues=true)), so whoever decides there is no
+        such phase also owns wiping the block. An interrupted run stops before
+        pdedupe_begin(), so if it still claimed the hand-off the worker rows
+        would sit on screen for the rest of the session - #179 exactly, reached
+        from the other side.
+        """
+        for i in range(8):
+            self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 256 * 1024)
+        tree = os.path.join(self.work, "tree")
+
+        screen = _render(_run_in_pty(
+            [DUPEREMOVE, "-dr", "--hashfile", self.hf, tree],
+            env={"DUPEREMOVE_INTERRUPT_AFTER": "4"}))
+        shown = "\n  ".join(screen)
+
+        stranded = [ln for ln in screen if WORKER_ROW.match(ln)]
+        self.assertEqual([], stranded,
+                         f"worker rows left on screen after an interrupt:"
+                         f"\n  {chr(10).join(stranded)}\n\nfull screen:\n  {shown}")
+
     def test_a_crafted_name_cannot_inject_ansi_into_the_block(self):
         """The worker rows are drawn straight to the tty (#202).
 

--- a/tests/integration/test_signal_flush.py
+++ b/tests/integration/test_signal_flush.py
@@ -82,6 +82,51 @@ class SignalFlushTest(DuperemoveTest):
         self.assertDmOk()
         self.assertEqual(1, self.hf_count("run_history"))
 
+    @requires_reflink
+    def test_an_interrupted_scan_does_not_go_on_to_the_dedupe_phase(self):
+        """Ctrl-C during hashing stops; it does not carry on into dedupe.
+
+        The interrupt check used to live only inside the dedupe *batch loop*,
+        so an interrupted scan still ran everything before it: the deleted-file
+        prune, the find-dupes index build, and the group analysis - seconds to
+        minutes each on a large hashfile - and then a VACUUM on the way out,
+        which rewrites the whole file and cannot itself be interrupted.
+
+        None of it produced any dedupe (the loop broke at once), so the only
+        visible result was a run that ignored the Ctrl-C for a long time and
+        then announced "Nothing to deduplicate" when it had stopped looking.
+        """
+        for i in range(40):
+            self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 128 * KiB)
+        self.sync()
+        tree = self.path("tree")
+
+        # This tree is 80 files, so it needs its own stop count rather than
+        # interrupt_scan()'s STOP_AFTER, which it would never reach.
+        self.dm("-rd", tree, env={"DUPEREMOVE_INTERRUPT_AFTER": "40"})
+        self.assertEqual(130, self.rc, self.out)
+
+        # The phase announces itself either way - it never deduped anything
+        # here, so its summary is the tell that it ran at all.
+        self.assertNotIn("Nothing to deduplicate", self.out,
+                         "the dedupe phase ran after an interrupted scan")
+        self.assertNotIn("net change in shared extents", self.out,
+                         "the dedupe phase ran after an interrupted scan")
+        self.assertNotIn("Compacting", self.out,
+                         "an interrupted run vacuumed the hashfile")
+
+        # Durability is unchanged: stopping earlier must not drop the batch.
+        self.assertGreater(
+            self.hf_scalar("select count(*) from files where digest is not null"),
+            0, "the interrupted scan persisted nothing")
+
+        # And the work is merely deferred - the next complete run does it.
+        self.dm("-rd", tree, quiet=False)
+        self.assertDmOk("run after an interrupted scan")
+        summary = self.reclaimed_summary()
+        self.assertTrue(summary and summary[0] != "0 B",
+                        f"the follow-up run found nothing to do; got {summary}")
+
     def test_resuming_matches_one_straight_through_scan(self):
         """The property that matters: an interrupted-then-resumed hashfile is
         indistinguishable from one produced in a single run.


### PR DESCRIPTION
Reported: pressing Ctrl-C in the hashing phase and watching the run carry on into dedupe.

## What actually happened

The interrupt check lives inside the dedupe **batch loop**, so an interrupted scan still ran everything *before* it — and none of it is cheap on a large hashfile:

- the deleted-file prune (walks every row),
- the find-dupes index build (the one deliberately deferred from the scan),
- `dbfile_count_dupe_work()`, the group analysis CLAUDE.md measures at ~9 s on 2M files,
- and then `dbfile_maybe_vacuum()` at `oans.c:2089`, which rewrites the whole file and **cannot itself be interrupted**.

Then the loop broke on its first check, having deduped nothing. Reproduced with `DUPEREMOVE_INTERRUPT_AFTER=5`:

```
Interrupted by SIGINT - finishing the work in flight and committing what has been hashed.
Hashfile "…/h.db" written
Nothing to deduplicate.
Comparison of extent info shows a net change in shared extents of: 0
Compacting the rebuilt hashfile ... done      ← a full VACUUM
```

`Nothing to deduplicate` is also just false — it stopped looking, it didn't look and find nothing.

## The fix

`process_duplicates()` returns right after the "Hashfile written" line when interrupted, and the vacuum is skipped. Durability is untouched: the batch is committed by `filescan_free()` on the way out of `scan_files()`, before any of this. `dbfile_record_run` already guarded on `!interrupted()`; these two sites just never got the same treatment.

**Wiping the progress block is part of the fix, not a detail.** The scan hands its block to the dedupe phase rather than wiping it (`pscan_join(continues=true)`), so whoever decides there is no such phase owns wiping it — `dedupe_live` now also tests `!interrupted()`. I reverted that half alone to check it was load-bearing, and it is:

```
AssertionError: Lists differ: [] != ['  1  idle', '  2  idle', '  3  idle', …]
```

That is #179 reached from the other side, so it gets a test next to the existing one.

## After

```
Interrupted by SIGINT - finishing the work in flight and committing what has been hashed.
Hashfile "…/h.db" written
exit 130
```

## Tests

Two, each pinning one half, and both verified to fail without their half:

- `test_signal_flush.py::…_an_interrupted_scan_does_not_go_on_to_the_dedupe_phase` — asserts the phase's own output is absent (it deduped nothing, so its summary is the only tell that it ran), that no VACUUM happened, that the batch still persisted, and that the next complete run does the deferred work.
- `test_progress_tty.py::…_an_interrupted_scan_leaves_nothing_behind_either` — the stranded-worker-row invariant, on the interrupt path.

`scripts/verify.sh`: 244 tests, valgrind smoke, all pass. `make lint` clean. CLAUDE.md's #201 section updated — it stated "the dedupe phase stops admitting batches and nothing else", which was the incomplete belief behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)