### PR TITLE
Fix a use-after-free in the partial-mode dedupe drain (#227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -747,11 +747,26 @@ extent passes. Lives in `run_dedupe.c` (`dedupe_phase_begin/end`,
   (`dext_work()` etc.) **before** the push. Reading after once fed
   `len * (0 - 1)` from a freed dext into the pushed-work total (frozen bar,
   multi-thousand-year ETA); `push_results` now asserts sane per-group work.
-- **Partial mode drains.** `find_additional_dedupe()` walks the **global**
-  filerec list, so with `--dedupe-options=partial` the producer calls
-  `dedupe_drain()` before the block-hash search — earlier batches are reaped
-  (filerecs freed) first, at the cost of cross-batch pipelining in that mode.
-  Default mode keeps the full overlap; don't add other drain points.
+- **Partial mode drains — *before* `dedupe_begin_batch()`, not mid-load (#227).**
+  `find_additional_dedupe()` walks the **global** filerec list, so with
+  `--dedupe-options=partial` the producer calls `dedupe_drain()` — earlier
+  batches reaped, filerecs freed — at the cost of cross-batch pipelining in that
+  mode. Default mode keeps the full overlap; don't add other drain points.
+  - **A reap may never land while a batch is open.** A batch takes its filerec
+    refs in `push_results()`, so between a load and its push the open batch's
+    groups point at filerecs kept alive only by the refs the reap drops — and a
+    group spanning two windows is exactly that shape, since the anchor member
+    (min id) is reloaded by every later window. The drain used to sit between
+    the extent load and the push, which freed that anchor and made
+    `push_results()` walk into it: a heap UAF that only showed up under
+    `--dedupe-options=partial`, and only when the previous batch was still in
+    flight. `free_batch()` now asserts `open_batch == NULL`, so putting a reap
+    back in the middle of a load aborts at the violation instead of corrupting
+    the heap.
+  - `DUPEREMOVE_DEDUPE_DELAY_MS` holds each dedupe worker back so a batch is
+    still in flight while the next one loads; on a test-sized tree the window
+    never opens without it (`test_partial_cross_window.py`). Sibling of
+    `DUPEREMOVE_SEARCH_DELAY_MS` below.
 - **The search must outlive nothing.** `find_additional_dedupe()` waits for
   every worker it pushed (its own counter/cond in `find_dupes.c`) before
   returning, because the caller reaps batches — freeing filerecs — right after.

--- a/src/oans.c
+++ b/src/oans.c
@@ -1279,14 +1279,10 @@ static void stream_load_batch(struct dbhandle *pdb, bool inmem,
 		struct hash_tree dups_tree;
 
 		/*
-		 * The block-hash search walks the GLOBAL filerec list, so the
-		 * previous window's batches must be reaped (their filerecs
-		 * freed) first or it would rescan those files. This gives up
-		 * cross-batch pipelining in partial mode; the default mode
-		 * keeps the full overlap.
+		 * The previous window's batches were already reaped before this
+		 * one was begun (see stream_duplicates), so the global filerec
+		 * list holds only this window's files.
 		 */
-		dedupe_drain();
-
 		init_hash_tree(&dups_tree);
 		load_lock(inmem);
 		ret = dbfile_load_block_hashes(pdb, &dups_tree, seq_lo, seq_hi);
@@ -1341,6 +1337,25 @@ static void stream_duplicates(struct dbhandle *db, unsigned int first_seq,
 		}
 
 		dedupe_await_slot();		/* bound to 2 batches in flight */
+
+		/*
+		 * The block-hash search (--dedupe-options=partial) walks the
+		 * GLOBAL filerec list, so the previous window's batches must be
+		 * reaped (their filerecs freed) before this one runs, or it
+		 * would rescan those files. It has to happen here, before the
+		 * batch is begun: reaping drops the refs that keep filerecs
+		 * alive, and a batch takes its own refs only once its loaded
+		 * groups are pushed. Draining between this batch's load and its
+		 * push - where this used to sit - freed a filerec that the
+		 * groups just loaded still pointed at (a cross-window anchor is
+		 * the same filerec in both windows), and push_results() then
+		 * dereferenced it: issue #227. This gives up cross-batch
+		 * pipelining in partial mode; the default mode keeps the full
+		 * overlap.
+		 */
+		if (options.do_block_hash)
+			dedupe_drain();
+
 		pdedupe_set_batch(++pass);
 		batch = dedupe_begin_batch(hi);
 		stream_load_batch(pdb, inmem, batch, i, hi);

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -105,6 +105,23 @@ static GMutex		producer_mutex;	/* guards the in-flight list + counts */
 static GCond		producer_cond;	/* producer waits; workers/seal signal */
 static struct list_head	inflight_batches = LIST_HEAD_INIT(inflight_batches);
 static unsigned int	inflight_count;
+/*
+ * The batch the producer is loading into, between dedupe_begin_batch() and
+ * dedupe_seal_batch(); NULL the rest of the time. Producer thread only, and
+ * only ever read by the assert in free_batch().
+ */
+static struct dedupe_batch *open_batch;
+
+/*
+ * Test hook (DUPEREMOVE_DEDUPE_DELAY_MS): hold each dedupe worker back so a
+ * batch is still in flight while the producer loads the next one. That is the
+ * ordering #227 needs - a reap has to land in the middle of a load - and on a
+ * test-sized tree a batch otherwise finishes long before the next load starts,
+ * so the window never opens. Read once on the producer thread in
+ * dedupe_phase_begin(); unset in normal use, so this costs one
+ * predictable-branch load per group.
+ */
+static useconds_t dedupe_delay_us;
 /* Called on the producer thread when a batch (and all earlier ones) complete,
  * to advance the durable dedupe_seq. Provided by the caller of the phase. */
 static void		(*batch_complete_cb)(unsigned int seq_hi);
@@ -853,6 +870,9 @@ static void dedupe_worker_body(void *priv)
 
 	free(item);	/* the item is consumed; dext/batch captured above */
 
+	if (dedupe_delay_us)
+		usleep(dedupe_delay_us);	/* test hook, see above */
+
 	/*
 	 * Seed the display line from the group before any work: first member
 	 * as the (provisional) target path, and the data the kernel has to
@@ -1028,6 +1048,7 @@ struct dedupe_batch *dedupe_begin_batch(unsigned int seq_hi)
 	b->held = g_ptr_array_new();
 	b->seq_hi = seq_hi;
 	INIT_LIST_HEAD(&b->list);
+	open_batch = b;
 	return b;
 }
 
@@ -1067,6 +1088,18 @@ static void free_batch(struct dedupe_batch *b)
 	 * than an abort.
 	 */
 	abort_on(!extents_search_idle());
+
+	/*
+	 * Nor may a batch be reaped while another one is being loaded. A batch
+	 * takes its filerec refs in push_results(), so between a load and its
+	 * push the open batch's groups point at filerecs kept alive only by the
+	 * refs of the batches reaped here - and a group spanning two windows
+	 * (the anchor member) is exactly that shape. Dropping those refs here
+	 * frees the filerec out from under the open batch, which then walks
+	 * into it: issue #227, where dedupe_drain() for the block-hash search
+	 * sat in the middle of the load. Reaps belong before dedupe_begin_batch.
+	 */
+	abort_on(open_batch != NULL);
 
 	if (batch_complete_cb)
 		batch_complete_cb(b->seq_hi);
@@ -1120,6 +1153,7 @@ void dedupe_await_slot(void)
  * reap it (and any earlier ready batch) if it is already complete. */
 void dedupe_seal_batch(struct dedupe_batch *b)
 {
+	open_batch = NULL;
 	g_mutex_lock(&producer_mutex);
 	b->fully_pushed = true;
 	list_add_tail(&b->list, &inflight_batches);
@@ -1136,6 +1170,7 @@ void dedupe_seal_batch(struct dedupe_batch *b)
 void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi))
 {
 	GError *err = NULL;
+	const char *delay = getenv("DUPEREMOVE_DEDUPE_DELAY_MS");
 
 	batch_complete_cb = on_complete;
 	/* Kept in step with the print condition in dedupe_phase_end(): this
@@ -1144,8 +1179,11 @@ void dedupe_phase_begin(void (*on_complete)(unsigned int seq_hi))
 	report_net_shared = !isatty(STDOUT_FILENO);
 	curr_dedupe_pass = 0;
 	total_dedupe_passes = 0;
+	open_batch = NULL;
 	inflight_count = 0;
 	INIT_LIST_HEAD(&inflight_batches);
+	if (delay)
+		dedupe_delay_us = (useconds_t)strtoul(delay, NULL, 10) * 1000;
 
 	vprintf("Using %u threads for dedupe phase\n", options.io_threads);
 

--- a/tests/integration/test_partial_cross_window.py
+++ b/tests/integration/test_partial_cross_window.py
@@ -1,0 +1,71 @@
+"""#227: draining the dedupe pipeline must not land in the middle of a load.
+
+--dedupe-options=partial has to reap every in-flight batch before the
+block-hash search runs, because that search walks the GLOBAL filerec list. The
+drain used to sit between the current batch's extent load and its push -- but a
+batch takes its filerec refs only at push time, so reaping there freed a
+filerec the just-loaded groups still pointed at, and push_results() walked into
+it. The victim is a group that spans two generation windows: its anchor member
+(the stable target, min file id) is loaded again by every later window, so the
+same filerec is referenced by both the in-flight batch and the open one.
+
+The tree here is built to force exactly that shape: one extent-level group
+whose members are spread over many small generations, so consecutive windows
+share the anchor. DUPEREMOVE_DEDUPE_DELAY_MS keeps the previous batch in flight
+while the next one loads -- without it a test-sized batch finishes first and the
+window never opens.
+
+Requires btrfs: the setup relies on an fsync-forced extent boundary between the
+unique head and the shared tail, the same reason test_extent_dedupe.py does.
+"""
+
+import os
+from harness import DuperemoveTest, requires_btrfs
+
+MiB = 1 << 20
+
+# Small generations (-B) plus a small pass stride give many windows over few
+# files, so batches overlap and an anchor is reloaded window after window.
+BATCH_SIZE = "2"
+FILES_PER_PASS = "2"
+FILES = 12
+
+
+@requires_btrfs
+class PartialCrossWindowTest(DuperemoveTest):
+    # The head/tail split relies on an fsync-forced extent boundary: see
+    # DuperemoveTest.serial.
+    serial = True
+
+    def _mkfile(self, rel, head, tail):
+        """A unique head, an fsync to force an extent boundary, shared tail."""
+        p = self.path(rel)
+        with open(p, "wb") as f:
+            f.write(head)
+            f.flush()
+            os.fsync(f.fileno())
+            f.write(tail)
+        return p
+
+    def test_a_cross_window_group_survives_the_partial_mode_drain(self):
+        tail = os.urandom(2 * MiB)
+        for i in range(FILES):
+            self._mkfile(f"f{i:02d}.bin", os.urandom(2 * MiB), tail)
+        self.sync()
+
+        self.dedupe(self.work, "--dedupe-options=partial",
+                    "-B", BATCH_SIZE, "--io-threads=2",
+                    env={"DUPEREMOVE_FILES_PER_PASS": FILES_PER_PASS,
+                         "DUPEREMOVE_DEDUPE_DELAY_MS": "200"})
+        # A use-after-free shows up as a signal (SIGABRT from the invariant
+        # assert, or SIGSEGV / an ASAN abort in a sanitizer build), which
+        # assertDmOk reports as a failure rather than reading the partial
+        # output as a clean run.
+        self.assertDmOk("partial-mode dedupe across generation windows failed")
+
+        # The run has to have actually deduped, or it proves nothing: an empty
+        # extent pass never loads a cross-window anchor in the first place.
+        for i in range(1, FILES):
+            self.assertShared(self.path("f00.bin"), self.path(f"f{i:02d}.bin"),
+                              "the shared tail was not deduped, so the "
+                              "cross-window load under test never ran")

--- a/tests/integration/test_partial_cross_window.py
+++ b/tests/integration/test_partial_cross_window.py
@@ -19,8 +19,9 @@ Requires btrfs: the setup relies on an fsync-forced extent boundary between the
 unique head and the shared tail, the same reason test_extent_dedupe.py does.
 """
 
+import collections
 import os
-from harness import DuperemoveTest, requires_btrfs
+from harness import DuperemoveTest, phys_extents, requires_btrfs
 
 MiB = 1 << 20
 
@@ -29,6 +30,14 @@ MiB = 1 << 20
 BATCH_SIZE = "2"
 FILES_PER_PASS = "2"
 FILES = 12
+# How many files must end up on one physical extent for the run to have proven
+# anything. Not FILES: the head/tail split rides on an fsync-forced extent
+# boundary, and a file whose writeback merged the two never joins the group at
+# all -- with 12 files that all-or-nothing assertion failed on the ASAN leg
+# while both plain btrfs legs passed. A class of 4 cannot fit in one -B 2
+# generation, so it provably spans at least two windows, which is the whole
+# point; the slack absorbs a file or two laid out differently.
+MIN_SHARED = 4
 
 
 @requires_btrfs
@@ -66,7 +75,17 @@ class PartialCrossWindowTest(DuperemoveTest):
 
         # The run has to have actually deduped, or it proves nothing: an empty
         # extent pass never loads a cross-window anchor in the first place.
-        for i in range(1, FILES):
-            self.assertShared(self.path("f00.bin"), self.path(f"f{i:02d}.bin"),
-                              "the shared tail was not deduped, so the "
-                              "cross-window load under test never ran")
+        shared = self._largest_shared_class()
+        self.assertGreaterEqual(
+            shared, MIN_SHARED,
+            f"only {shared} of {FILES} files ended up on a common physical "
+            "extent: the shared tail was not deduped across enough files, so "
+            "the cross-window load under test never ran")
+
+    def _largest_shared_class(self):
+        """How many distinct files sit on the most widely shared extent."""
+        owners = collections.Counter()
+        for i in range(FILES):
+            # A set per file: one file listing an extent twice is not sharing.
+            owners.update(set(phys_extents(self.path(f"f{i:02d}.bin"))))
+        return max(owners.values(), default=0)

--- a/tests/integration/test_partial_cross_window.py
+++ b/tests/integration/test_partial_cross_window.py
@@ -53,15 +53,16 @@ class PartialCrossWindowTest(DuperemoveTest):
             self._mkfile(f"f{i:02d}.bin", os.urandom(2 * MiB), tail)
         self.sync()
 
-        self.dedupe(self.work, "--dedupe-options=partial",
-                    "-B", BATCH_SIZE, "--io-threads=2",
-                    env={"DUPEREMOVE_FILES_PER_PASS": FILES_PER_PASS,
-                         "DUPEREMOVE_DEDUPE_DELAY_MS": "200"})
+        self.dm("-rd", self.work, "--dedupe-options=partial",
+                "-B", BATCH_SIZE, "--io-threads=2",
+                env={"DUPEREMOVE_FILES_PER_PASS": FILES_PER_PASS,
+                     "DUPEREMOVE_DEDUPE_DELAY_MS": "200"})
         # A use-after-free shows up as a signal (SIGABRT from the invariant
         # assert, or SIGSEGV / an ASAN abort in a sanitizer build), which
         # assertDmOk reports as a failure rather than reading the partial
         # output as a clean run.
         self.assertDmOk("partial-mode dedupe across generation windows failed")
+        self.sync()
 
         # The run has to have actually deduped, or it proves nothing: an empty
         # extent pass never loads a cross-window anchor in the first place.


### PR DESCRIPTION
Fixes #227.

## The bug

`--dedupe-options=partial` has to reap every in-flight batch before the block-hash search runs, because `find_additional_dedupe()` walks the **global** filerec list. That drain sat in `stream_load_batch()`, between the current batch's extent load and its push:

```c
dbfile_load_extent_hashes(...);   /* the loaded groups now point at filerecs */
dedupe_drain();                   /* reaps earlier batches -> filerec_put -> free */
...
dedupe_push(batch, false);        /* push_results -> filerec_get(extent->e_file) */
```

A batch takes its filerec refs in `push_results()`, at push time. So the reap dropped the last refs on a filerec the just-loaded groups still pointed at, freed it, and `push_results()` then dereferenced it.

The victim is a group spanning two generation windows: its anchor member (the stable target, min file id) is loaded again by every later window, so the same filerec is referenced by both the in-flight batch and the open one. Hence the reported shape — partial mode only, and only sometimes.

The issue's report shows `heap-buffer-overflow` rather than `heap-use-after-free` only because on a 900k-group run the freed chunk had already left ASAN's quarantine.

## Reproduction

A tree of files with unique heads and a shared, fsync-separated tail, run with `-B 2`, `DUPEREMOVE_FILES_PER_PASS=2` and `--dedupe-options=partial`, gives the reported stack under ASAN, with the free side naming the culprit:

```
READ of size 4 ... filerec_get src/filerec.c:226
                   push_results src/run_dedupe.c:954
                   dedupe_push / stream_load_batch / stream_duplicates
freed by thread T0 here:
                   filerec_put -> free_batch -> reap_ready_locked
                   -> dedupe_drain -> stream_load_batch src/oans.c:1288
```

## The fix

- Move `dedupe_drain()` ahead of `dedupe_begin_batch()` in `stream_duplicates()`, so no reap can land while a batch is being loaded. The search keeps the same guarantee (the global list still holds only this window's files); the cost is a little more of the overlap partial mode had already given up.
- Assert the invariant: `free_batch()` now checks `open_batch == NULL`, so putting a reap back in the middle of a load aborts at the violation instead of corrupting the heap. Confirmed it fires by temporarily restoring the old ordering.
- New test hook `DUPEREMOVE_DEDUPE_DELAY_MS`, sibling of the existing `DUPEREMOVE_SEARCH_DELAY_MS` (which exists for the analogous #123 race): it keeps a batch in flight while the next one loads, since a test-sized batch otherwise finishes long before the next load starts and the window never opens.
- `tests/integration/test_partial_cross_window.py` drives one extent-level group across many small generation windows under partial mode. It asserts the run does not die, and — so that an empty extent pass cannot pass for a clean one — that some physical extent ends up shared by at least 4 files. Deliberately not "all 12": the head/tail split rides on an fsync-forced extent boundary, so a file whose writeback merged the two never joins the group; a class of 4 cannot fit in one `-B 2` generation, so the group still provably spans two windows.
- Working notes in `CLAUDE.md` updated: the drain's new position, the "no reap while a batch is open" invariant, and the new hook.

## Testing

Verified both ways with the new test's own parameters: **3/3 runs abort on the old ordering, 3/3 clean with the fix**.

Two caveats on what I could run locally: the sandbox has no btrfs or XFS, so the new test (`@requires_btrfs`) skips there, and `scripts/verify.sh` / `make integration-valgrind` cannot run either — the integration failures on that box are environmental and identical with and without this change. I confirmed the reproduction and the fix by temporarily letting `is_fs_supported()` accept ext4 (a throwaway patch, not part of this branch). Locally green: `make test` (31 tests, 5910 assertions), `make lint`, warning-free release build.

CI is the real gate for the new test, and it is green on all 11 checks — btrfs and xfs, gcc and clang, ASAN/UBSAN/TSAN, and all four valgrind shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnzrFSkWUB4fLyZTEtQ6CB