### PR TITLE
docs: ext4 is refused, not scanned

### DIFF
--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -19,7 +19,9 @@ findmnt -no FSTYPE /srv/media      # or: stat -f -c %T /srv/media
 - **btrfs / xfs** → you're good. (Most Synology volumes are btrfs.)
 - **zfs** → stop. oans cannot dedupe ZFS; use ZFS's own deduplication instead.
   (This rules out a stock TrueNAS SCALE pool.)
-- **ext4 / other** → oans will scan and report, but cannot deduplicate.
+- **ext4 / anything else** → stop. oans refuses an unsupported filesystem before
+  it walks it, so there is no scan-only mode either: it needs FIEMAP to find
+  extents and `FIDEDUPERANGE` to share them.
 
 ## Step 1 — Build and install
 


### PR DESCRIPTION
The NAS quickstart's filesystem checklist claimed:

> **ext4 / other** → oans will scan and report, but cannot deduplicate.

That hasn't been true since the seed-time rejection landed. `check_file()` refuses any root that isn't btrfs or XFS *before* the walk starts ("its filesystem is not btrfs or XFS, which oans needs to deduplicate"), and a run whose roots are all unsupported fails loudly rather than reporting an empty success. There is no scan-only mode.

Verified while looking at discussion #228, where this line is what led someone to expect scan-only support on ZFS — so it was actively misleading, not just out of date. The new wording also says *why*, since that's the question the discussion was really asking: FIEMAP to find extents, `FIDEDUPERANGE` to share them.

Docs only; no code change. Checked that the same claim isn't repeated in the README, man page, or `--help`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnzrFSkWUB4fLyZTEtQ6CB)_