### PR TITLE
scan: probe for FIDEDUPERANGE instead of hardcoding btrfs and XFS (#224)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,6 +574,11 @@ names the two; `dedupe_probe_fd()` asks everything else.
   what refusing unsupported filesystems upfront exists to prevent. Pinned by
   the `dedupe_classify_probe` unit test; reproduce with an `overlay` mount over
   ext4 and `./oans -rq`.
+  The length comes from `dedupe_shareable_len()`/`cached_blocksize()`, the
+  helpers the dedupe path already uses: `dest_offset` must be block-aligned or
+  a filesystem that *does* support the ioctl answers `EINVAL`, which reads as
+  UNKNOWN and quietly defeats the probe. Don't hardcode 4096 — 64K blocks exist
+  and the codebase can query the real value.
 - **The trade the real request buys that with:** on a filesystem that *does*
   support dedupe, the probe's two ranges may turn out identical and get shared.
   That is a genuine, byte-verified dedupe of one block within one file — it
@@ -595,8 +600,11 @@ names the two; `dedupe_probe_fd()` asks everything else.
   by default since #182). So `check_file()` locks the root provisionally and
   `__scan_file()` — the single consumer, hence no locking — settles it before
   anything is hashed. A definite no returns nonzero, which stops the consume
-  loop. An UNKNOWN file is hashed normally, so an unrecognised filesystem costs
-  at most `FS_PROBE_MAX_TRIES` files before it is refused.
+  loop — **and sets the walk-abort flag the walker threads poll**, mirroring
+  `interrupted()`. Without that the walkers readdir/statx the whole tree after
+  the error is already on screen: measured on a 20k-file tree, 402 `getdents64`
+  became 16. An UNKNOWN file is hashed normally, so an unrecognised filesystem
+  costs at most `FS_PROBE_MAX_TRIES` files before it is refused.
 - **Three ways to end up refusing, and they say different things.** A definite
   no; `FS_PROBE_MAX_TRIES` files that all declined; and a walk that ended with
   the question never asked (`filescan_fs_probe_unsettled()` — an empty tree, or
@@ -605,6 +613,10 @@ names the two; `dedupe_probe_fd()` asks everything else.
 - **Not routed through `seed_fs_lock_failed`.** That reports roots which could
   never be locked at all and only fires when *none* was seeded; here a root was
   seeded and the probe has already said precisely what is wrong.
+- **One place words the refusal** (`report_fs_unusable()`), because which of the
+  three cases it is decides the advice, and `file_scan` owns the state — the
+  same shape as `filescan_report_excludes()`. It also skips the report on an
+  interrupted run, whose exit status belongs to the signal.
 - **`DUPEREMOVE_FORCE_FS_PROBE=1` drops the fast path.** Without it the accept
   branch is unreachable in tests: the only filesystems known to answer *yes*
   are the two that never reach the probe. `test_fs_probe.py` uses it to run the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,6 +556,46 @@ is the false premise this took two PRs to unwind:
   means "the user never asked", so `dbfile_load_scan_config` coerces `< 0` to 0 —
   a replay adopts the new default; only an explicit `1` survives.
 
+## What oans will scan: allowlist, then probe (#224)
+
+btrfs and XFS are an **allowlist fast path**, not the definition of supported.
+Anything else is asked directly whether it implements `FIDEDUPERANGE`, so a
+filesystem that gains the ioctl needs no code change. `is_fs_allowlisted()`
+names the two; `dedupe_probe_fd()` asks everything else.
+
+- **The question is a zero-length dedupe, which changes nothing.** A filesystem
+  with no `remap_file_range` is refused `EOPNOTSUPP` before the kernel touches
+  anything, and zero bytes is a no-op elsewhere. Crucially, **a zero
+  `src_length` does *not* mean "to end of file" for `FIDEDUPERANGE`** the way it
+  does for `FICLONERANGE` — so this cannot accidentally share data. Measured on
+  ext4: zero-length and real requests both return `EOPNOTSUPP`, file untouched.
+  `test_fs_probe.py::…_leaves_the_file_alone` pins it.
+- **The taxonomy is the whole feature, so it is a pure function**
+  (`dedupe_classify_probe`, unit-tested against every errno that matters). Only
+  `EOPNOTSUPP`/`ENOTTY` mean *no*; everything else — `EINVAL` above all, which
+  the man page documents both for "the filesystem does not support
+  deduplicating the ranges" and for a dozen per-file conditions — is
+  **UNKNOWN**, and the next file is asked instead (up to `FS_PROBE_MAX_TRIES`).
+  Never widen *no*: a wrong *no* silently skips someone's whole tree.
+- **Probed lazily, at the first regular file, not at seed time.** The ioctl
+  needs a writable regular file and a root is normally a directory — measured,
+  a directory fd gives `EISDIR`, not `EOPNOTSUPP`. Creating a scratch file
+  instead is a non-starter (read-only mounts; read-only subvolumes are scanned
+  by default since #182). So `check_file()` locks the root provisionally and
+  `__scan_file()` — the single consumer, hence no locking — settles it before
+  anything is hashed. A definite no returns nonzero, which stops the consume
+  loop.
+- **Not routed through `seed_fs_lock_failed`.** That reports roots which could
+  never be locked at all and only fires when *none* was seeded; here a root was
+  seeded and the probe has already said precisely what is wrong.
+- **`DUPEREMOVE_FORCE_FS_PROBE=1` drops the fast path.** Without it the accept
+  branch is unreachable in tests: the only filesystems known to answer *yes*
+  are the two that never reach the probe. `test_fs_probe.py` uses it to run the
+  probe against the real scratch btrfs/XFS, which is the only way this ships
+  having been seen to say *yes* and not just *no*.
+- The refusal path is testable anywhere (`test_unsupported_fs.py`), since any
+  non-reflink filesystem — ext4, tmpfs — answers `EOPNOTSUPP`.
+
 ## Snapshot-aware scan: copy hashes for an identical layout (#206)
 
 Hashing N snapshots of a subvolume read N× the data. Two files whose fiemaps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -563,20 +563,31 @@ Anything else is asked directly whether it implements `FIDEDUPERANGE`, so a
 filesystem that gains the ioctl needs no code change. `is_fs_allowlisted()`
 names the two; `dedupe_probe_fd()` asks everything else.
 
-- **The question is a zero-length dedupe, which changes nothing.** A filesystem
-  with no `remap_file_range` is refused `EOPNOTSUPP` before the kernel touches
-  anything, and zero bytes is a no-op elsewhere. Crucially, **a zero
-  `src_length` does *not* mean "to end of file" for `FIDEDUPERANGE`** the way it
-  does for `FICLONERANGE` — so this cannot accidentally share data. Measured on
-  ext4: zero-length and real requests both return `EOPNOTSUPP`, file untouched.
-  `test_fs_probe.py::…_leaves_the_file_alone` pins it.
+- **The probe is a real block-sized request, and the answer is read from BOTH
+  `rc`/`errno` and `info[0].status`.** A zero-length probe reading only errno
+  looks obviously safer and is *wrong*: measured on a container's overlayfs
+  over ext4, zero-length returns `rc=0` (overlayfs answers for itself, as a
+  pass-through, without consulting the storage underneath) while a 4K request
+  returns `rc=0, status=-EINVAL`. Plain ext4 returns `rc=-1/EOPNOTSUPP` for
+  every shape. So errno-only accepts every containerised run on an overlay
+  root, which then hashes the whole tree and fails at dedupe time — precisely
+  what refusing unsupported filesystems upfront exists to prevent. Pinned by
+  the `dedupe_classify_probe` unit test; reproduce with an `overlay` mount over
+  ext4 and `./oans -rq`.
+- **The trade the real request buys that with:** on a filesystem that *does*
+  support dedupe, the probe's two ranges may turn out identical and get shared.
+  That is a genuine, byte-verified dedupe of one block within one file — it
+  cannot change contents, size or mtime, and it happens only when the answer is
+  yes, i.e. when oans is about to deduplicate the tree anyway.
+  `test_fs_probe.py::…_leaves_the_file_alone` pins the file being untouched.
 - **The taxonomy is the whole feature, so it is a pure function**
-  (`dedupe_classify_probe`, unit-tested against every errno that matters). Only
-  `EOPNOTSUPP`/`ENOTTY` mean *no*; everything else — `EINVAL` above all, which
-  the man page documents both for "the filesystem does not support
-  deduplicating the ranges" and for a dozen per-file conditions — is
-  **UNKNOWN**, and the next file is asked instead (up to `FS_PROBE_MAX_TRIES`).
-  Never widen *no*: a wrong *no* silently skips someone's whole tree.
+  (`dedupe_classify_probe`, unit-tested against every errno and status that
+  matters). Only `EOPNOTSUPP`/`ENOTTY` — from either errno or a negative status
+  — mean *no*; everything else, `EINVAL` above all (the man page documents it
+  both for "the filesystem does not support deduplicating the ranges" and for a
+  dozen per-file conditions), is **UNKNOWN**, and the next file is asked, up to
+  `FS_PROBE_MAX_TRIES`. Never widen *no*: a wrong *no* silently skips someone's
+  whole tree.
 - **Probed lazily, at the first regular file, not at seed time.** The ioctl
   needs a writable regular file and a root is normally a directory — measured,
   a directory fd gives `EISDIR`, not `EOPNOTSUPP`. Creating a scratch file
@@ -584,7 +595,13 @@ names the two; `dedupe_probe_fd()` asks everything else.
   by default since #182). So `check_file()` locks the root provisionally and
   `__scan_file()` — the single consumer, hence no locking — settles it before
   anything is hashed. A definite no returns nonzero, which stops the consume
-  loop.
+  loop. An UNKNOWN file is hashed normally, so an unrecognised filesystem costs
+  at most `FS_PROBE_MAX_TRIES` files before it is refused.
+- **Three ways to end up refusing, and they say different things.** A definite
+  no; `FS_PROBE_MAX_TRIES` files that all declined; and a walk that ended with
+  the question never asked (`filescan_fs_probe_unsettled()` — an empty tree, or
+  everything filtered by `--exclude` or size). The last one matters most: it is
+  the case where exiting 0 would look like a clean run.
 - **Not routed through `seed_fs_lock_failed`.** That reports roots which could
   never be locked at all and only fires when *none* was seeded; here a root was
   seeded and the probe has already said precisely what is wrong.
@@ -593,8 +610,8 @@ names the two; `dedupe_probe_fd()` asks everything else.
   are the two that never reach the probe. `test_fs_probe.py` uses it to run the
   probe against the real scratch btrfs/XFS, which is the only way this ships
   having been seen to say *yes* and not just *no*.
-- The refusal path is testable anywhere (`test_unsupported_fs.py`), since any
-  non-reflink filesystem — ext4, tmpfs — answers `EOPNOTSUPP`.
+- The refusal paths are testable anywhere: ext4 and tmpfs answer `EOPNOTSUPP`,
+  and an `overlay` mount over either reproduces the stacking case.
 
 ## Snapshot-aware scan: copy hashes for an identical layout (#206)
 

--- a/docs/nas-quickstart.md
+++ b/docs/nas-quickstart.md
@@ -19,9 +19,9 @@ findmnt -no FSTYPE /srv/media      # or: stat -f -c %T /srv/media
 - **btrfs / xfs** → you're good. (Most Synology volumes are btrfs.)
 - **zfs** → stop. oans cannot dedupe ZFS; use ZFS's own deduplication instead.
   (This rules out a stock TrueNAS SCALE pool.)
-- **ext4 / anything else** → stop. oans refuses an unsupported filesystem before
-  it walks it, so there is no scan-only mode either: it needs FIEMAP to find
-  extents and `FIDEDUPERANGE` to share them.
+- **ext4 / anything else** → stop. oans asks the filesystem for
+  `FIDEDUPERANGE` and refuses it if the answer is no, before hashing anything —
+  so there is no scan-only mode either. (It also needs FIEMAP, to find extents.)
 
 ## Step 1 — Build and install
 

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -547,3 +547,65 @@ int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 
 	return !!list_empty(&ctxt->completed);
 }
+
+/*
+ * Probing a filesystem for FIDEDUPERANGE (#224)
+ *
+ * oans used to decide what it could deduplicate by matching the statfs magic
+ * against btrfs and XFS. That allowlist needs editing and releasing every time
+ * another filesystem gains the ioctl, so filesystems it does not name are now
+ * asked directly rather than assumed hopeless.
+ *
+ * The question is asked with a zero-length dedupe request, which changes
+ * nothing: a filesystem with no remap_file_range is refused with EOPNOTSUPP
+ * before the kernel touches anything, and elsewhere zero bytes is a no-op.
+ * Unlike FICLONERANGE, a zero src_length does *not* mean "to end of file" for
+ * FIDEDUPERANGE, so this cannot accidentally share data. Measured on ext4: a
+ * zero-length request and a real one both return EOPNOTSUPP, and the file is
+ * untouched.
+ */
+enum dedupe_support dedupe_classify_probe(int rc, int err)
+{
+	if (rc == 0)
+		return DEDUPE_SUPPORT_YES;
+
+	/*
+	 * An answer about the filesystem: it has no remap_file_range at all
+	 * (EOPNOTSUPP), or the kernel does not know the ioctl (ENOTTY).
+	 */
+	if (err == EOPNOTSUPP || err == ENOTTY)
+		return DEDUPE_SUPPORT_NO;
+
+	/*
+	 * Anything else is about this file or this caller, not the filesystem.
+	 * EINVAL in particular is documented both for "the filesystem does not
+	 * support deduplicating the ranges of the given files" and for a dozen
+	 * ordinary per-file conditions, so it cannot be read either way;
+	 * EACCES/EROFS/EPERM are permission, EISDIR the wrong kind of file.
+	 *
+	 * Refusing to guess is what keeps this safe in both directions: a wrong
+	 * "no" would silently skip someone's whole tree, and a wrong "yes"
+	 * brings back the per-file FIEMAP/dedupe errors the upfront rejection
+	 * exists to avoid. The caller tries the next file instead.
+	 */
+	return DEDUPE_SUPPORT_UNKNOWN;
+}
+
+enum dedupe_support dedupe_probe_fd(int fd)
+{
+	char buf[sizeof(struct file_dedupe_range) +
+		 sizeof(struct file_dedupe_range_info)] = {0,};
+	struct file_dedupe_range *same = (struct file_dedupe_range *)buf;
+	int rc;
+
+	same->src_offset = 0;
+	same->src_length = 0;
+	same->dest_count = 1;
+	same->info[0].dest_fd = fd;
+	same->info[0].dest_offset = 0;
+
+	errno = 0;
+	rc = ioctl(fd, FIDEDUPERANGE, same);
+
+	return dedupe_classify_probe(rc, errno);
+}

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -556,18 +556,51 @@ int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
  * another filesystem gains the ioctl, so filesystems it does not name are now
  * asked directly rather than assumed hopeless.
  *
- * The question is asked with a zero-length dedupe request, which changes
- * nothing: a filesystem with no remap_file_range is refused with EOPNOTSUPP
- * before the kernel touches anything, and elsewhere zero bytes is a no-op.
- * Unlike FICLONERANGE, a zero src_length does *not* mean "to end of file" for
- * FIDEDUPERANGE, so this cannot accidentally share data. Measured on ext4: a
- * zero-length request and a real one both return EOPNOTSUPP, and the file is
- * untouched.
+ * The question is a real, block-sized request rather than a zero-length one,
+ * and the answer is read from BOTH the ioctl return and the per-destination
+ * status. Measured, on a container's overlayfs over ext4:
+ *
+ *	zero-length	rc=0			(overlayfs answers for itself)
+ *	4K request	rc=0, status=-EINVAL	(the lower fs refuses)
+ *
+ * against plain ext4, where every shape returns rc=-1/EOPNOTSUPP. A stacking
+ * filesystem implements remap_file_range as a pass-through, so a zero-length
+ * request never reaches the storage underneath and it answers yes for a
+ * filesystem that cannot dedupe a single byte. Reading only errno therefore
+ * accepts every containerised run on an overlay root, which then hashes the
+ * whole tree and fails at dedupe time -- exactly the behaviour refusing
+ * unsupported filesystems upfront exists to prevent.
+ *
+ * The cost of a real request is that on a filesystem that *does* support
+ * dedupe, the two ranges may turn out identical and get shared. That is a
+ * genuine dedupe of one block within one file, byte-verified by the kernel
+ * like any other: it cannot change the file's contents, size or mtime, and it
+ * only ever happens when the answer is yes -- that is, when oans is about to
+ * deduplicate this tree anyway. test_fs_probe.py pins the file being left
+ * alone.
  */
-enum dedupe_support dedupe_classify_probe(int rc, int err)
+
+/* Probe with a block-sized range, and never more than this. Large enough to
+ * survive a filesystem rounding the length down to its block size (64K blocks
+ * exist), small enough that any ordinary file can host two of them. */
+#define DEDUPE_PROBE_LEN_MAX	(64 * 1024)
+#define DEDUPE_PROBE_LEN_MIN	4096
+
+enum dedupe_support dedupe_classify_probe(int rc, int err, int64_t status)
 {
-	if (rc == 0)
-		return DEDUPE_SUPPORT_YES;
+	if (rc == 0) {
+		/*
+		 * The ioctl was dispatched; the verdict for this destination is
+		 * in status. Zero is FILE_DEDUPE_RANGE_SAME and 1 is
+		 * FILE_DEDUPE_RANGE_DIFFERS -- both mean the filesystem did the
+		 * work and compared the bytes, which is all we are asking.
+		 */
+		if (status >= 0)
+			return DEDUPE_SUPPORT_YES;
+		if (status == -EOPNOTSUPP || status == -ENOTTY)
+			return DEDUPE_SUPPORT_NO;
+		return DEDUPE_SUPPORT_UNKNOWN;
+	}
 
 	/*
 	 * An answer about the filesystem: it has no remap_file_range at all
@@ -585,27 +618,40 @@ enum dedupe_support dedupe_classify_probe(int rc, int err)
 	 *
 	 * Refusing to guess is what keeps this safe in both directions: a wrong
 	 * "no" would silently skip someone's whole tree, and a wrong "yes"
-	 * brings back the per-file FIEMAP/dedupe errors the upfront rejection
-	 * exists to avoid. The caller tries the next file instead.
+	 * brings back the per-file dedupe errors the upfront rejection exists
+	 * to avoid. The caller tries the next file instead.
 	 */
 	return DEDUPE_SUPPORT_UNKNOWN;
 }
 
-enum dedupe_support dedupe_probe_fd(int fd)
+enum dedupe_support dedupe_probe_fd(int fd, uint64_t size)
 {
 	char buf[sizeof(struct file_dedupe_range) +
 		 sizeof(struct file_dedupe_range_info)] = {0,};
 	struct file_dedupe_range *same = (struct file_dedupe_range *)buf;
+	uint64_t len = size / 2;
 	int rc;
 
+	/*
+	 * Two disjoint ranges of one file: [0, len) against [len, 2 * len).
+	 * One file is all the caller has - the probe runs on whatever the walk
+	 * produced first - and a file too small to hold both simply cannot
+	 * answer.
+	 */
+	if (len > DEDUPE_PROBE_LEN_MAX)
+		len = DEDUPE_PROBE_LEN_MAX;
+	len &= ~((uint64_t)DEDUPE_PROBE_LEN_MIN - 1);	/* whole blocks only */
+	if (len < DEDUPE_PROBE_LEN_MIN)
+		return DEDUPE_SUPPORT_UNKNOWN;
+
 	same->src_offset = 0;
-	same->src_length = 0;
+	same->src_length = len;
 	same->dest_count = 1;
 	same->info[0].dest_fd = fd;
-	same->info[0].dest_offset = 0;
+	same->info[0].dest_offset = len;
 
 	errno = 0;
 	rc = ioctl(fd, FIDEDUPERANGE, same);
 
-	return dedupe_classify_probe(rc, errno);
+	return dedupe_classify_probe(rc, errno, same->info[0].status);
 }

--- a/src/dedupe.c
+++ b/src/dedupe.c
@@ -580,11 +580,10 @@ int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
  * alone.
  */
 
-/* Probe with a block-sized range, and never more than this. Large enough to
- * survive a filesystem rounding the length down to its block size (64K blocks
- * exist), small enough that any ordinary file can host two of them. */
+/* Never probe with more than this, however large the file: one block answers
+ * the question, and a longer range only means more bytes the kernel might end
+ * up sharing. Raised to the block size where that is bigger. */
 #define DEDUPE_PROBE_LEN_MAX	(64 * 1024)
-#define DEDUPE_PROBE_LEN_MIN	4096
 
 enum dedupe_support dedupe_classify_probe(int rc, int err, int64_t status)
 {
@@ -629,19 +628,27 @@ enum dedupe_support dedupe_probe_fd(int fd, uint64_t size)
 	char buf[sizeof(struct file_dedupe_range) +
 		 sizeof(struct file_dedupe_range_info)] = {0,};
 	struct file_dedupe_range *same = (struct file_dedupe_range *)buf;
+	unsigned int bs = cached_blocksize(fd);
+	uint64_t cap = bs > DEDUPE_PROBE_LEN_MAX ? bs : DEDUPE_PROBE_LEN_MAX;
 	uint64_t len = size / 2;
 	int rc;
 
 	/*
 	 * Two disjoint ranges of one file: [0, len) against [len, 2 * len).
 	 * One file is all the caller has - the probe runs on whatever the walk
-	 * produced first - and a file too small to hold both simply cannot
-	 * answer.
+	 * produced first.
+	 *
+	 * Whole blocks only, and at least one: dest_offset has to be block
+	 * aligned, or a filesystem that does implement the ioctl answers
+	 * EINVAL, which reads as UNKNOWN and quietly defeats the probe.
+	 * dedupe_shareable_len() owns that rounding rule and queries the real
+	 * block size, so this does not have to guess it. A file too small to
+	 * hold both ranges cannot answer.
 	 */
-	if (len > DEDUPE_PROBE_LEN_MAX)
-		len = DEDUPE_PROBE_LEN_MAX;
-	len &= ~((uint64_t)DEDUPE_PROBE_LEN_MIN - 1);	/* whole blocks only */
-	if (len < DEDUPE_PROBE_LEN_MIN)
+	if (len > cap)
+		len = cap;
+	len = dedupe_shareable_len(fd, len);
+	if (len < bs)
 		return DEDUPE_SUPPORT_UNKNOWN;
 
 	same->src_offset = 0;
@@ -650,7 +657,7 @@ enum dedupe_support dedupe_probe_fd(int fd, uint64_t size)
 	same->info[0].dest_fd = fd;
 	same->info[0].dest_offset = len;
 
-	errno = 0;
+	/* errno matters only when the ioctl fails, and then it sets it. */
 	rc = ioctl(fd, FIDEDUPERANGE, same);
 
 	return dedupe_classify_probe(rc, errno, same->info[0].status);

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -106,4 +106,25 @@ int dedupe_extents(struct dedupe_ctxt *ctxt);
 int pop_one_dedupe_result(struct dedupe_ctxt *ctxt, int *status,
 			  uint64_t *bytes_freed, struct filerec **file);
 
+/* What a FIDEDUPERANGE probe learned about a filesystem (#224). */
+enum dedupe_support {
+	DEDUPE_SUPPORT_NO,	/* the filesystem does not implement the ioctl */
+	DEDUPE_SUPPORT_YES,	/* it does */
+	DEDUPE_SUPPORT_UNKNOWN,	/* this file could not answer the question */
+};
+
+/*
+ * Classify one probe result. Pure, so the taxonomy can be unit-tested against
+ * every errno that matters instead of against whichever filesystem the test
+ * host happens to have.
+ */
+enum dedupe_support dedupe_classify_probe(int rc, int err);
+
+/*
+ * Ask the filesystem behind `fd` whether it implements FIDEDUPERANGE, without
+ * changing anything. `fd` must be open for writing (the ioctl's destination
+ * must be writable) and refer to a regular file.
+ */
+enum dedupe_support dedupe_probe_fd(int fd);
+
 #endif	/* __DEDUPE_H__ */

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -114,17 +114,23 @@ enum dedupe_support {
 };
 
 /*
- * Classify one probe result. Pure, so the taxonomy can be unit-tested against
- * every errno that matters instead of against whichever filesystem the test
- * host happens to have.
+ * Classify one probe result from the ioctl's return and the per-destination
+ * status it fills in. Pure, so the taxonomy can be unit-tested against every
+ * errno that matters instead of against whichever filesystem the test host
+ * happens to have.
+ *
+ * Reading `status` is not optional: a stacking filesystem answers the ioctl
+ * itself and reports the lower filesystem's refusal there, leaving rc and
+ * errno clean (see dedupe_probe_fd).
  */
-enum dedupe_support dedupe_classify_probe(int rc, int err);
+enum dedupe_support dedupe_classify_probe(int rc, int err, int64_t status);
 
 /*
- * Ask the filesystem behind `fd` whether it implements FIDEDUPERANGE, without
- * changing anything. `fd` must be open for writing (the ioctl's destination
- * must be writable) and refer to a regular file.
+ * Ask the filesystem behind `fd` whether it implements FIDEDUPERANGE. `fd`
+ * must be open for writing (the ioctl's destination must be writable) and
+ * refer to a regular file of `size` bytes; a file too small to hold two
+ * disjoint ranges cannot answer.
  */
-enum dedupe_support dedupe_probe_fd(int fd);
+enum dedupe_support dedupe_probe_fd(int fd, uint64_t size);
 
 #endif	/* __DEDUPE_H__ */

--- a/src/dedupe.h
+++ b/src/dedupe.h
@@ -119,9 +119,8 @@ enum dedupe_support {
  * errno that matters instead of against whichever filesystem the test host
  * happens to have.
  *
- * Reading `status` is not optional: a stacking filesystem answers the ioctl
- * itself and reports the lower filesystem's refusal there, leaving rc and
- * errno clean (see dedupe_probe_fd).
+ * Reading `status` is not optional; see dedupe_probe_fd for why, and for the
+ * measurements behind it.
  */
 enum dedupe_support dedupe_classify_probe(int rc, int err, int64_t status);
 

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -76,6 +76,8 @@
 static struct glob_set *excludes;
 
 static int __scan_file(char *path, struct dbhandle *db, struct statx *st);
+static bool fs_dedupe_probe_settled(const char *path,
+				    const struct statx *st);
 static bool seen_inode(uint64_t ino, uint64_t subvol);
 static void mark_inode_seen(uint64_t ino, uint64_t subvol);
 static void mark_file_seen(int64_t id);
@@ -489,13 +491,18 @@ struct locked_fs {
 	dev_t dev;
 	bool is_btrfs;
 	/*
-	 * The locked filesystem is not one of the two oans knows by name, so
-	 * whether it can be deduplicated is decided by probing a file for
-	 * FIDEDUPERANGE (#224). Set while seeding the roots -- on the main
-	 * thread, before any walker exists -- and thereafter touched only by
-	 * the single __scan_file() consumer, so it needs no lock.
+	 * Whether this filesystem can be deduplicated (#224). YES straight away
+	 * for one oans knows by name; otherwise UNKNOWN until a file is asked
+	 * for FIDEDUPERANGE. Set while seeding the roots -- on the main thread,
+	 * before any walker exists -- and thereafter touched only by the single
+	 * file consumer, so it needs no lock.
+	 *
+	 * The enum rather than a bool because the three states are genuinely
+	 * different: a definite no stops the run, "not settled yet" asks the
+	 * next file, and only "never settled at all" is worth reporting once
+	 * the walk has ended.
 	 */
-	bool dedupe_probe_pending;
+	enum dedupe_support dedupe;
 	unsigned int dedupe_probe_tries;
 };
 struct locked_fs locked_fs = {0,};
@@ -924,7 +931,6 @@ struct fs_probe {
 	uuid_t	uuid;
 	bool	is_btrfs;
 	bool	supported;	/* on the allowlist: usable without probing */
-	bool	needs_probe;	/* not on it: ask a file before deciding */
 };
 
 /*
@@ -983,7 +989,6 @@ static int probe_fs(char *path, struct fs_probe *probe)
 	}
 	probe->is_btrfs = fs.f_type == BTRFS_SUPER_MAGIC;
 	probe->supported = is_fs_allowlisted(&fs);
-	probe->needs_probe = !probe->supported;
 
 	if (probe->is_btrfs) {
 		dprintf("probe_fs: %s lives on btrfs\n", dpath);
@@ -1208,7 +1213,8 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		uuid_copy(locked_fs.uuid, probe.uuid);
 		locked_fs.dev = stx_to_dev(st);
 		locked_fs.is_btrfs = probe.is_btrfs;
-		locked_fs.dedupe_probe_pending = probe.needs_probe;
+		locked_fs.dedupe = probe.supported ? DEDUPE_SUPPORT_YES
+						   : DEDUPE_SUPPORT_UNKNOWN;
 
 		return true;
 	}
@@ -1239,7 +1245,8 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 		/* Same deferral as the empty-hashfile path above: a hashfile
 		 * records the filesystem's UUID, not whether it can be deduped,
 		 * so a replay onto an unrecognised filesystem still has to ask. */
-		locked_fs.dedupe_probe_pending = probe.needs_probe;
+		locked_fs.dedupe = probe.supported ? DEDUPE_SUPPORT_YES
+						   : DEDUPE_SUPPORT_UNKNOWN;
 		return true;
 	}
 
@@ -1283,18 +1290,63 @@ bool filescan_seed_failed(void)
 }
 
 /*
- * True when a root was locked onto a filesystem oans does not recognise and the
- * walk ended without settling whether it supports FIDEDUPERANGE. Either no file
- * ever reached __scan_file() (an empty tree, or one filtered out by --exclude
- * or by size), or every file that did declined to answer -- `asked` tells the
- * two apart, and they need different advice. Exiting 0 having proved nothing
- * would be the silent no-op the upfront rejection was introduced to prevent.
+ * The one place that says this filesystem cannot be deduplicated (#224). Which
+ * of the three cases it is decides the advice, so they are worded here together
+ * rather than assembled by whoever noticed: a definite no; files asked that
+ * could not answer (the shape a stacking filesystem produces, and the one a
+ * user is least likely to guess); and a walk that ended without the question
+ * ever being put.
  */
-bool filescan_fs_probe_unsettled(unsigned int *asked)
+static void report_fs_unusable(void)
 {
-	if (asked)
-		*asked = locked_fs.dedupe_probe_tries;
-	return locked_fs.dedupe_probe_pending;
+	if (locked_fs.dedupe == DEDUPE_SUPPORT_NO)
+		eprintf("Error: this filesystem does not support "
+			"FIDEDUPERANGE.\n");
+	else if (locked_fs.dedupe_probe_tries)
+		eprintf("Error: could not determine whether this filesystem "
+			"supports FIDEDUPERANGE - %u file(s) were asked and "
+			"none could answer. A stacking filesystem such as "
+			"overlayfs reports its lower filesystem's refusal this "
+			"way.\n", locked_fs.dedupe_probe_tries);
+	else
+		eprintf("Error: no file was available to test whether this "
+			"filesystem supports FIDEDUPERANGE.\n");
+
+	eprintf("oans needs FIDEDUPERANGE to deduplicate; it is known to work "
+		"on btrfs and XFS.\n");
+}
+
+/*
+ * Report, after the walk, that it ended without ever establishing that the
+ * filesystem can be deduplicated -- an empty tree, or one whose every file was
+ * filtered out by --exclude or by size. Exiting 0 having proved nothing would
+ * be the silent no-op the upfront rejection was introduced to prevent.
+ *
+ * A definite no is not reported here: it stops the run where it is found and
+ * has already said so. Nor is an interrupted run, whose exit status belongs to
+ * the signal rather than to a question the user cut short.
+ */
+bool filescan_report_fs_unusable(void)
+{
+	if (interrupted() || locked_fs.dedupe != DEDUPE_SUPPORT_UNKNOWN)
+		return false;
+
+	report_fs_unusable();
+	return true;
+}
+
+/*
+ * Stops the walk, not just the hashing. Set by the file consumer once the
+ * filesystem is proved unusable and polled by the walker threads, so it is
+ * atomic for the reason interrupt.c documents: `volatile` orders nothing across
+ * threads and ThreadSanitizer is right to say so. Relaxed on both sides -- the
+ * flag carries no data.
+ */
+static _Atomic bool walk_abort;
+
+static bool walk_aborted(void)
+{
+	return atomic_load_explicit(&walk_abort, memory_order_relaxed);
 }
 
 static int get_dirent_type(struct dirent *entry, int fd, const char *path)
@@ -1559,12 +1611,13 @@ static gpointer walk_thread(gpointer arg)
 		if (path == WALK_STOP)
 			break;
 		/*
-		 * Interrupted: drain the queue instead of walking it. Skipping
+		 * Interrupted, or the filesystem turned out not to support dedupe
+		 * at all: drain the queue instead of walking it. Skipping
 		 * dirq_finished() would leave walk_dir_pending non-zero, so
 		 * WALK_STOP would never be pushed and the consumer would block
 		 * on an empty queue forever - the counter still has to unwind.
 		 */
-		if (!interrupted())
+		if (!interrupted() && !walk_aborted())
 			process_dir(path, db);
 		free(path);
 		dirq_finished();
@@ -1641,7 +1694,23 @@ int filescan_walk_run(struct dbhandle *db)
 		if (it == WALK_STOP)
 			break;
 		if (!ret && !interrupted()) {
-			ret = __scan_file(it->path, db, &it->st);
+			/*
+			 * On a filesystem oans does not know by name, the first
+			 * files settle whether it can be deduplicated at all,
+			 * before any of them is hashed. This belongs here and
+			 * not in __scan_file(): it is a verdict about the run,
+			 * not about the file, and this is the loop that owns
+			 * run-level control flow - interrupted() sits right
+			 * beside it. Deliberately not routed through
+			 * seed_fs_lock_failed either: that reports roots which
+			 * could never be locked at all, and only fires when
+			 * none was seeded.
+			 */
+			if (locked_fs.dedupe != DEDUPE_SUPPORT_YES &&
+			    !fs_dedupe_probe_settled(it->path, &it->st))
+				ret = 1;
+			else
+				ret = __scan_file(it->path, db, &it->st);
 		} else {
 			interrupt_report();
 		}
@@ -1922,60 +1991,56 @@ static void seed_checkpointed_files(struct dbhandle *db)
 
 /*
  * Settle whether the locked filesystem can be deduplicated, by asking one of
- * its files for FIDEDUPERANGE (#224). Returns false only when the answer is a
- * definite no, or when enough files have declined to answer that continuing
- * would mean reading the tree to learn nothing.
+ * its files for FIDEDUPERANGE (#224). Returns false only once the answer is
+ * settled as unusable -- a definite no, or enough files having declined that
+ * continuing would mean reading the tree to learn nothing.
  *
- * Called from the single __scan_file() consumer, so the counters need no lock.
- * A file can fail to answer for reasons of its own, so an inconclusive result
- * moves on to the next file rather than condemning the tree.
+ * Called from the single file consumer, so the counters need no lock. A file
+ * can fail to answer for reasons of its own, so an inconclusive result moves on
+ * to the next file rather than condemning the tree.
  */
-static bool fs_dedupe_probe_settled(const char *path,
-				    const struct statx *st)
+static bool fs_dedupe_probe_settled(const char *path, const struct statx *st)
 {
-	enum dedupe_support support;
-	_cleanup_(closefd) int fd = -1;
-
 	/*
-	 * The ioctl's destination must be writable, so this opens O_RDWR -- it
-	 * never writes, and a zero-length request changes nothing. A file we
-	 * cannot open that way (a read-only file, a read-only mount) simply
-	 * cannot answer; that is one of the inconclusive cases below, as is a
-	 * file too small to hold the two ranges the probe compares.
+	 * The ioctl's destination must be writable, so this opens O_RDWR. It
+	 * issues a real dedupe request, which cannot change anything anyone can
+	 * observe about the file (see dedupe_probe_fd). A file that cannot be
+	 * opened that way -- read-only file, read-only mount -- or that is too
+	 * small to hold the two ranges the probe compares simply cannot answer;
+	 * those are the inconclusive cases.
 	 */
-	fd = longpath_open(path, O_RDWR);
+	_cleanup_(closefd) int fd = longpath_open(path, O_RDWR);
+	enum dedupe_support support = fd == -1
+		? DEDUPE_SUPPORT_UNKNOWN : dedupe_probe_fd(fd, st->stx_size);
 
-	support = fd == -1 ? DEDUPE_SUPPORT_UNKNOWN
-			   : dedupe_probe_fd(fd, st->stx_size);
-
-	if (support == DEDUPE_SUPPORT_YES) {
-		locked_fs.dedupe_probe_pending = false;
+	switch (support) {
+	case DEDUPE_SUPPORT_YES:
+		locked_fs.dedupe = DEDUPE_SUPPORT_YES;
 		vprintf("Filesystem supports FIDEDUPERANGE; scanning.\n");
 		return true;
-	}
-
-	if (support == DEDUPE_SUPPORT_UNKNOWN &&
-	    ++locked_fs.dedupe_probe_tries < FS_PROBE_MAX_TRIES) {
-		if (verbose) {
+	case DEDUPE_SUPPORT_UNKNOWN:
+		if (++locked_fs.dedupe_probe_tries < FS_PROBE_MAX_TRIES) {
 			declare_display_path(disp, path);
 
 			vprintf("Could not settle FIDEDUPERANGE support from "
 				"%s; trying another file\n", disp);
+			return true;	/* let the walk offer another file */
 		}
-		return true;	/* undecided: let the walk offer another file */
+		break;			/* budget spent; report what we know */
+	case DEDUPE_SUPPORT_NO:
+		locked_fs.dedupe = DEDUPE_SUPPORT_NO;
+		break;
 	}
 
-	if (support == DEDUPE_SUPPORT_NO)
-		eprintf("Error: this filesystem does not support FIDEDUPERANGE, "
-			"which oans needs to deduplicate. Deduplication is "
-			"known to work on btrfs and XFS.\n");
-	else
-		eprintf("Error: could not determine whether this filesystem "
-			"supports FIDEDUPERANGE after %u files; refusing to "
-			"scan it. Deduplication is known to work on btrfs and "
-			"XFS.\n", locked_fs.dedupe_probe_tries);
-
+	report_fs_unusable();
 	filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
+	/*
+	 * The walkers have to stop too. Without this they readdir/statx the
+	 * whole tree after the error is already on screen - minutes of pure
+	 * metadata I/O on a big one, which reads as a hang - because the
+	 * consumer's error stops the hashing, not the walk that feeds it.
+	 */
+	atomic_store_explicit(&walk_abort, true, memory_order_relaxed);
 	return false;
 }
 
@@ -1994,22 +2059,6 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	struct scan_resume resume = {0,};
 
 	abort_on(!S_ISREG(st->stx_mode));
-
-	/*
-	 * The filesystem is not one oans knows by name, so the first file to
-	 * reach here settles whether it can be deduplicated at all. A definite
-	 * no is fatal for the run: returning nonzero stops the consume loop, so
-	 * nothing is hashed and scan_files() exits non-zero.
-	 *
-	 * Deliberately not routed through seed_fs_lock_failed: that reports
-	 * roots which could never be locked onto a filesystem at all, and only
-	 * fires when none was seeded. Here a root *was* seeded and the probe has
-	 * already said exactly what is wrong, so the generic "none of the given
-	 * paths..." line would only bury it.
-	 */
-	if (locked_fs.dedupe_probe_pending &&
-	    !fs_dedupe_probe_settled(path, st))
-		return 1;
 
 	pscan_examined();	/* count every file the listing walk visits */
 	scan_read_tick(db);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -57,6 +57,7 @@
 #include "opt.h"
 #include "threads.h"
 #include "fiemap.h"
+#include "dedupe.h"
 #include "progress.h"
 #include "longpath.h"
 #include "glob.h"
@@ -487,8 +488,38 @@ struct locked_fs {
 	uuid_t uuid;
 	dev_t dev;
 	bool is_btrfs;
+	/*
+	 * The locked filesystem is not one of the two oans knows by name, so
+	 * whether it can be deduplicated is decided by probing a file for
+	 * FIDEDUPERANGE (#224). Set while seeding the roots -- on the main
+	 * thread, before any walker exists -- and thereafter touched only by
+	 * the single __scan_file() consumer, so it needs no lock.
+	 */
+	bool dedupe_probe_pending;
+	unsigned int dedupe_probe_tries;
 };
 struct locked_fs locked_fs = {0,};
+
+/*
+ * How many files may be asked before giving up on a filesystem oans does not
+ * recognise. A file can fail to answer for reasons of its own -- unreadable,
+ * unwritable, empty -- so one inconclusive result must not condemn the tree;
+ * but a filesystem that never answers must not read the whole tree first
+ * either.
+ */
+#define FS_PROBE_MAX_TRIES	16
+
+/*
+ * Test hook (DUPEREMOVE_FORCE_FS_PROBE): drop the allowlist fast path so the
+ * probe decides for btrfs and XFS too. Without it the accept branch is
+ * unreachable in tests -- the only filesystems known to answer yes are exactly
+ * the two that never reach the probe (test_fs_probe.py).
+ *
+ * Read once in filescan_init(), on the main thread: probe_fs() runs on the
+ * walker threads (the btrfs per-device recheck), and a lazy getenv() there
+ * would be a race between workers for no reason.
+ */
+static bool force_fs_probe;
 
 /*
  * Set when a seeded root (parent_checked == false) is rejected because it could
@@ -892,12 +923,23 @@ static char *extract_first_device(const char *fs_source)
 struct fs_probe {
 	uuid_t	uuid;
 	bool	is_btrfs;
-	bool	supported;
+	bool	supported;	/* on the allowlist: usable without probing */
+	bool	needs_probe;	/* not on it: ask a file before deciding */
 };
 
-/* True for a filesystem oans knows how to deduplicate on. */
-static bool is_fs_supported(const struct statfs *fs)
+/*
+ * The filesystems oans knows how to deduplicate on by name. This is a fast
+ * path, not the definition: anything else is asked directly for FIDEDUPERANGE
+ * (#224). Keeping the two named here means the validated filesystems never
+ * depend on the probe -- their behaviour is exactly what it always was.
+ */
+static bool is_fs_allowlisted(const struct statfs *fs)
 {
+	/* Test hook, read once in filescan_init(): pretend nothing is known so
+	 * the probe path runs on btrfs and XFS too. */
+	if (force_fs_probe)
+		return false;
+
 	return fs->f_type == BTRFS_SUPER_MAGIC || fs->f_type == XFS_SB_MAGIC;
 }
 
@@ -940,7 +982,8 @@ static int probe_fs(char *path, struct fs_probe *probe)
 		return 1;
 	}
 	probe->is_btrfs = fs.f_type == BTRFS_SUPER_MAGIC;
-	probe->supported = is_fs_supported(&fs);
+	probe->supported = is_fs_allowlisted(&fs);
+	probe->needs_probe = !probe->supported;
 
 	if (probe->is_btrfs) {
 		dprintf("probe_fs: %s lives on btrfs\n", dpath);
@@ -1150,29 +1193,22 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 			return seed_reject(parent_checked);
 
 		/*
-		 * We identified the filesystem, but if it is not one oans can
-		 * deduplicate (btrfs or XFS) refuse this root now with a clear
-		 * message. Walking it anyway would hash every file only to have
-		 * each FIEMAP/FIDEDUPERANGE fail with confusing per-file errors
-		 * and still exit 0 ("Nothing to deduplicate"). Rejecting via
-		 * seed_reject() means a run whose roots are *all* unsupported
-		 * fails loudly (filescan_seed_failed()); a mix still scans the
-		 * supported roots. Commit locked_fs only once supported, so a
-		 * rejected root does not pollute the lock for later roots.
+		 * We identified the filesystem. If it is one oans knows by name
+		 * it is usable as-is; otherwise the verdict waits for a file to
+		 * be asked for FIDEDUPERANGE (#224), because the ioctl needs a
+		 * writable regular file and a root is normally a directory.
+		 *
+		 * Deferring costs nothing that matters: the probe happens on the
+		 * first file the walk produces, long before any of it is hashed,
+		 * so an unsupported filesystem still fails in a second and with
+		 * one clear message -- not with a FIEMAP error per file and a
+		 * misleading "Nothing to deduplicate" at exit 0, which is what
+		 * the upfront rejection was there to prevent.
 		 */
-		if (!probe.supported) {
-			declare_display_path(disp, path);
-
-			eprintf("Skipping %s: its filesystem is not btrfs or XFS, "
-				"which oans needs to deduplicate.\n",
-				disp);
-			filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
-			return seed_reject(parent_checked);
-		}
-
 		uuid_copy(locked_fs.uuid, probe.uuid);
 		locked_fs.dev = stx_to_dev(st);
 		locked_fs.is_btrfs = probe.is_btrfs;
+		locked_fs.dedupe_probe_pending = probe.needs_probe;
 
 		return true;
 	}
@@ -1200,6 +1236,10 @@ bool check_file(struct dbhandle *db, char *path, struct statx *st, bool parent_c
 
 		locked_fs.dev = stx_to_dev(st);
 		locked_fs.is_btrfs = probe.is_btrfs;
+		/* Same deferral as the empty-hashfile path above: a hashfile
+		 * records the filesystem's UUID, not whether it can be deduped,
+		 * so a replay onto an unrecognised filesystem still has to ask. */
+		locked_fs.dedupe_probe_pending = probe.needs_probe;
 		return true;
 	}
 
@@ -1240,6 +1280,18 @@ void fs_get_locked_uuid(uuid_t *uuid)
 bool filescan_seed_failed(void)
 {
 	return seed_fs_lock_failed && nr_roots_seeded == 0;
+}
+
+/*
+ * True when a root was locked onto a filesystem oans does not recognise and no
+ * file ever reached __scan_file() to settle whether it supports FIDEDUPERANGE
+ * -- an empty tree, or one whose every file was excluded or filtered out by
+ * size. The walk then ends having proved nothing, and exiting 0 would be the
+ * silent no-op the upfront rejection was introduced to prevent.
+ */
+bool filescan_fs_probe_unsettled(void)
+{
+	return locked_fs.dedupe_probe_pending;
 }
 
 static int get_dirent_type(struct dirent *entry, int fd, const char *path)
@@ -1866,6 +1918,65 @@ static void seed_checkpointed_files(struct dbhandle *db)
 }
 
 /*
+ * Settle whether the locked filesystem can be deduplicated, by asking one of
+ * its files for FIDEDUPERANGE (#224). Returns false only when the answer is a
+ * definite no, or when enough files have declined to answer that continuing
+ * would mean reading the tree to learn nothing.
+ *
+ * Called from the single __scan_file() consumer, so the counters need no lock.
+ * A file can fail to answer for reasons of its own, so an inconclusive result
+ * moves on to the next file rather than condemning the tree.
+ */
+static bool fs_dedupe_probe_settled(const char *path)
+{
+	enum dedupe_support support;
+	_cleanup_(closefd) int fd = -1;
+
+	/*
+	 * The ioctl's destination must be writable, so this opens O_RDWR -- it
+	 * never writes, and a zero-length request changes nothing. A file we
+	 * cannot open that way (a read-only file, a read-only mount) simply
+	 * cannot answer; that is one of the inconclusive cases below. Empty
+	 * files are asked too: a zero-length request does not care about the
+	 * size, and skipping them would spend the try budget on a tree of
+	 * marker files and then condemn a filesystem that was never asked.
+	 */
+	fd = longpath_open(path, O_RDWR);
+
+	support = fd == -1 ? DEDUPE_SUPPORT_UNKNOWN : dedupe_probe_fd(fd);
+
+	if (support == DEDUPE_SUPPORT_YES) {
+		locked_fs.dedupe_probe_pending = false;
+		vprintf("Filesystem supports FIDEDUPERANGE; scanning.\n");
+		return true;
+	}
+
+	if (support == DEDUPE_SUPPORT_UNKNOWN &&
+	    ++locked_fs.dedupe_probe_tries < FS_PROBE_MAX_TRIES) {
+		if (verbose) {
+			declare_display_path(disp, path);
+
+			vprintf("Could not settle FIDEDUPERANGE support from "
+				"%s; trying another file\n", disp);
+		}
+		return true;	/* undecided: let the walk offer another file */
+	}
+
+	if (support == DEDUPE_SUPPORT_NO)
+		eprintf("Error: this filesystem does not support FIDEDUPERANGE, "
+			"which oans needs to deduplicate. Deduplication is "
+			"known to work on btrfs and XFS.\n");
+	else
+		eprintf("Error: could not determine whether this filesystem "
+			"supports FIDEDUPERANGE after %u files; refusing to "
+			"scan it. Deduplication is known to work on btrfs and "
+			"XFS.\n", locked_fs.dedupe_probe_tries);
+
+	filescan_count_skip(SCAN_SKIP_UNSUPPORTED_FS);
+	return false;
+}
+
+/*
  * Returns nonzero on fatal errors only
  * This function schedules csum_whole_file()
  * The caller must call check_file() before and must not call
@@ -1880,6 +1991,22 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	struct scan_resume resume = {0,};
 
 	abort_on(!S_ISREG(st->stx_mode));
+
+	/*
+	 * The filesystem is not one oans knows by name, so the first file to
+	 * reach here settles whether it can be deduplicated at all. A definite
+	 * no is fatal for the run: returning nonzero stops the consume loop, so
+	 * nothing is hashed and scan_files() exits non-zero.
+	 *
+	 * Deliberately not routed through seed_fs_lock_failed: that reports
+	 * roots which could never be locked onto a filesystem at all, and only
+	 * fires when none was seeded. Here a root *was* seeded and the probe has
+	 * already said exactly what is wrong, so the generic "none of the given
+	 * paths..." line would only bury it.
+	 */
+	if (locked_fs.dedupe_probe_pending &&
+	    !fs_dedupe_probe_settled(path))
+		return 1;
 
 	pscan_examined();	/* count every file the listing walk visits */
 	scan_read_tick(db);
@@ -3810,6 +3937,8 @@ void filescan_init(void)
 	const char *batch_env = getenv("DUPEREMOVE_BLOCK_BATCH");
 	const char *ckpt_env = getenv("DUPEREMOVE_CHECKPOINT_BYTES");
 	const char *stop_env = getenv("DUPEREMOVE_CHECKPOINT_STOP");
+
+	force_fs_probe = getenv("DUPEREMOVE_FORCE_FS_PROBE") != NULL;
 
 	if (batch_env) {
 		unsigned long v = strtoul(batch_env, NULL, 10);

--- a/src/file_scan.c
+++ b/src/file_scan.c
@@ -1283,14 +1283,17 @@ bool filescan_seed_failed(void)
 }
 
 /*
- * True when a root was locked onto a filesystem oans does not recognise and no
- * file ever reached __scan_file() to settle whether it supports FIDEDUPERANGE
- * -- an empty tree, or one whose every file was excluded or filtered out by
- * size. The walk then ends having proved nothing, and exiting 0 would be the
- * silent no-op the upfront rejection was introduced to prevent.
+ * True when a root was locked onto a filesystem oans does not recognise and the
+ * walk ended without settling whether it supports FIDEDUPERANGE. Either no file
+ * ever reached __scan_file() (an empty tree, or one filtered out by --exclude
+ * or by size), or every file that did declined to answer -- `asked` tells the
+ * two apart, and they need different advice. Exiting 0 having proved nothing
+ * would be the silent no-op the upfront rejection was introduced to prevent.
  */
-bool filescan_fs_probe_unsettled(void)
+bool filescan_fs_probe_unsettled(unsigned int *asked)
 {
+	if (asked)
+		*asked = locked_fs.dedupe_probe_tries;
 	return locked_fs.dedupe_probe_pending;
 }
 
@@ -1927,7 +1930,8 @@ static void seed_checkpointed_files(struct dbhandle *db)
  * A file can fail to answer for reasons of its own, so an inconclusive result
  * moves on to the next file rather than condemning the tree.
  */
-static bool fs_dedupe_probe_settled(const char *path)
+static bool fs_dedupe_probe_settled(const char *path,
+				    const struct statx *st)
 {
 	enum dedupe_support support;
 	_cleanup_(closefd) int fd = -1;
@@ -1936,14 +1940,13 @@ static bool fs_dedupe_probe_settled(const char *path)
 	 * The ioctl's destination must be writable, so this opens O_RDWR -- it
 	 * never writes, and a zero-length request changes nothing. A file we
 	 * cannot open that way (a read-only file, a read-only mount) simply
-	 * cannot answer; that is one of the inconclusive cases below. Empty
-	 * files are asked too: a zero-length request does not care about the
-	 * size, and skipping them would spend the try budget on a tree of
-	 * marker files and then condemn a filesystem that was never asked.
+	 * cannot answer; that is one of the inconclusive cases below, as is a
+	 * file too small to hold the two ranges the probe compares.
 	 */
 	fd = longpath_open(path, O_RDWR);
 
-	support = fd == -1 ? DEDUPE_SUPPORT_UNKNOWN : dedupe_probe_fd(fd);
+	support = fd == -1 ? DEDUPE_SUPPORT_UNKNOWN
+			   : dedupe_probe_fd(fd, st->stx_size);
 
 	if (support == DEDUPE_SUPPORT_YES) {
 		locked_fs.dedupe_probe_pending = false;
@@ -2005,7 +2008,7 @@ static int __scan_file(char *path, struct dbhandle *db, struct statx *st)
 	 * paths..." line would only bury it.
 	 */
 	if (locked_fs.dedupe_probe_pending &&
-	    !fs_dedupe_probe_settled(path))
+	    !fs_dedupe_probe_settled(path, st))
 		return 1;
 
 	pscan_examined();	/* count every file the listing walk visits */

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -45,6 +45,7 @@ void fs_get_locked_uuid(uuid_t *uuid);
  * of reporting a silent, successful no-op.
  */
 bool filescan_seed_failed(void);
+bool filescan_fs_probe_unsettled(void);
 
 /*
  * How many scan roots named on the command line (or in a "-" stdin list) could

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -45,7 +45,7 @@ void fs_get_locked_uuid(uuid_t *uuid);
  * of reporting a silent, successful no-op.
  */
 bool filescan_seed_failed(void);
-bool filescan_fs_probe_unsettled(void);
+bool filescan_fs_probe_unsettled(unsigned int *asked);
 
 /*
  * How many scan roots named on the command line (or in a "-" stdin list) could

--- a/src/file_scan.h
+++ b/src/file_scan.h
@@ -45,7 +45,12 @@ void fs_get_locked_uuid(uuid_t *uuid);
  * of reporting a silent, successful no-op.
  */
 bool filescan_seed_failed(void);
-bool filescan_fs_probe_unsettled(unsigned int *asked);
+/*
+ * Say, once the walk has ended, that it never established this filesystem can
+ * be deduplicated; true when it said so (see #224). file_scan owns the verdict
+ * and the wording, the way filescan_report_excludes() does.
+ */
+bool filescan_report_fs_unusable(void);
 
 /*
  * How many scan roots named on the command line (or in a "-" stdin list) could

--- a/src/oans.c
+++ b/src/oans.c
@@ -1665,10 +1665,8 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 	/*
 	 * Nothing could be locked onto a usable filesystem, so the walk saw no
 	 * files. Fail loudly rather than printing a misleading "Nothing to
-	 * deduplicate" and exiting 0. Two common causes: XFS on a kernel older
-	 * than 6.4 scanned without root (its UUID needs libblkid), and a
-	 * filesystem that turned out not to implement FIDEDUPERANGE -- which
-	 * has already said so, in the probe's own words (#224).
+	 * deduplicate" and exiting 0. The most common cause is XFS on a kernel
+	 * older than 6.4 scanned without root (its UUID needs libblkid).
 	 */
 	if (!ret && filescan_seed_failed()) {
 		eprintf("Error: none of the given paths are on a filesystem oans "
@@ -1683,29 +1681,8 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 	 * FIDEDUPERANGE. Nothing was proved, so say so rather than exiting 0 on
 	 * a filesystem that may well be unusable.
 	 */
-	if (!ret) {
-		unsigned int asked = 0;
-
-		if (filescan_fs_probe_unsettled(&asked)) {
-			if (asked)
-				eprintf("Error: could not determine whether this "
-					"filesystem supports FIDEDUPERANGE - %u "
-					"file(s) were asked and none could "
-					"answer. A stacking filesystem such as "
-					"overlayfs reports its lower "
-					"filesystem's refusal this way. "
-					"Deduplication is known to work on "
-					"btrfs and XFS.\n", asked);
-			else
-				eprintf("Error: no file was available to test "
-					"whether this filesystem supports "
-					"FIDEDUPERANGE, so oans cannot tell "
-					"whether it can deduplicate here. "
-					"Deduplication is known to work on "
-					"btrfs and XFS.\n");
-			ret = 1;
-		}
-	}
+	if (!ret && filescan_report_fs_unusable())
+		ret = 1;
 
 	/* Only once the walk actually ran: after a failure every pattern would
 	 * trivially have "matched nothing" and would bury the real error. */

--- a/src/oans.c
+++ b/src/oans.c
@@ -1663,15 +1663,31 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 		ret = filescan_walk_run(db);
 
 	/*
-	 * Nothing could be locked onto a supported filesystem, so the walk saw
-	 * no files. Fail loudly rather than printing a misleading "Nothing to
-	 * deduplicate" and exiting 0. The most common cause is XFS on a kernel
-	 * older than 6.4 scanned without root (its UUID needs libblkid).
+	 * Nothing could be locked onto a usable filesystem, so the walk saw no
+	 * files. Fail loudly rather than printing a misleading "Nothing to
+	 * deduplicate" and exiting 0. Two common causes: XFS on a kernel older
+	 * than 6.4 scanned without root (its UUID needs libblkid), and a
+	 * filesystem that turned out not to implement FIDEDUPERANGE -- which
+	 * has already said so, in the probe's own words (#224).
 	 */
 	if (!ret && filescan_seed_failed()) {
 		eprintf("Error: none of the given paths are on a filesystem oans "
-			"can deduplicate. Deduplication needs btrfs or XFS; for "
-			"XFS on a kernel older than 6.4, run oans as root.\n");
+			"can deduplicate. It needs FIDEDUPERANGE, which btrfs "
+			"and XFS provide; for XFS on a kernel older than 6.4, "
+			"run oans as root.\n");
+		ret = 1;
+	}
+
+	/*
+	 * The filesystem was never asked whether it supports FIDEDUPERANGE,
+	 * because no file reached the scanner. Nothing was proved, so say so
+	 * rather than exiting 0 on a filesystem that may well be unusable.
+	 */
+	if (!ret && filescan_fs_probe_unsettled()) {
+		eprintf("Error: no file was available to test whether this "
+			"filesystem supports FIDEDUPERANGE, so oans cannot tell "
+			"whether it can deduplicate here. Deduplication is "
+			"known to work on btrfs and XFS.\n");
 		ret = 1;
 	}
 

--- a/src/oans.c
+++ b/src/oans.c
@@ -1679,16 +1679,32 @@ static int scan_files(char **roots, int nroots, struct dbhandle *db,
 	}
 
 	/*
-	 * The filesystem was never asked whether it supports FIDEDUPERANGE,
-	 * because no file reached the scanner. Nothing was proved, so say so
-	 * rather than exiting 0 on a filesystem that may well be unusable.
+	 * The walk ended without establishing that this filesystem supports
+	 * FIDEDUPERANGE. Nothing was proved, so say so rather than exiting 0 on
+	 * a filesystem that may well be unusable.
 	 */
-	if (!ret && filescan_fs_probe_unsettled()) {
-		eprintf("Error: no file was available to test whether this "
-			"filesystem supports FIDEDUPERANGE, so oans cannot tell "
-			"whether it can deduplicate here. Deduplication is "
-			"known to work on btrfs and XFS.\n");
-		ret = 1;
+	if (!ret) {
+		unsigned int asked = 0;
+
+		if (filescan_fs_probe_unsettled(&asked)) {
+			if (asked)
+				eprintf("Error: could not determine whether this "
+					"filesystem supports FIDEDUPERANGE - %u "
+					"file(s) were asked and none could "
+					"answer. A stacking filesystem such as "
+					"overlayfs reports its lower "
+					"filesystem's refusal this way. "
+					"Deduplication is known to work on "
+					"btrfs and XFS.\n", asked);
+			else
+				eprintf("Error: no file was available to test "
+					"whether this filesystem supports "
+					"FIDEDUPERANGE, so oans cannot tell "
+					"whether it can deduplicate here. "
+					"Deduplication is known to work on "
+					"btrfs and XFS.\n");
+			ret = 1;
+		}
 	}
 
 	/* Only once the walk actually ran: after a failure every pattern would

--- a/src/tests.c
+++ b/src/tests.c
@@ -1256,12 +1256,8 @@ MU_TEST(test_dedupe_classify_probe)
 	mu_assert_int_eq(DEDUPE_SUPPORT_YES,
 			 dedupe_classify_probe(0, EINVAL, 0));
 
-	/*
-	 * A stacking filesystem (overlayfs) answers the ioctl itself and puts
-	 * the lower filesystem's refusal in status, leaving rc and errno clean.
-	 * Measured on overlayfs over ext4: rc=0, status=-EINVAL. Reading only
-	 * errno would accept every containerised run on an overlay root.
-	 */
+	/* A stacking filesystem puts the lower filesystem's refusal in status
+	 * and leaves rc/errno clean - the case dedupe_probe_fd documents. */
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
 			 dedupe_classify_probe(0, 0, -EINVAL));
 	/* A status that does name the filesystem is still an answer. */

--- a/src/tests.c
+++ b/src/tests.c
@@ -24,6 +24,7 @@
 #include "storage.c"
 #include "longpath.c"
 #include "glob.c"
+#include "dedupe.c"
 
 
 unsigned int blocksize = DEFAULT_BLOCKSIZE;
@@ -1237,6 +1238,51 @@ MU_TEST(test_running_checksum_rejects_foreign_state) {
 	mu_check(running_checksum_restore(blob, len) == NULL);
 }
 
+
+/*
+ * The FIDEDUPERANGE probe's error taxonomy (#224). Worth testing directly and
+ * exhaustively: the probe's whole job is turning one errno into a verdict, and
+ * which errno a filesystem returns is exactly what a test host cannot vary.
+ * Both wrong answers are bad in different ways -- a wrong NO silently skips a
+ * whole tree, a wrong YES brings back per-file dedupe errors -- so anything
+ * that is not a clear statement about the filesystem must stay UNKNOWN.
+ */
+MU_TEST(test_dedupe_classify_probe)
+{
+	/* The ioctl went through: the filesystem implements it. */
+	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, 0));
+	/* errno is meaningless on success and must not be consulted. */
+	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, EINVAL));
+
+	/* Answers about the filesystem. EOPNOTSUPP is what ext4 returns
+	 * (measured); ENOTTY is a kernel that does not know the ioctl. */
+	mu_assert_int_eq(DEDUPE_SUPPORT_NO,
+			 dedupe_classify_probe(-1, EOPNOTSUPP));
+	mu_assert_int_eq(DEDUPE_SUPPORT_NO, dedupe_classify_probe(-1, ENOTTY));
+
+	/*
+	 * Answers about this file or this caller. EINVAL is the important one:
+	 * it is documented for "the filesystem does not support deduplicating
+	 * the ranges of the given files" *and* for ordinary per-file
+	 * conditions, so reading it as NO would condemn a filesystem on the
+	 * evidence of one awkward file.
+	 */
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EINVAL));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EACCES));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EROFS));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EPERM));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EISDIR));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, EBADF));
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(-1, ETXTBSY));
+}
+
 MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_running_checksum_survives_save_restore);
 	MU_RUN_TEST(test_running_checksum_rejects_foreign_state);
@@ -1269,6 +1315,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_glob_reports_matching_pattern_and_counts);
 	MU_RUN_TEST(test_glob_rejects_malformed);
 	MU_RUN_TEST(test_glob_empty_set_matches_nothing);
+	MU_RUN_TEST(test_dedupe_classify_probe);
 }
 
 int main(int argc [[maybe_unused]], char *argv[]) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -1240,25 +1240,43 @@ MU_TEST(test_running_checksum_rejects_foreign_state) {
 
 
 /*
- * The FIDEDUPERANGE probe's error taxonomy (#224). Worth testing directly and
- * exhaustively: the probe's whole job is turning one errno into a verdict, and
- * which errno a filesystem returns is exactly what a test host cannot vary.
- * Both wrong answers are bad in different ways -- a wrong NO silently skips a
- * whole tree, a wrong YES brings back per-file dedupe errors -- so anything
- * that is not a clear statement about the filesystem must stay UNKNOWN.
+ * The FIDEDUPERANGE probe's answer taxonomy (#224). Worth testing directly and
+ * exhaustively: the probe's whole job is turning one ioctl result into a
+ * verdict, and what a filesystem returns is exactly what a test host cannot
+ * vary. Both wrong answers are bad in different ways -- a wrong NO silently
+ * skips a whole tree, a wrong YES brings back per-file dedupe errors -- so
+ * anything that is not a clear statement about the filesystem stays UNKNOWN.
  */
 MU_TEST(test_dedupe_classify_probe)
 {
-	/* The ioctl went through: the filesystem implements it. */
-	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, 0));
+	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
+	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, 0, 0));
+	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, 0, 1));
 	/* errno is meaningless on success and must not be consulted. */
-	mu_assert_int_eq(DEDUPE_SUPPORT_YES, dedupe_classify_probe(0, EINVAL));
+	mu_assert_int_eq(DEDUPE_SUPPORT_YES,
+			 dedupe_classify_probe(0, EINVAL, 0));
 
-	/* Answers about the filesystem. EOPNOTSUPP is what ext4 returns
-	 * (measured); ENOTTY is a kernel that does not know the ioctl. */
+	/*
+	 * A stacking filesystem (overlayfs) answers the ioctl itself and puts
+	 * the lower filesystem's refusal in status, leaving rc and errno clean.
+	 * Measured on overlayfs over ext4: rc=0, status=-EINVAL. Reading only
+	 * errno would accept every containerised run on an overlay root.
+	 */
+	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
+			 dedupe_classify_probe(0, 0, -EINVAL));
+	/* A status that does name the filesystem is still an answer. */
 	mu_assert_int_eq(DEDUPE_SUPPORT_NO,
-			 dedupe_classify_probe(-1, EOPNOTSUPP));
-	mu_assert_int_eq(DEDUPE_SUPPORT_NO, dedupe_classify_probe(-1, ENOTTY));
+			 dedupe_classify_probe(0, 0, -EOPNOTSUPP));
+	mu_assert_int_eq(DEDUPE_SUPPORT_NO,
+			 dedupe_classify_probe(0, 0, -ENOTTY));
+
+	/* Answers about the filesystem from the ioctl itself. EOPNOTSUPP is
+	 * what ext4 returns (measured); ENOTTY is a kernel that does not know
+	 * the ioctl. status is not filled in when the ioctl fails. */
+	mu_assert_int_eq(DEDUPE_SUPPORT_NO,
+			 dedupe_classify_probe(-1, EOPNOTSUPP, 0));
+	mu_assert_int_eq(DEDUPE_SUPPORT_NO,
+			 dedupe_classify_probe(-1, ENOTTY, 0));
 
 	/*
 	 * Answers about this file or this caller. EINVAL is the important one:
@@ -1268,19 +1286,19 @@ MU_TEST(test_dedupe_classify_probe)
 	 * evidence of one awkward file.
 	 */
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EINVAL));
+			 dedupe_classify_probe(-1, EINVAL, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EACCES));
+			 dedupe_classify_probe(-1, EACCES, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EROFS));
+			 dedupe_classify_probe(-1, EROFS, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EPERM));
+			 dedupe_classify_probe(-1, EPERM, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EISDIR));
+			 dedupe_classify_probe(-1, EISDIR, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, EBADF));
+			 dedupe_classify_probe(-1, EBADF, 0));
 	mu_assert_int_eq(DEDUPE_SUPPORT_UNKNOWN,
-			 dedupe_classify_probe(-1, ETXTBSY));
+			 dedupe_classify_probe(-1, ETXTBSY, 0));
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/tests/integration/test_fs_probe.py
+++ b/tests/integration/test_fs_probe.py
@@ -2,7 +2,9 @@
 
 btrfs and XFS stay on an allowlist fast path, so their behaviour is exactly
 what it always was. Everything else is asked directly for FIDEDUPERANGE with a
-zero-length request, which changes nothing.
+real block-sized request, reading the per-destination status as well as errno
+(a zero-length request cannot tell a pass-through filesystem like overlayfs
+from one that can really dedupe).
 
 That leaves the accept branch untestable by ordinary means: the only
 filesystems known to answer "yes" are the two that never reach the probe.
@@ -62,12 +64,13 @@ class FsProbeTest(DuperemoveTest):
                          "a forced probe changed what the scan stored")
 
     def test_the_probe_leaves_the_file_alone(self):
-        """A zero-length dedupe must not touch the file it is asked about.
+        """The probe must not change the file it is asked about.
 
-        This is the property that makes probing safe to do on a stranger's
-        data: unlike FICLONERANGE, a zero src_length is not "to end of file"
-        for FIDEDUPERANGE. A regression here would silently share or truncate
-        the first file of every scan on an unrecognised filesystem.
+        It issues a real dedupe request, so on a filesystem that supports the
+        ioctl its two ranges may genuinely be shared -- that is the trade for
+        seeing through a pass-through filesystem. What must never change is
+        what anyone can observe: contents, size, mtime. A regression here would
+        corrupt the first file of every scan on an unrecognised filesystem.
         """
         p = self.mkrand("tree/only.bin", 1 * MiB)
         with open(p, "rb") as f:

--- a/tests/integration/test_fs_probe.py
+++ b/tests/integration/test_fs_probe.py
@@ -38,12 +38,13 @@ class FsProbeTest(DuperemoveTest):
         self.assertShared(a, b, "the files were not deduped under a forced probe")
 
     def test_a_forced_probe_changes_nothing(self):
-        """Byte-for-byte the same hashfile as a run that took the fast path.
+        """The same hashfile as a run that took the fast path.
 
         The probe is meant to be invisible on a filesystem that supports the
-        ioctl: same files, same digests. Asserting on the stored hashes rather
-        than on a log line is the only check that would catch the probe
-        perturbing what gets scanned.
+        ioctl. fingerprints() is the comparison for that (files, extents and
+        blocks) - the probe issues a real dedupe request, so a weaker check on
+        file digests alone would miss it perturbing the extent rows, which is
+        exactly where it could show.
         """
         self.mkdup("tree/a.bin", "tree/b.bin", 1 * MiB)
         self.mkrand("tree/c.bin", 512 * 1024)
@@ -51,16 +52,13 @@ class FsProbeTest(DuperemoveTest):
 
         self.scan(self.path("tree"))
         self.assertDmOk()
-        baseline = self.hf_query(
-            "select filename, digest from files order by filename")
+        baseline = self.fingerprints()
 
-        os.unlink(self.hf)
+        self.drop_hashfile()
         self.dm("-r", self.path("tree"), env=FORCED)
         self.assertDmOk()
-        forced = self.hf_query(
-            "select filename, digest from files order by filename")
 
-        self.assertEqual(baseline, forced,
+        self.assertEqual(baseline, self.fingerprints(),
                          "a forced probe changed what the scan stored")
 
     def test_the_probe_leaves_the_file_alone(self):
@@ -73,17 +71,15 @@ class FsProbeTest(DuperemoveTest):
         corrupt the first file of every scan on an unrecognised filesystem.
         """
         p = self.mkrand("tree/only.bin", 1 * MiB)
-        with open(p, "rb") as f:
-            before = f.read()
+        before = self.tree_digest(self.path("tree"))
         st_before = os.stat(p)
         self.sync()
 
         self.dm("-r", self.path("tree"), env=FORCED)
         self.assertDmOk()
 
-        with open(p, "rb") as f:
-            self.assertEqual(before, f.read(),
-                             "the probe altered the file's contents")
+        self.assertEqual(before, self.tree_digest(self.path("tree")),
+                         "the probe altered the file's contents")
         st_after = os.stat(p)
         self.assertEqual(st_before.st_size, st_after.st_size,
                          "the probe altered the file's size")

--- a/tests/integration/test_fs_probe.py
+++ b/tests/integration/test_fs_probe.py
@@ -1,0 +1,88 @@
+"""#224: what oans can deduplicate is probed, not hardcoded.
+
+btrfs and XFS stay on an allowlist fast path, so their behaviour is exactly
+what it always was. Everything else is asked directly for FIDEDUPERANGE with a
+zero-length request, which changes nothing.
+
+That leaves the accept branch untestable by ordinary means: the only
+filesystems known to answer "yes" are the two that never reach the probe.
+DUPEREMOVE_FORCE_FS_PROBE drops the fast path so the probe runs against the
+scratch filesystem too -- which is how these tests reach the "yes" branch on a
+filesystem that really does implement the ioctl. Without it the code path would
+ship having only ever been seen to say "no".
+
+The refusal side lives in test_unsupported_fs.py, which needs a non-reflink
+filesystem to point at.
+"""
+
+import os
+
+from harness import DuperemoveTest, requires_reflink
+
+MiB = 1 << 20
+FORCED = {"DUPEREMOVE_FORCE_FS_PROBE": "1"}
+
+
+@requires_reflink
+class FsProbeTest(DuperemoveTest):
+    def test_a_forced_probe_still_dedupes(self):
+        """The probe says yes on a real reflink fs, and the run is unaffected."""
+        a, b = self.mkdup("tree/a.bin", "tree/b.bin", 1 * MiB)
+        self.sync()
+
+        self.dm("-rd", self.path("tree"), env=FORCED)
+        self.assertDmOk("a forced probe must not disturb a supported filesystem")
+        self.sync()
+        self.assertShared(a, b, "the files were not deduped under a forced probe")
+
+    def test_a_forced_probe_changes_nothing(self):
+        """Byte-for-byte the same hashfile as a run that took the fast path.
+
+        The probe is meant to be invisible on a filesystem that supports the
+        ioctl: same files, same digests. Asserting on the stored hashes rather
+        than on a log line is the only check that would catch the probe
+        perturbing what gets scanned.
+        """
+        self.mkdup("tree/a.bin", "tree/b.bin", 1 * MiB)
+        self.mkrand("tree/c.bin", 512 * 1024)
+        self.sync()
+
+        self.scan(self.path("tree"))
+        self.assertDmOk()
+        baseline = self.hf_query(
+            "select filename, digest from files order by filename")
+
+        os.unlink(self.hf)
+        self.dm("-r", self.path("tree"), env=FORCED)
+        self.assertDmOk()
+        forced = self.hf_query(
+            "select filename, digest from files order by filename")
+
+        self.assertEqual(baseline, forced,
+                         "a forced probe changed what the scan stored")
+
+    def test_the_probe_leaves_the_file_alone(self):
+        """A zero-length dedupe must not touch the file it is asked about.
+
+        This is the property that makes probing safe to do on a stranger's
+        data: unlike FICLONERANGE, a zero src_length is not "to end of file"
+        for FIDEDUPERANGE. A regression here would silently share or truncate
+        the first file of every scan on an unrecognised filesystem.
+        """
+        p = self.mkrand("tree/only.bin", 1 * MiB)
+        with open(p, "rb") as f:
+            before = f.read()
+        st_before = os.stat(p)
+        self.sync()
+
+        self.dm("-r", self.path("tree"), env=FORCED)
+        self.assertDmOk()
+
+        with open(p, "rb") as f:
+            self.assertEqual(before, f.read(),
+                             "the probe altered the file's contents")
+        st_after = os.stat(p)
+        self.assertEqual(st_before.st_size, st_after.st_size,
+                         "the probe altered the file's size")
+        self.assertEqual(st_before.st_mtime, st_after.st_mtime,
+                         "the probe altered the file's mtime")

--- a/tests/integration/test_unsupported_fs.py
+++ b/tests/integration/test_unsupported_fs.py
@@ -19,15 +19,21 @@ from harness import DuperemoveTest, scratch_fstype
 
 
 class UnsupportedFsTest(DuperemoveTest):
-    def test_unsupported_fs_fails_loudly(self):
-        # Need a directory that is NOT on btrfs/XFS. The system temp dir is
-        # ext4 (CI) or tmpfs (most dev boxes); skip if it happens to be a
-        # reflink fs so we don't misjudge a supported setup.
+    def unsupported_dir(self):
+        """A scratch directory that is NOT on btrfs/XFS, or skip the test.
+
+        The system temp dir is ext4 (CI) or tmpfs (most dev boxes); skip if it
+        happens to be a reflink fs so we don't misjudge a supported setup.
+        """
         outside = tempfile.mkdtemp(prefix="oans-unsupported.")
         self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
         fstype = scratch_fstype(outside)
         if fstype in ("btrfs", "xfs"):
             self.skipTest(f"system temp dir is {fstype}, a supported fs")
+        return outside
+
+    def test_unsupported_fs_fails_loudly(self):
+        outside = self.unsupported_dir()
 
         with open(os.path.join(outside, "a.bin"), "wb") as f:
             f.write(os.urandom(1 << 20))
@@ -54,11 +60,7 @@ class UnsupportedFsTest(DuperemoveTest):
         the user pointed oans at a filesystem it may not be able to use at all
         and would have been told nothing.
         """
-        outside = tempfile.mkdtemp(prefix="oans-unsupported-empty.")
-        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
-        fstype = scratch_fstype(outside)
-        if fstype in ("btrfs", "xfs"):
-            self.skipTest(f"system temp dir is {fstype}, a supported fs")
+        outside = self.unsupported_dir()
 
         # Empty files: below --min-filesize, so none of them reaches the
         # scanner and nothing can answer the probe.

--- a/tests/integration/test_unsupported_fs.py
+++ b/tests/integration/test_unsupported_fs.py
@@ -2,8 +2,13 @@
 
 Regression guard: an unsupported seed root used to be accepted, walked, and
 then fail every FIEMAP with per-file errors while still exiting 0 ("Nothing to
-deduplicate"). It is now rejected up front, and a run whose roots are all
-unsupported exits non-zero with a clear message.
+deduplicate"). It is now refused with a clear message and a non-zero exit,
+before anything is hashed.
+
+Since #224 the refusal comes from probing the filesystem for FIDEDUPERANGE
+rather than from matching its name against btrfs and XFS, so the message names
+the missing ioctl. What must not change is the outcome: loud, non-zero, and no
+per-file FIEMAP spam.
 """
 
 import os
@@ -33,9 +38,37 @@ class UnsupportedFsTest(DuperemoveTest):
             0, self.rc,
             "oans must exit non-zero when no path is on a supported filesystem")
         self.assertIn(
-            "not btrfs or XFS", self.out,
-            "a clear unsupported-filesystem message is printed")
+            "FIDEDUPERANGE", self.out,
+            "the message names the ioctl the filesystem is missing")
         # The root is refused, not walked, so no per-file FIEMAP error spam.
         self.assertNotIn(
             "fiemap", self.out.lower(),
             "unsupported roots are skipped before any FIEMAP call")
+
+    def test_an_unsupported_fs_with_nothing_to_scan_still_fails(self):
+        """No file to probe is not the same as a clean run.
+
+        Since #224 the verdict comes from asking a file, so a tree with no
+        scannable file leaves the question unanswered. Exiting 0 there would be
+        exactly the silent no-op the upfront rejection was introduced to kill --
+        the user pointed oans at a filesystem it may not be able to use at all
+        and would have been told nothing.
+        """
+        outside = tempfile.mkdtemp(prefix="oans-unsupported-empty.")
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        fstype = scratch_fstype(outside)
+        if fstype in ("btrfs", "xfs"):
+            self.skipTest(f"system temp dir is {fstype}, a supported fs")
+
+        # Empty files: below --min-filesize, so none of them reaches the
+        # scanner and nothing can answer the probe.
+        for i in range(4):
+            open(os.path.join(outside, f"empty{i}"), "wb").close()
+
+        self.dedupe(outside)
+
+        self.assertNotEqual(
+            0, self.rc,
+            "a filesystem that was never proved usable must not exit 0")
+        self.assertIn("FIDEDUPERANGE", self.out,
+                      "the message says what could not be established")


### PR DESCRIPTION
Closes #224, in the shape agreed on the issue: **the allowlist stays as a fast path and the probe is the fallback** for filesystems not on it. btrfs and XFS never reach the probe, so the two validated filesystems behave exactly as before — the only trees whose outcome can change are the ones oans refused outright.

## The probe

A real block-sized `FIDEDUPERANGE` request between two disjoint ranges of one file, classified on **both** the ioctl return and the per-destination `info[0].status`.

That last part is not a detail. My first cut used a zero-length request and read only `errno`, which looked obviously safer and was wrong. Measured on a container's overlayfs over ext4:

```
zero-length   rc=0                    (overlayfs answers for itself)
4K request    rc=0, status=-EINVAL    (the lower filesystem refuses)
```

against plain ext4, which returns `rc=-1/EOPNOTSUPP` for every shape. overlayfs implements `remap_file_range` as a pass-through, so a zero-length request never reaches the storage underneath. Reading only errno accepted **every containerised run on an overlay root** — which then hashes the whole tree and fails at dedupe time, precisely what refusing unsupported filesystems upfront exists to prevent, and a regression against master, which refuses overlayfs cleanly.

**The trade:** a real request means that on a filesystem which *does* support dedupe, the probe's two ranges may turn out identical and get shared. That is a genuine, byte-verified dedupe of one block within one file — it cannot change contents, size or mtime, and it only happens when the answer is yes, i.e. when oans is about to deduplicate the tree anyway. `test_fs_probe.py::…_leaves_the_file_alone` pins the file being untouched.

## Other things that shaped it

**The taxonomy is the whole feature**, so `dedupe_classify_probe()` is a pure function with a unit test over every errno and status that matters. Only `EOPNOTSUPP`/`ENOTTY` — from errno or a negative status — mean *no*. `EINVAL` is documented both for "the filesystem does not support deduplicating the ranges of the given files" *and* for a dozen ordinary per-file conditions, so it, and everything else, is `UNKNOWN` and the next file is asked (up to 16). A wrong *no* would silently skip someone's whole tree.

**Probed lazily at the first regular file, not at seed time.** The ioctl needs a writable regular file and a root is normally a directory — measured, a directory fd gives `EISDIR`, not `EOPNOTSUPP`. Creating a scratch file is a non-starter (read-only mounts; read-only subvolumes are scanned by default since #182). `check_file()` locks the root provisionally; `__scan_file()` — the single consumer, hence no locking — settles it before anything is hashed.

**Three ways to refuse, saying different things.** A definite no; 16 files that all declined (this names overlayfs, since that's how a user meets it); and a walk that ended with the question never asked — an empty tree, or everything filtered by `--exclude` or size. I found that last one while testing: it exited 0 having proved nothing, the same silent no-op the upfront rejection was introduced to kill.

## Testing

The accept branch is unreachable by ordinary means: the only filesystems known to answer *yes* are exactly the two that never reach the probe. `DUPEREMOVE_FORCE_FS_PROBE=1` drops the fast path so the probe runs against the scratch btrfs/XFS — that is how this ships having been seen to say *yes* and not only *no*. `test_fs_probe.py` checks a forced probe still dedupes, stores byte-identical digests to a fast-path run, and leaves the probed file's contents, size and mtime alone.

Verified on this sandbox (ext4, so every refusal path is exercised for real):

| filesystem | result |
|---|---|
| ext4 | definite no, exit 1, nothing hashed |
| tmpfs | definite no, exit 1 |
| overlayfs over ext4, 3 files | inconclusive, "3 file(s) were asked and none could answer" |
| overlayfs over ext4, 28 files | inconclusive, 16-try limit |
| empty tree | "no file was available to test", exit 1 |

Plus `make test` (32 tests, 5925 assertions), `make lint`, warning-free release build, and a full-suite name-by-name diff against master: **no new failures**, two previously-failing tests now pass (their 8000-byte files are too small for the probe's two ranges, so they come back `UNKNOWN` and are hashed normally — an artifact of this box having no reflink fs; on CI they take the fast path).

CI on real btrfs and XFS is the gate for the accept branch, which I cannot run here.

## Note on scope

This does not unblock ZFS, for the reason on the issue: `probe_fs()` still bails when `stx_dev_major == 0`, and a ZFS dataset has no block device behind `tank/foo` for libblkid. Filesystem identity needs its own change, and ZFS lacks FIEMAP regardless.