### PR TITLE
test: the hashfile, against an in-memory SQLite (dbfile.c 901 → 785 survivors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,29 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
 `dbfile_open_handle(NULL)` opens a shared-cache in-memory SQLite - the same path
 a run without `--hashfile` takes - so `dbfile.c` needs no filesystem, no btrfs
 and no scan to test. That is not a test-only seam; it is the in-memory mode
-oans already ships. Coverage went 0% → 47% on eight tests.
+oans already ships. Coverage went 0% → 47% on eight tests, and a whole-file
+sweep from **901 survivors to 785**.
+
+- **`memdb()` handles all share one database.** Shared-cache in-memory means a
+  second `dbfile_open_handle(NULL)` is the *same* database, not an empty one -
+  so "what does this answer against a fresh hashfile" has to be asked before
+  the test stores anything, and a test that opens a second handle expecting a
+  clean slate silently asserts against the first one's rows.
+- **Read the survivors by function here too, and twice it changed the fix.**
+  `dbfile_get_run_summary` barely moved on the second sweep, 22 → 21, and the
+  grouping said why: its five error buckets are adjacent columns read by
+  index, and the fixture had three of them at 0 - indistinguishable from each
+  other *and* from a read that was dropped. Distinct values fixed it.
+  `dbfile_load_scan_config` still let `mfs = 0` be deleted, because the
+  fixture deleted *both* size-limit keys; the two limits are read through one
+  scratch variable, so only deleting the additive one exposes `max` silently
+  becoming `min`. In both cases the test looked thorough and the number said
+  otherwise.
+- **A `perror_sqlite` + `goto out` pair is residue, not a hole.** After the
+  strengthening, all ten of `dbfile_describe_file`'s remaining survivors are
+  that shape - a bind or step failure no unit test can provoke. Triage to
+  that point and stop; the next honest move is a fault-injection seam, not a
+  bigger fixture.
 
 - **What is worth testing there is what fails silently.** A hashfile is a cache,
   so nothing downstream validates it: a row that vanished, a digest copied from
@@ -306,6 +328,21 @@ counterexample. No dependencies, one header, minunit-compatible.
   the named-bug files they earn their place differently again — leaving the
   fiemap address set unsorted is caught by nothing else. Expect that
   unevenness rather than a uniform number.
+  - The three **hashfile** properties are the same story a third time:
+    `src/dbfile.c` swept with and without them is **786 survivors → 785**,
+    one mutant. That one is worth the three, though - `i > 0` → `i > 1` in
+    `dbfile_layout_matches`, i.e. *a donor with exactly one stored extent
+    stops matching*. Every fixture in the table has two records, so nothing
+    there could see it, and a single-extent file is the common case: btrfs
+    reports a contiguously allocated file as one fiemap record however large
+    it is. A snapshot-aware scan would have silently stopped copying
+    anything on the most ordinary layout there is.
+  - **And the sweep cannot score one of them at all.** "Normalize adjacent
+    records before comparing" - the #186 confusion, and what
+    `test_prop_a_split_record_is_not_the_layout_it_covers` exists to refuse -
+    is a design change, not a single-token edit or a statement deletion, so
+    no operator generates it. Read a property's `caught` count as a lower
+    bound on what it guards, never as the measure.
 
 ## Profiling & measurement — read before optimizing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,13 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
     line, and the caller's comes after). A `--make-arg SANITIZE=...` run is
     unaffected either way — the makefile appends its own `-O1 -fsanitize=...`
     through `override CFLAGS +=`, which lands last and wins.
+  - **Validated over a whole file, not a sample.** `src/dbfile.c` swept at both
+    settings: 908 survivors at `-O2`, 901 at `-O0`, and **17 of 1,879 mutants
+    (0.9%) differ**. Every one of the 17 is a *statement deletion* — a removed
+    `return ret;` or assignment, which leaves a function falling off the end or
+    a value uninitialised. That is undefined behaviour, so its observable
+    result depends on codegen and the verdict is not a stable property of the
+    tests under any build. Nothing else moved, in either direction.
 - **Read a survivor count by function, never as a total.** The first sweep of
   `src/util.c` came back 213 survivors of 413 and that number says nothing:
   grouped by function it was 5-9% survival everywhere a test existed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,24 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
   edit it here — change it there, run that suite, re-copy into all three and
   update each `mutate_core.sha256`. `make lint` fails if this copy has drifted.
   Only `scripts/mutate/mutate.py` (the ~130-line adapter) is oans's.
-- A mutant costs one compile of `src/tests.c` (~4.5 s) — every source is
-  `#include`d into it, so there is no incremental build and ccache cannot help.
-  The `-fsyntax-only` pre-filter rejects the invalid ones at about a tenth of
-  that.
+- **A mutant costs one compile of `src/tests.c`** — every source is `#include`d
+  into it, so ~20,000 lines in one translation unit, no incremental build, and
+  nothing for ccache to hit since each mutant is a preprocessed source nothing
+  has ever seen. That compile *is* the run: the suite itself is 0.3 s. The
+  `-fsyntax-only` pre-filter rejects the invalid ones at about a tenth of a
+  build.
+  - **The lanes therefore build at `-O0`** (`MUTANT_CFLAGS` in the adapter),
+    which is the single biggest lever there is. Measured, interleaved: the
+    makefile's shipping flags (`-O2 -ggdb` plus hardening) compile in 5.6 s
+    against 1.3 s, while the suite goes only 0.24 s → 0.30 s — so a mutant is
+    **5.84 s → 1.60 s, 3.7×**, and a whole-file sweep of `src/dbfile.c` is 22
+    minutes instead of 49. The warning flags stay: dropping them would move
+    mutants between `compiler` and the verdicts that are about the tests, which
+    is the one comparison this tool exists to make.
+  - `--make-arg CFLAGS=...` overrides it (make takes the last assignment on the
+    line, and the caller's comes after). A `--make-arg SANITIZE=...` run is
+    unaffected either way — the makefile appends its own `-O1 -fsanitize=...`
+    through `override CFLAGS +=`, which lands last and wins.
 - **Read a survivor count by function, never as a total.** The first sweep of
   `src/util.c` came back 213 survivors of 413 and that number says nothing:
   grouped by function it was 5-9% survival everywhere a test existed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
 `dbfile_open_handle(NULL)` opens a shared-cache in-memory SQLite - the same path
 a run without `--hashfile` takes - so `dbfile.c` needs no filesystem, no btrfs
 and no scan to test. That is not a test-only seam; it is the in-memory mode
-oans already ships. Coverage went 0% → 47% on nine tests.
+oans already ships. Coverage went 0% → 47% on eight tests.
 
 - **What is worth testing there is what fails silently.** A hashfile is a cache,
   so nothing downstream validates it: a row that vanished, a digest copied from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,30 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
   the equivalents rather than assuming them: three that looked equivalent were
   not, and one of those wrote a byte past a buffer.
 
+### The hashfile is unit-testable, in memory
+
+`dbfile_open_handle(NULL)` opens a shared-cache in-memory SQLite - the same path
+a run without `--hashfile` takes - so `dbfile.c` needs no filesystem, no btrfs
+and no scan to test. That is not a test-only seam; it is the in-memory mode
+oans already ships. Coverage went 0% → 47% on nine tests.
+
+- **What is worth testing there is what fails silently.** A hashfile is a cache,
+  so nothing downstream validates it: a row that vanished, a digest copied from
+  the wrong donor and a replay that adopted a dead default all produce a run
+  that exits 0 and looks exactly like a correct one. `bugs/dbfile.txt` puts
+  eight of those back.
+- **Three API shapes that a test gets wrong first.** `dbfile_store_file_info()`
+  writes no digest - `dbfile_update_scanned_file()` does, and the digest is
+  precisely what tells a finished file from one an interrupted run left partway,
+  so a helper that skips it builds rows the startup prune deletes.
+  `dbfile_load_scan_config()` returns **1** for "a config was stored" and 0 for
+  "none", so `== 0` reads success as failure. And `dbfile_load_checkpoint()`
+  *copies into buffers the caller owns* - a zeroed `struct scan_checkpoint` is a
+  write through NULL, which is now said in the header.
+- **`mu_check()` cannot be used in a helper that returns a value.** It expands
+  to a bare `return;`; gcc warns, clang refuses. Conditions that mean "the test
+  itself is broken" `abort()` instead, the way `gs_hit()` already did.
+
 ### `src/proptest.h` — properties, not tables
 
 An ordinary test names an input and its answer; a property names a relationship

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -1,0 +1,119 @@
+# file: src/dbfile.c
+#
+# Invariants of the hashfile, each broken on purpose, and what notices.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/dbfile.txt
+#
+# Everything in this file fails *silently*. A hashfile is a cache, so nothing
+# downstream validates it: a row that vanished, a digest copied from the wrong
+# donor and a replay that adopted a dead default all produce a run that exits 0
+# and looks exactly like a correct one. That is why these are worth pinning
+# even though none of them can crash.
+#
+# These run against an in-memory SQLite - `dbfile_open_handle(NULL)`, the same
+# path a run without --hashfile takes - so they need no filesystem and no btrfs.
+
+# ---------------------------------------------------------------- #182
+
+# a 1.7.x "auto" is inherited instead of resolved to today's default
+# -1 meant "the user never asked", and 1.7.x resolved it to "skip" under -d.
+# Carrying that forward means a scheduled replay silently stops scanning every
+# snapshot on the machine, and the summary looks the same as it always did.
+<<<
+	if (sc->skip_readonly_subvols < 0)
+		sc->skip_readonly_subvols = 0;
+===
+>>>
+
+# ---------------------------------------------------------------- #159
+
+# the startup prune stops sparing checkpointed rows
+# A digest is what says a file was finished, so an interrupted file's row has
+# none - and deleting it is deleting the only record that the file was ever
+# started. The 1 TiB file this feature exists for then restarts at byte zero on
+# every run, forever, which is precisely the bug #159 was filed for.
+<<<
+"delete from files where digest is NULL and "				\
+"id not in (select fileid from scan_checkpoints);"
+===
+"delete from files where digest is NULL;"
+>>>
+
+# a resumed file is put through the ordinary upsert instead of a targeted UPDATE
+# INSERT OR REPLACE deletes the row and cascades its checkpoint and every stored
+# hash away. The file keeps its name and its size, so nothing looks wrong.
+<<<
+int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
+{
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
+	return run_by_fileid_arg(stmt, fileid, seq);
+}
+===
+int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
+{
+	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
+
+	sqlite3_exec(db->db, "delete from scan_checkpoints", NULL, NULL, NULL);
+	return run_by_fileid_arg(stmt, fileid, seq);
+}
+>>>
+
+# ---------------------------------------------------------------- #206
+
+# a donor with no stored extents counts as a layout match
+# Both record counts are then zero and agree, so the digest of one file is
+# copied onto another on the strength of no evidence at all. A miss costs one
+# redundant hash; this stores a digest of bytes the file never had, and nothing
+# downstream can tell that from a file with no duplicate.
+<<<
+	return i == fm->fm_mapped_extents && i > 0;
+===
+	return i == fm->fm_mapped_extents;
+>>>
+
+# the layout re-check compares only the record count
+# The 128-bit key is a hash, so it cannot be the whole test - this is the bar
+# that actually reads the donor's stored (loff, poff, len) triples back.
+<<<
+		if ((uint64_t)sqlite3_column_int64(stmt, 0) != e->fe_logical ||
+		    (uint64_t)sqlite3_column_int64(stmt, 1) != e->fe_physical ||
+		    (uint64_t)sqlite3_column_int64(stmt, 2) != e->fe_length)
+			return 0;
+===
+>>>
+
+# copying a donor brings its extents but not its block hashes
+# The file then reads as scanned and dedupes against nothing at the block level,
+# which only shows up as --dedupe-options=partial quietly finding less.
+<<<
+	if (!ret)
+		ret = run_by_fileid_arg(blk, dst, donor);
+===
+>>>
+
+# ---------------------------------------------------------------- schema
+
+# the hash tables stop cascading when their file is dropped
+# The stat-based prune then leaves orphan hashes behind on every deleted file:
+# they match nothing, are never collected, and the hashfile grows forever.
+<<<
+"UNIQUE(fileid, loff) "							\
+"FOREIGN KEY(fileid) REFERENCES files(id) ON DELETE CASCADE);"
+===
+"UNIQUE(fileid, loff));"
+>>>
+
+# ---------------------------------------------------------------- history
+
+# the error buckets report a lifetime total rather than the last run
+# A monitoring consumer alarms on these, so summing them means a permission
+# error fixed months ago keeps the alarm on forever - and the operator stops
+# reading it.
+<<<
+		"select skip_permission, skip_unreadable, skip_path_too_long, "
+		"skip_unsupported_fs, readonly_subvols "
+===
+		"select sum(skip_permission), sum(skip_unreadable), "
+		"sum(skip_path_too_long), sum(skip_unsupported_fs), "
+		"sum(readonly_subvols) "
+>>>

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -39,23 +39,18 @@
 "delete from files where digest is NULL;"
 >>>
 
-# a resumed file is put through the ordinary upsert instead of a targeted UPDATE
-# INSERT OR REPLACE deletes the row and cascades its checkpoint and every stored
-# hash away. The file keeps its name and its size, so nothing looks wrong.
+# a resumed file's generation is written with the ordinary upsert
+# The mistake is reaching for the statement that already writes a files row.
+# INSERT OR REPLACE deletes the row and cascades its checkpoint *and* every
+# stored hash away, so the file restarts at byte zero - and it keeps its name
+# and its size, so nothing looks wrong.
 <<<
-int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
-{
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
-	return run_by_fileid_arg(stmt, fileid, seq);
-}
+#define UPDATE_DEDUPE_SEQ "update files set dedupe_seq = ?2 where id = ?1;"
 ===
-int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
-{
-	_cleanup_(sqlite3_reset_stmt) sqlite3_stmt *stmt = db->stmts.update_dedupe_seq;
-
-	sqlite3_exec(db->db, "delete from scan_checkpoints", NULL, NULL, NULL);
-	return run_by_fileid_arg(stmt, fileid, seq);
-}
+#define UPDATE_DEDUPE_SEQ						\
+"insert or replace into files (id, filename, path_hash, ino, subvol, "	\
+"size, mtime, dedupe_seq) select id, filename, path_hash, ino, subvol, "\
+"size, mtime, ?2 from files where id = ?1;"
 >>>
 
 # ---------------------------------------------------------------- #206
@@ -93,14 +88,27 @@ int dbfile_update_dedupe_seq(struct dbhandle *db, int64_t fileid, uint64_t seq)
 
 # ---------------------------------------------------------------- schema
 
-# the hash tables stop cascading when their file is dropped
-# The stat-based prune then leaves orphan hashes behind on every deleted file:
-# they match nothing, are never collected, and the hashfile grows forever.
+# the block hashes stop cascading when their file is dropped
+# `blocks` only - `extents` spells its UNIQUE differently, so one edit cannot
+# reach both. The stat-based prune then leaves orphan block hashes behind on
+# every deleted file: they match nothing, are never collected, and the hashfile
+# grows forever.
 <<<
 "UNIQUE(fileid, loff) "							\
 "FOREIGN KEY(fileid) REFERENCES files(id) ON DELETE CASCADE);"
 ===
 "UNIQUE(fileid, loff));"
+>>>
+
+# the files table is unique on the inode alone rather than the pair
+# A subvolume id and an inode number are each 64 bits, and two files in
+# different subvolumes routinely share an inode number - so this quietly
+# collapses them into one row, and one of the two files stops being scanned at
+# all. The same trap seen_inode() has on the other side of the fence.
+<<<
+"flags INTEGER, UNIQUE(ino, subvol), UNIQUE(path_hash));"
+===
+"flags INTEGER, UNIQUE(ino), UNIQUE(path_hash));"
 >>>
 
 # ---------------------------------------------------------------- history

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -191,3 +191,47 @@
 ===
 "select mtime, size, filename, id, 1 from files "			\
 >>>
+
+# the two size limits are read through one scratch variable, unreset
+# A hashfile written before --max-filesize existed has no row for it, and
+# get_config_int64() then leaves the caller's variable alone - which is the
+# value min_filesize just landed in it. So max_filesize silently becomes min,
+# every file above the lower limit stops being scanned, and the run looks
+# exactly like one that had nothing to do.
+<<<
+		mfs = 0;
+		ret = get_config_int64(stmt, "opt_max_filesize", &mfs);
+===
+		ret = get_config_int64(stmt, "opt_max_filesize", &mfs);
+>>>
+
+# the last run's error buckets are read one column across
+# Five adjacent columns read back by index: shift them and a monitoring
+# consumer alarms on the wrong bucket, or on a column that is not an error at
+# all. Nothing downstream can tell, because every one of them is a plausible
+# small integer.
+<<<
+		s->last_skip_permission = sqlite3_column_int64(stmt, 0);
+		s->last_skip_unreadable = sqlite3_column_int64(stmt, 1);
+		s->last_skip_path_too_long = sqlite3_column_int64(stmt, 2);
+		s->last_skip_unsupported_fs = sqlite3_column_int64(stmt, 3);
+===
+		s->last_skip_permission = sqlite3_column_int64(stmt, 1);
+		s->last_skip_unreadable = sqlite3_column_int64(stmt, 2);
+		s->last_skip_path_too_long = sqlite3_column_int64(stmt, 3);
+		s->last_skip_unsupported_fs = sqlite3_column_int64(stmt, 4);
+>>>
+
+# a resumed file's position is read one column across
+# loff, size and mtime decide where hashing restarts and whether the
+# checkpoint is trusted at all. Read the wrong column and the run resumes at
+# an offset the file never reached - and the digest that comes out describes a
+# byte string that never existed, which nothing downstream can distinguish
+# from a file with no duplicate.
+<<<
+	cp->size = sqlite3_column_int64(stmt, 1);
+	cp->mtime = sqlite3_column_int64(stmt, 2);
+===
+	cp->size = sqlite3_column_int64(stmt, 2);
+	cp->mtime = sqlite3_column_int64(stmt, 1);
+>>>

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -125,3 +125,69 @@
 		"sum(skip_path_too_long), sum(skip_unsupported_fs), "
 		"sum(readonly_subvols) "
 >>>
+
+# ---------------------------------------------------------------- the prune
+
+# the prune becomes scope-based instead of stat-based
+# "delete the rows this run did not walk" is the obvious implementation and the
+# wrong one: one hashfile may cover several trees, so scanning a subdirectory
+# would drop every file outside it. Nothing says so at the time - the next full
+# scan just rehashes everything, which reads as slow rather than as broken.
+<<<
+		fn = (const char *)sqlite3_column_text(sel, 1);
+		if (!fn || longpath_stat(fn, &st) == 0)
+			continue;
+		/* Only ENOENT/ENOTDIR mean "gone"; keep rows on EACCES, EIO, etc. */
+		if (errno != ENOENT && errno != ENOTDIR)
+			continue;
+===
+>>>
+
+# a stat that failed for any other reason counts as "gone"
+# EACCES on a directory whose permissions changed, or EIO on a disk going bad,
+# then deletes the hashes for files that are still there - so the run that was
+# meant to notice the disk is failing rebuilds the cache instead.
+<<<
+		if (errno != ENOENT && errno != ENOTDIR)
+			continue;
+===
+>>>
+
+# the walk's confirmation is ignored and every row is stat'd
+# Not wrong, only slow - one extra stat per file on a tree the walk just
+# finished. It is here because it is the shape a refactor reaches for, and
+# because a test that never passes a `seen` oracle cannot tell the difference.
+<<<
+		if (seen && seen(id))
+			continue;
+===
+>>>
+
+# ---------------------------------------------------------------- #159
+
+# a checkpoint blob of the wrong length is copied out of anyway
+# The length is the only thing standing between a truncated or foreign row and
+# a memcpy into the caller's fixed buffer. A shorter blob reads past the row;
+# whatever comes back is then restored as an xxhash state and produces a digest
+# of a byte string that never existed.
+<<<
+	ext_len = sqlite3_column_bytes(stmt, 6);
+	if ((size_t)sqlite3_column_bytes(stmt, 3) != len ||
+	    (ext_len != 0 && (size_t)ext_len != len))
+		return false;
+===
+	ext_len = sqlite3_column_bytes(stmt, 6);
+>>>
+
+# ---------------------------------------------------------------- scan
+
+# change detection stops asking whether the file was ever hashed
+# A row is written with its mtime and size *before* hashing starts, so only the
+# digest tells a finished file from one an interrupted run left partway. Drop
+# the column and every started-but-unhashed file reads as up to date: it is
+# never hashed again, and it silently never takes part in dedupe.
+<<<
+"select mtime, size, filename, id, digest is not null from files "	\
+===
+"select mtime, size, filename, id, 1 from files "			\
+>>>

--- a/scripts/mutate/mutate.py
+++ b/scripts/mutate/mutate.py
@@ -11,6 +11,10 @@ unit binary `./test`, and make builds the lanes.
     scripts/mutate/mutate.py --file src/glob.c --diff   # whatever is uncommitted
     scripts/mutate/mutate.py --file src/fiemap.c --lines 120-190
 
+**Lanes build at `-O0`** (see MUTANT_CFLAGS), which is 3.7x faster per mutant
+than the makefile's shipping flags and scores the same verdicts. Pass
+`--make-arg CFLAGS=...` to override it.
+
 **The target is any C file, and `--file` is how you say which.** oans is not a
 single-header library, so unlike the other two projects that vendor this core
 there is no one file that is obviously *the* code. The default is only a default;
@@ -67,6 +71,41 @@ def bug_file_target(path):
     return m.group(1) if m else None
 
 
+#: What a lane compiles with, unless the caller says otherwise.
+#:
+#: A mutant is one compile of `src/tests.c`, which `#include`s 24 sources - some
+#: 20,000 lines in a single translation unit, with no incremental build to be had
+#: and nothing for ccache to hit, since every mutant is a preprocessed source
+#: nothing has ever seen. That compile *is* the run. Measured on this tree,
+#: interleaved: `-O2 -ggdb` plus release hardening is 5.6 s and `-O0` without
+#: debug info is 1.3 s, while the suite itself goes only 0.24 s -> 0.30 s. So a
+#: mutant costs 5.84 s by default and 1.60 s here - 3.7x, or a whole-file sweep
+#: in 13 minutes instead of 49.
+#:
+#: The warning flags stay. They cost nothing and dropping them would move
+#: mutants between `compiler` and the verdicts that are about the tests, which
+#: is the one comparison this tool exists to make.
+MUTANT_CFLAGS = ("-Wall -Wextra -Wno-unused-parameter -std=gnu11 "
+                 "-Werror=strict-prototypes -MMD -O0")
+
+
+class OansMake(mutate_core.MakeBackend):
+    """make, told to compile for speed rather than for shipping.
+
+    Only the default changes: `--make-arg CFLAGS=...` still wins, because make
+    takes the last assignment on the command line and the caller's arguments
+    come after this one. A `--make-arg SANITIZE=...` run is unaffected too - the
+    makefile appends its own `-O1 -fsanitize=...` through `override CFLAGS +=`,
+    which lands after this and therefore wins.
+    """
+
+    def setup_args(self, args):
+        supplied = super().setup_args(args)
+        if any(a.startswith("CFLAGS=") for a in supplied):
+            return supplied
+        return ["CFLAGS=" + MUTANT_CFLAGS] + supplied
+
+
 class Oans(mutate_core.Project):
     slug = "oans"
     repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -89,7 +128,7 @@ class Oans(mutate_core.Project):
     # `test-build` and not `test`: the latter builds *and runs* the binary, so a
     # mutant the suite caught would exit nonzero at the build step and be scored
     # `compiler` - the compiler credited with protection the tests provided.
-    backend = mutate_core.MakeBackend("test-build")
+    backend = OansMake("test-build")
     harness = mutate_core.MinunitHarness()
 
     compiler_env = "CC"
@@ -107,12 +146,13 @@ class Oans(mutate_core.Project):
     # Measured: ~4 MB of sources, ~13 MB once built (one binary with -ggdb).
     lane_bytes = 24 * mutate_core.MIB
 
-    # Measured on this tree, gcc 13 at -O2: one mutant is 4.4 s of compiling
-    # `src/tests.c`, 0.5 s to link and 0.004 s to run the suite. Nearly all of
-    # it is one serial compile inside one lane, so the lanes divide it and the
+    # Measured on this tree with MUTANT_CFLAGS: one mutant is ~1.3 s of
+    # compiling and linking `src/tests.c` and 0.3 s to run the suite. Nearly all
+    # of it is one serial compile inside one lane, so the lanes divide it and the
     # machine does not - the same shape as nanobench and the opposite of
-    # unordered_dense's ~90 translation units.
-    lane_seconds_per_mutant = 5.0
+    # unordered_dense's ~90 translation units. At the makefile's own -O2 this
+    # figure is 5.8; pass `--make-arg CFLAGS=...` and --dry-run will read low.
+    lane_seconds_per_mutant = 1.6
     overhead_seconds_per_mutant = 0.3
     setup_seconds = 8.0
     setup_seconds_per_lane = 0.2

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -398,6 +398,12 @@ struct scan_checkpoint {
 
 int dbfile_store_checkpoint(struct dbhandle *db, int64_t fileid,
 			    const struct scan_checkpoint *cp);
+/*
+ * The caller owns the two state buffers and must point `file_state` and
+ * `ext_state` at running_checksum_state_size() bytes each before calling:
+ * this copies into them rather than allocating. A zeroed `struct
+ * scan_checkpoint` is therefore a write through NULL, not an empty result.
+ */
 bool dbfile_load_checkpoint(struct dbhandle *db, int64_t fileid,
 			    struct scan_checkpoint *cp);
 int dbfile_remove_checkpoint(struct dbhandle *db, int64_t fileid);

--- a/src/tests.c
+++ b/src/tests.c
@@ -1816,6 +1816,21 @@ static struct dbhandle *memdb(void)
  * `--stats` and `--json` print, so asserting through it covers the production
  * counters as well as the tables.
  */
+/*
+ * A statement whose only job is to set the fixture up. It aborts rather than
+ * mu_check()s: a mistyped column name makes sqlite3_exec() a no-op, and a
+ * fixture that quietly did nothing is a test that quietly proves nothing -
+ * which is how the wrong-length-blob case below first passed against a column
+ * that does not exist.
+ */
+static void exec(struct dbhandle *db, const char *sql)
+{
+	char *err = NULL;
+
+	if (sqlite3_exec(db->db, sql, NULL, NULL, &err) != SQLITE_OK)
+		abort();
+	sqlite3_free(err);
+}
 static uint64_t rows(struct dbhandle *db, const char *table)
 {
 	char sql[64];
@@ -2079,9 +2094,9 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	char *roots[] = { (char *)"/data", (char *)"/srv" };
 	char *excludes[] = { (char *)"*.iso" };
 	struct scan_config out = {
-		.run_dedupe = 1, .recurse = 1, .skip_zeroes = 0,
-		.skip_readonly_subvols = 1, .only_whole_files = 0,
-		.do_block_hash = 1, .dedupe_same_file = 0,
+		.run_dedupe = 1, .recurse = 1, .skip_zeroes = 1,
+		.skip_readonly_subvols = 1, .only_whole_files = 1,
+		.do_block_hash = 1, .dedupe_same_file = 1,
 		.min_filesize = 1024, .max_filesize = 1u << 20,
 		.roots = roots, .nroots = 2,
 		.excludes = excludes, .nexcludes = 1,
@@ -2096,7 +2111,15 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	mu_check(dbfile_store_scan_config(db, &out) == 0);
 	mu_check(dbfile_load_scan_config(db, &in) == 1);
 
+	/*
+	 * Every option, not a representative few: a replay adopts whatever this
+	 * does not read, so an option the loader drops silently reverts to its
+	 * default on a scheduled run and the hashfile stops describing what
+	 * produced it. All 1 here, so a dropped key reads as 0.
+	 */
 	mu_check(in.run_dedupe == 1 && in.recurse == 1 && in.do_block_hash == 1);
+	mu_check(in.skip_zeroes == 1 && in.only_whole_files == 1);
+	mu_check(in.dedupe_same_file == 1);
 	mu_check(in.min_filesize == 1024 && in.max_filesize == (1u << 20));
 	mu_check(in.skip_readonly_subvols == 1);	/* an explicit 1 survives */
 	mu_check(in.nroots == 2 && in.nexcludes == 1);
@@ -2105,14 +2128,38 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	scan_config_free(&in);
 
 	/* What a 1.7.x hashfile holds. */
-	sqlite3_exec(db->db, "update config set keyval = -1 "
-			     "where keyname = 'opt_skip_readonly_subvols'",
-		     NULL, NULL, NULL);
+	exec(db, "update config set keyval = -1 "
+		 "where keyname = 'opt_skip_readonly_subvols'");
 	memset(&in, 0, sizeof(in));
 	mu_check(dbfile_load_scan_config(db, &in) == 1);
 	mu_check(in.skip_readonly_subvols == 0);	/* coerced to the new default */
 	scan_config_free(&in);
 
+	/* ...and the mirror image, so that all-1 above cannot be a constant. */
+	memset(&out, 0, sizeof(out));
+	out.roots = roots;
+	out.nroots = 2;
+	mu_check(dbfile_store_scan_config(db, &out) == 0);
+	memset(&in, 0, sizeof(in));
+	mu_check(dbfile_load_scan_config(db, &in) == 1);
+	mu_check(!in.run_dedupe && !in.recurse && !in.do_block_hash);
+	mu_check(!in.skip_zeroes && !in.only_whole_files && !in.dedupe_same_file);
+	scan_config_free(&in);
+
+	/*
+	 * A key that is simply not there. Sizes are the two that a hashfile
+	 * written by an older oans can lack, and the default has to be "no
+	 * limit" rather than whatever the caller's struct happened to hold -
+	 * a stale non-zero max_filesize skips every large file for good.
+	 */
+	exec(db, "delete from config where keyname in "
+		 "('opt_min_filesize', 'opt_max_filesize')");
+	memset(&in, 0, sizeof(in));
+	in.min_filesize = 99;
+	in.max_filesize = 99;
+	mu_check(dbfile_load_scan_config(db, &in) == 1);
+	mu_check(in.min_filesize == 0 && in.max_filesize == 0);
+	scan_config_free(&in);
 }
 
 /*
@@ -2135,7 +2182,11 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
 		.skip_permission = 0, .skip_unreadable = 0,
 		.readonly_subvols = 4,
 	};
-	struct run_summary s = {0};
+	/* Deliberately not zeroed: the summary clears what it does not fill,
+	 * so a caller's stack garbage cannot be read back as a lifetime total. */
+	struct run_summary s;
+
+	memset(&s, 0x5a, sizeof(s));
 
 	mu_check(dbfile_record_run(db, &first) == 0);
 	mu_check(dbfile_record_run(db, &second) == 0);
@@ -2234,6 +2285,255 @@ MU_TEST(test_dbfile_copying_a_donor_brings_all_three) {
 	mu_check(dbfile_query_u64(db->db,
 		 "select count(*) from files where digest is not null") == 2);
 
+}
+
+/*
+ * Every field a stored row carries, read back through the change-detection
+ * path the scan itself uses. The original test asserted only that a row
+ * appeared, which leaves each `sqlite3_bind_*` free to write the right value
+ * into the wrong column - a sweep found the bind indices in
+ * dbfile_store_file_info() entirely unguarded. Distinct values throughout, so
+ * a swapped pair cannot look correct.
+ */
+MU_TEST(test_dbfile_a_stored_file_round_trips_every_field) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(file_cleanup) struct file f = {0};
+	_cleanup_(file_cleanup) struct file got = {0};
+	unsigned char digest[DIGEST_LEN];
+	int64_t id;
+
+	if (file_set_filename(&f, "/tree/distinctive-name"))
+		abort();
+	f.ino = 111; f.subvol = 222; f.size = 333; f.mtime = 444;
+	f.dedupe_seq = 5;
+	id = dbfile_store_file_info(db, &f);
+	mu_check(id > 0);
+
+	/*
+	 * Before the digest lands the row exists but is not a finished file -
+	 * which is the whole distinction an interrupted run turns on, and the
+	 * only thing that tells the two apart.
+	 */
+	mu_check(dbfile_describe_file(db, 111, 222, &got) == 0);
+	mu_check(got.id == id && !got.digest_valid);
+	file_cleanup(&got);
+	memset(&got, 0, sizeof(got));
+
+	memset(digest, 0xab, DIGEST_LEN);
+	mu_check(dbfile_update_scanned_file(db, id, digest, 6, 7) == 0);
+
+	/* Looked up by (ino, subvol), which is how the scan finds it again. */
+	mu_check(dbfile_describe_file(db, 111, 222, &got) == 0);
+	mu_check(got.id == id);
+	mu_check(got.size == 333);
+	mu_check(got.mtime == 444);
+	mu_check(got.filename && !strcmp(got.filename, "/tree/distinctive-name"));
+	mu_check(got.digest_valid);	/* it has been hashed all the way through */
+
+	/* The columns describe_file does not return, and the ones only
+	 * update_scanned_file writes. */
+	mu_check(dbfile_query_u64(db->db, "select ino from files") == 111);
+	mu_check(dbfile_query_u64(db->db, "select subvol from files") == 222);
+	mu_check(dbfile_query_u64(db->db, "select dedupe_seq from files") == 5);
+	mu_check(dbfile_query_u64(db->db, "select flags from files") == 6);
+	mu_check(dbfile_query_u64(db->db, "select nr_extents from files") == 7);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from files "
+		 "where hex(digest) = 'ABABABABABABABABABABABABABABABAB'") == 1);
+
+	/* A file nothing knows about leaves the caller's struct alone rather
+	 * than reporting someone else's row. */
+	_cleanup_(file_cleanup) struct file absent = {0};
+
+	mu_check(dbfile_describe_file(db, 999, 999, &absent) == 0);
+	mu_check(absent.id == 0 && absent.size == 0 && absent.filename == NULL);
+}
+
+/*
+ * Hashes carry the offsets that say where they came from, and the loaders join
+ * on them. Asserting only the row *count* - which is what the first cut did -
+ * leaves every bind index free: a block hash stored at the wrong loff still
+ * counts as one row, and dedupe then compares the wrong parts of two files.
+ */
+MU_TEST(test_dbfile_hashes_round_trip_their_offsets) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t id = put_unscanned_file(db, "/tree/a", 1, 1);
+	struct block_csum blocks[2] = { { .loff = 4096 }, { .loff = 8192 } };
+	struct extent_csum extents[2] = {
+		{ .loff = 0,    .poff = 65536, .len = 4096 },
+		{ .loff = 4096, .poff = 69632, .len = 8192 },
+	};
+
+	memset(blocks[0].digest, 0x11, DIGEST_LEN);
+	memset(blocks[1].digest, 0x22, DIGEST_LEN);
+	memset(extents[0].digest, 0x33, DIGEST_LEN);
+	memset(extents[1].digest, 0x44, DIGEST_LEN);
+
+	mu_check(dbfile_store_block_hashes(db, id, 2, blocks) == 0);
+	mu_check(dbfile_store_extent_hashes(db, id, 2, extents) == 0);
+
+	mu_check(dbfile_query_u64(db->db,
+		 "select loff from blocks order by loff limit 1") == 4096);
+	mu_check(dbfile_query_u64(db->db,
+		 "select loff from blocks order by loff desc limit 1") == 8192);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from blocks where fileid = (select id from files)") == 2);
+	/* Paired with its offset, so a digest bound into the wrong slot shows. */
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from blocks where loff = 4096 and "
+		 "hex(digest) = '11111111111111111111111111111111'") == 1);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from blocks where loff = 8192 and "
+		 "hex(digest) = '22222222222222222222222222222222'") == 1);
+
+	/* Each extent's three numbers, together: a swapped poff/len pair keeps
+	 * both the row count and either column's set of values intact. */
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where loff = 0 and poff = 65536 "
+		 "and len = 4096") == 1);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where loff = 4096 and poff = 69632 "
+		 "and len = 8192") == 1);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where loff = 0 and "
+		 "hex(digest) = '33333333333333333333333333333333'") == 1);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where loff = 4096 and "
+		 "hex(digest) = '44444444444444444444444444444444'") == 1);
+
+	/*
+	 * A zero-length extent is skipped rather than stored: it names no
+	 * bytes, so a later join against it would match a range that does not
+	 * exist.
+	 */
+	struct extent_csum empty[2] = {
+		{ .loff = 65536, .poff = 1, .len = 0 },
+		{ .loff = 69632, .poff = 2, .len = 1 },
+	};
+
+	mu_check(dbfile_store_extent_hashes(db, id, 2, empty) == 0);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where len = 0") == 0);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from extents where len = 1") == 1);
+}
+
+/*
+ * The checkpoint reader declines everything it cannot vouch for. Reporting
+ * success for a checkpoint that is absent or the wrong size hands the scan a
+ * resume position built from an uninitialised buffer, and the digest that comes
+ * out describes bytes no file ever held.
+ */
+MU_TEST(test_dbfile_load_checkpoint_declines_what_it_cannot_vouch_for) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t id = put_unscanned_file(db, "/tree/big", 1, 1);
+	size_t len = running_checksum_state_size();
+	_cleanup_(freep) void *state = malloc(len);
+	_cleanup_(freep) void *got_file = malloc(len);
+	_cleanup_(freep) void *got_ext = malloc(len);
+	struct scan_checkpoint cp = mkcheckpoint(state, NULL, 4096);
+	struct scan_checkpoint got = { .file_state = got_file, .ext_state = got_ext };
+
+	/* Nothing stored yet: not an error, but not a checkpoint either. */
+	mu_check(!dbfile_load_checkpoint(db, id, &got));
+
+	mu_check(dbfile_store_checkpoint(db, id, &cp) == 0);
+	mu_check(dbfile_load_checkpoint(db, id, &got));
+
+	/* A file that has one tells nothing about a file that does not. */
+	int64_t other = put_unscanned_file(db, "/tree/other", 2, 1);
+
+	mu_check(!dbfile_load_checkpoint(db, other, &got));
+
+	/* A state blob of the wrong length is refused rather than copied out
+	 * of - the length is the only thing standing between a truncated row
+	 * and a memcpy past the caller's buffer. */
+	exec(db, "update scan_checkpoints set state = x'0011'");
+	mu_check(!dbfile_load_checkpoint(db, id, &got));
+
+	/* And once removed it is gone, so a finished file cannot resume. */
+	mu_check(dbfile_store_checkpoint(db, id, &cp) == 0);
+	mu_check(dbfile_load_checkpoint(db, id, &got));
+	mu_check(dbfile_remove_checkpoint(db, id) == 0);
+	mu_check(!dbfile_load_checkpoint(db, id, &got));
+}
+
+/* Which id the seen-oracle below claims the walk confirmed on disk. */
+static int64_t seen_oracle_id;
+
+static bool claims_seen(int64_t id)
+{
+	return id == seen_oracle_id;
+}
+
+/*
+ * The prune's actual contract, which the first cut only tested from one side:
+ * it removes rows whose path is *gone* and keeps everything else. Testing only
+ * the removal half leaves "delete what this run did not walk" passing, and that
+ * is the mistake the rule exists to prevent - it would wipe a shared hashfile
+ * the moment anyone scanned a subdirectory.
+ *
+ * Needs a real file, but any filesystem will do: the rule is a stat(), not a
+ * dedupe.
+ */
+MU_TEST(test_dbfile_pruning_keeps_what_still_exists) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	char present[] = "/tmp/oans-prune-XXXXXX";
+	int fd = mkstemp(present);
+
+	if (fd < 0)
+		abort();
+	close(fd);
+
+	put_file(db, present, 1, 1);
+	put_file(db, "/tmp/oans-prune-definitely-not-here", 2, 1);
+	mu_check(stats_of(db).num_files == 2);
+
+	/* One gone, one still there. */
+	mu_check(dbfile_prune_missing_files(db, NULL) == 1);
+	mu_check(stats_of(db).num_files == 1);
+	mu_check(dbfile_query_u64(db->db, "select ino from files") == 1);
+
+	/*
+	 * The seen-oracle is the scan's "I confirmed this one on disk" answer,
+	 * and it must short-circuit the stat entirely - that is the whole point
+	 * of it, since the common case is that nothing was deleted. Claim the
+	 * missing file was seen and it survives.
+	 */
+	int64_t ghost = put_file(db, "/tmp/oans-prune-also-not-here", 3, 1);
+
+	seen_oracle_id = ghost;
+	mu_check(dbfile_prune_missing_files(db, claims_seen) == 0);
+	mu_check(stats_of(db).num_files == 2);
+
+	/* Withdraw the claim and it goes. */
+	seen_oracle_id = 0;
+	mu_check(dbfile_prune_missing_files(db, claims_seen) == 1);
+	mu_check(stats_of(db).num_files == 1);
+
+	unlink(present);
+}
+
+/*
+ * More missing files than the collector's initial capacity, so the array has to
+ * grow. 512 is where it starts; a growth that loses or duplicates ids deletes
+ * the wrong rows, and at 8 files nothing would ever notice.
+ */
+MU_TEST(test_dbfile_pruning_grows_past_its_initial_capacity) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	const unsigned int n = 600;
+	char name[64];
+
+	mu_check(dbfile_begin_trans(db->db) == 0);
+	for (unsigned int i = 0; i < n; i++) {
+		snprintf(name, sizeof(name), "/tmp/oans-absent-%u", i);
+		put_file(db, name, 1000 + i, 1);
+	}
+	mu_check(dbfile_commit_trans(db->db) == 0);
+	mu_check(stats_of(db).num_files == n);
+
+	mu_check(dbfile_prune_missing_files(db, NULL) == (int64_t)n);
+	mu_check(stats_of(db).num_files == 0);
 }
 
 /*
@@ -3067,6 +3367,11 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run);
 	MU_RUN_TEST(test_dbfile_layout_matches_compares_every_record);
 	MU_RUN_TEST(test_dbfile_copying_a_donor_brings_all_three);
+	MU_RUN_TEST(test_dbfile_a_stored_file_round_trips_every_field);
+	MU_RUN_TEST(test_dbfile_hashes_round_trip_their_offsets);
+	MU_RUN_TEST(test_dbfile_load_checkpoint_declines_what_it_cannot_vouch_for);
+	MU_RUN_TEST(test_dbfile_pruning_keeps_what_still_exists);
+	MU_RUN_TEST(test_dbfile_pruning_grows_past_its_initial_capacity);
 
 	/* Property-based (src/proptest.h). Grouped rather than interleaved: they
 	 * are a different question about the same code, and a failure here names

--- a/src/tests.c
+++ b/src/tests.c
@@ -3367,6 +3367,199 @@ MU_TEST(test_prop_a_literal_path_matches_itself_and_nothing_else) {
  * skips a whole tree, a wrong YES brings back per-file dedupe errors -- so
  * anything that is not a clear statement about the filesystem stays UNKNOWN.
  */
+/*
+ * ---------------------------------------------------------------------------
+ * Properties of the hashfile
+ *
+ * The tables above name a layout and its answer. These name the two
+ * relationships that decide whether a snapshot-aware scan is safe at all, and
+ * go looking for a layout that breaks them - which is the right shape here,
+ * because what makes a layout interesting (a hole, two records that abut, a
+ * split at a block boundary) is a fact about extents rather than one anybody
+ * sits down and enumerates.
+ * ---------------------------------------------------------------------------
+ */
+
+/* One donor per case, since a file may hold only one set of extent rows. */
+static int64_t prop_donor(struct dbhandle *db, struct prop *p)
+{
+	char name[64];
+
+	snprintf(name, sizeof(name), "/snap/%u", p->iteration);
+	return put_file(db, name, 100000 + p->iteration, 1);
+}
+
+/* The fiemap records, as the rows a scan would have stored for them. */
+static void rows_of(const struct fm_rec *recs, unsigned int n,
+		    struct extent_csum *out)
+{
+	for (unsigned int i = 0; i < n; i++) {
+		out[i].loff = recs[i].log;
+		out[i].poff = recs[i].phys;
+		out[i].len = recs[i].len;
+		memset(out[i].digest, (int)i + 1, DIGEST_LEN);
+	}
+}
+
+/*
+ * The re-check accepts exactly the layout it was given and nothing else.
+ *
+ * Misses are free and false hits are catastrophic: a wrong match copies one
+ * file's digest onto another, and nothing downstream can tell that from a file
+ * with no duplicate. So both halves are asserted for every generated layout -
+ * that the records it stored match, and that no single-field change to any one
+ * record still does.
+ *
+ * Not a tautology: one side is a `struct fiemap`, the other is the rows
+ * dbfile_store_extent_hashes() wrote, and only the loop under test relates
+ * them. A mutation inside it makes the two sides disagree rather than agreeing
+ * with each other.
+ */
+MU_TEST(test_prop_a_layout_matches_only_itself) {
+	declare_prop(p, 300);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+	while (prop_next(&p)) {
+		struct fm_rec recs[PROP_MAX_RECS], probe[PROP_MAX_RECS];
+		struct extent_csum rows[PROP_MAX_RECS];
+		unsigned int n = gen_layout(&p, recs);
+		int64_t donor = prop_donor(db, &p);
+		unsigned int k, field;
+
+		rows_of(recs, n, rows);
+		if (dbfile_store_extent_hashes(db, donor, n, rows))
+			abort();
+
+		memcpy(probe, recs, n * sizeof(*probe));
+		prop_check(&p, layout_matches(db, donor, probe, n) == 1);
+
+		/* One field of one record, moved by one block. */
+		k = (unsigned int)prop_below(&p, n);
+		field = (unsigned int)prop_below(&p, 3);
+		if (field == 0)
+			probe[k].log += PROP_BLOCK;
+		else if (field == 1)
+			probe[k].phys += PROP_BLOCK;
+		else
+			probe[k].len += PROP_BLOCK;
+		prop_check(&p, layout_matches(db, donor, probe, n) == 0);
+
+		/* A prefix of the donor is still a miss, both directions. */
+		memcpy(probe, recs, n * sizeof(*probe));
+		if (n > 1)
+			prop_check(&p, layout_matches(db, donor, probe, n - 1) == 0);
+	}
+}
+
+/*
+ * The same *storage* described with different record boundaries reads as a
+ * miss. Splitting one record in two covers byte for byte what the donor
+ * covers, at the same addresses - so a check that reasoned about coverage
+ * would say yes, and it must say no (#186 is the same confusion from the other
+ * side, where treating two descriptions as different cost convergence).
+ *
+ * Its own property rather than a branch of the one above, because it is the
+ * one case where "obviously the same bytes" and "the same records" part
+ * company, and a generator has to be told to produce it.
+ */
+MU_TEST(test_prop_a_split_record_is_not_the_layout_it_covers) {
+	declare_prop(p, 300);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+	while (prop_next(&p)) {
+		struct fm_rec recs[PROP_MAX_RECS], probe[PROP_MAX_RECS + 1];
+		struct extent_csum rows[PROP_MAX_RECS];
+		unsigned int n = gen_layout(&p, recs);
+		int64_t donor;
+		unsigned int k = (unsigned int)prop_below(&p, n);
+		unsigned int i, j;
+		uint64_t half;
+
+		if (recs[k].len < 2 * PROP_BLOCK)
+			continue;		/* nothing to split */
+		half = recs[k].len / 2;
+
+		donor = prop_donor(db, &p);
+		rows_of(recs, n, rows);
+		if (dbfile_store_extent_hashes(db, donor, n, rows))
+			abort();
+
+		for (i = 0, j = 0; i < n; i++) {
+			probe[j++] = recs[i];
+			if (i != k)
+				continue;
+			probe[j - 1].len = half;
+			probe[j] = recs[i];
+			probe[j].log += half;
+			probe[j].len -= half;
+			/* The address is left alone: fe_physical addresses a
+			 * whole extent, so an offset into it means nothing on
+			 * a compressed one. Same trap as fiemap_maps_share. */
+			j++;
+		}
+		prop_check(&p, layout_matches(db, donor, probe, j) == 0);
+	}
+}
+
+/*
+ * Everything handed to dbfile_store_extent_hashes() comes back at the offsets
+ * it was given, and nothing else does.
+ *
+ * The second clause is what makes the zero-length skip a property rather than
+ * a case: an extent naming no bytes must not be stored at any count, at any
+ * position in the array, including as the only element. The table above can
+ * only ask that at the two shapes it writes down.
+ *
+ * Read back with SQL rather than through a loader, so a bind index shifted
+ * consistently in both directions cannot round-trip.
+ */
+MU_TEST(test_prop_stored_extents_come_back_where_they_were_put) {
+	declare_prop(p, 300);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+	while (prop_next(&p)) {
+		struct extent_csum ext[6];
+		unsigned int n = (unsigned int)prop_range(&p, 0, ARRAY_SIZE(ext));
+		uint64_t loff = 0, expect = 0;
+		int64_t id = prop_donor(db, &p);
+		char sql[256];
+
+		for (unsigned int i = 0; i < n; i++) {
+			ext[i].loff = loff;
+			ext[i].poff = PROP_BLOCK * prop_range(&p, 100, 108);
+			/* Empty about one record in five, so the skip is
+			 * reached first, last and alone across the run. */
+			ext[i].len = prop_chance(&p, 5)
+				   ? 0 : PROP_BLOCK * prop_range(&p, 1, 3);
+			memset(ext[i].digest, (int)prop_u64(&p), DIGEST_LEN);
+			loff += PROP_BLOCK * prop_range(&p, 1, 4);
+			if (ext[i].len)
+				expect++;
+		}
+
+		if (dbfile_store_extent_hashes(db, id, n, ext))
+			abort();
+
+		for (unsigned int i = 0; i < n; i++) {
+			if (!ext[i].len)
+				continue;
+			snprintf(sql, sizeof(sql),
+				 "select count(*) from extents where "
+				 "fileid = %lld and loff = %llu and "
+				 "poff = %llu and len = %llu",
+				 (long long)id, (unsigned long long)ext[i].loff,
+				 (unsigned long long)ext[i].poff,
+				 (unsigned long long)ext[i].len);
+			prop_check(&p, dbfile_query_u64(db->db, sql) == 1);
+		}
+
+		snprintf(sql, sizeof(sql),
+			 "select count(*) from extents where fileid = %lld",
+			 (long long)id);
+		prop_check(&p, dbfile_query_u64(db->db, sql) == expect);
+	}
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -3457,6 +3650,9 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_glob_reports_matching_pattern_and_counts);
 	MU_RUN_TEST(test_glob_rejects_malformed);
 	MU_RUN_TEST(test_glob_empty_set_matches_nothing);
+	MU_RUN_TEST(test_prop_a_layout_matches_only_itself);
+	MU_RUN_TEST(test_prop_a_split_record_is_not_the_layout_it_covers);
+	MU_RUN_TEST(test_prop_stored_extents_come_back_where_they_were_put);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -1771,6 +1771,433 @@ MU_TEST(test_running_checksum_rejects_foreign_state) {
 	mu_check(running_checksum_restore(blob, len) == NULL);
 }
 
+/* --- the hashfile (dbfile.c) ---
+ *
+ * These run against an in-memory SQLite database, which oans already supports:
+ * `dbfile_open_handle(NULL)` is the same path a run without `--hashfile` takes,
+ * so nothing here is a test-only seam. That is what makes dbfile.c reachable
+ * from the unit suite at all - it needs no filesystem, no btrfs, and no scan.
+ *
+ * What is worth testing here is not "does SQLite work" but the handful of
+ * invariants this file has actually broken before, each of which fails
+ * *silently*: a hashfile that empties itself while the run exits 0, a resumed
+ * file whose stored hashes vanish, a replay that adopts the wrong default.
+ */
+
+/* A fresh in-memory hashfile. The shared-cache URI means every handle in this
+ * process sees the same database, so each test drops what it made. */
+static struct dbhandle *memdb(void)
+{
+	struct dbhandle *db = dbfile_open_handle(NULL);
+
+	if (!db)
+		abort();	/* the test cannot run at all, not a finding */
+	sqlite3_exec(db->db, "delete from scan_checkpoints; delete from blocks;"
+			     "delete from extents; delete from files;"
+			     "delete from config; delete from scan_roots;"
+			     "delete from scan_excludes; delete from run_history;",
+		     NULL, NULL, NULL);
+	return db;
+}
+
+static uint64_t rows(struct dbhandle *db, const char *table)
+{
+	char sql[64];
+
+	snprintf(sql, sizeof(sql), "select count(*) from %s", table);
+	return dbfile_query_u64(db->db, sql);
+}
+
+/*
+ * A checkpoint carries a real running-checksum state - `file_state` is bound as
+ * a blob of running_checksum_state_size() bytes, so a NULL there is a
+ * constraint failure rather than an empty column. Caller frees `*state`.
+ */
+static struct scan_checkpoint mkcheckpoint(void **state, uint64_t loff)
+{
+	struct running_checksum *c = start_running_checksum();
+	struct scan_checkpoint cp = {
+		.loff = loff, .size = loff * 2, .mtime = 1000,
+		.ext_loff = 0, .ext_len = 4096, .has_ext_state = false,
+	};
+
+	*state = malloc(running_checksum_state_size());
+	if (!*state)
+		abort();
+	add_to_running_checksum(c, (unsigned char *)"some bytes", 10);
+	if (running_checksum_save(c, *state, running_checksum_state_size()))
+		abort();
+	finish_running_checksum(c, NULL);
+	cp.file_state = *state;
+	return cp;
+}
+
+/* Store one file row; returns its id. */
+static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
+			uint64_t subvol, unsigned int seq)
+{
+	_cleanup_(file_cleanup) struct file f = {0};
+	int64_t id;
+
+	if (file_set_filename(&f, name))
+		abort();
+	f.ino = ino;
+	f.subvol = subvol;
+	f.size = 4096;
+	f.blocks = 1;
+	f.mtime = 1000;
+	f.dedupe_seq = seq;
+	id = dbfile_store_file_info(db, &f);
+	if (id <= 0)
+		abort();
+	/*
+	 * A digest is written separately, and only once the file has been
+	 * hashed all the way through - `dbfile_store_file_info` deliberately
+	 * writes none. That is what tells a scanned row from one an interrupted
+	 * run left partway, so a helper that skipped this would produce rows
+	 * the startup prune deletes.
+	 */
+	unsigned char digest[DIGEST_LEN];
+
+	memset(digest, (int)ino, DIGEST_LEN);
+	if (dbfile_update_scanned_file(db, id, digest, 0, 1))
+		abort();
+	return id;
+}
+
+/*
+ * The hardlink hazard, from CLAUDE.md: `files` has UNIQUE(ino, subvol), and
+ * storing a second link to the same inode is an INSERT OR REPLACE - which
+ * *deletes* the first row and cascades its hashes away. The scan guards this
+ * with an in-memory seen_inodes set rather than in SQL, so what this pins is
+ * the shape of the hazard: two names, one inode, one surviving row. A batch
+ * that hit this could empty a hashfile while exiting 0.
+ */
+MU_TEST(test_dbfile_hardlink_replaces_rather_than_adds) {
+	struct dbhandle *db = memdb();
+
+	int64_t first = put_file(db, "/tree/a", 42, 1, 1);
+
+	mu_check(rows(db, "files") == 1);
+
+	/* A second link to the same inode: same (ino, subvol), different name. */
+	int64_t second = put_file(db, "/tree/b", 42, 1, 1);
+
+	mu_check(rows(db, "files") == 1);	/* replaced, not added */
+	mu_check(second != first);		/* and it is a *new* row */
+
+	/* A different inode is a different row, so the uniqueness is on the
+	 * inode pair and not on something coarser. */
+	put_file(db, "/tree/c", 43, 1, 1);
+	mu_check(rows(db, "files") == 2);
+
+	/* Different subvol, same inode number: also distinct - the two 64-bit
+	 * fields must not be conflated (the same trap seen_inode() has). */
+	put_file(db, "/other/a", 42, 2, 1);
+	mu_check(rows(db, "files") == 3);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * A file's hashes belong to it: dropping the row takes them with it, via the
+ * ON DELETE CASCADE the prune relies on. If that FK is ever lost, pruning a
+ * deleted file leaves orphan hashes that later match nothing and are never
+ * collected.
+ */
+MU_TEST(test_dbfile_dropping_a_file_takes_its_hashes) {
+	struct dbhandle *db = memdb();
+	int64_t id = put_file(db, "/tree/a", 1, 1, 1);
+	struct block_csum blocks[2] = { { .loff = 0 }, { .loff = 4096 } };
+	struct extent_csum extents[1] = { { .loff = 0, .poff = 8192, .len = 8192 } };
+
+	mu_check(dbfile_store_block_hashes(db, id, 2, blocks) == 0);
+	mu_check(dbfile_store_extent_hashes(db, id, 1, extents) == 0);
+	mu_check(rows(db, "blocks") == 2);
+	mu_check(rows(db, "extents") == 1);
+
+	mu_check(dbfile_remove_file(db, "/tree/a") == 0);
+	mu_check(rows(db, "files") == 0);
+	mu_check(rows(db, "blocks") == 0);	/* cascaded */
+	mu_check(rows(db, "extents") == 0);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * #159's resume path. A file interrupted partway keeps its row, its stored
+ * hashes and its checkpoint; the run that picks it up moves it into the current
+ * dedupe generation with a *targeted* UPDATE. Re-running the ordinary upsert
+ * instead would INSERT OR REPLACE the row and cascade the checkpoint and every
+ * stored hash away - the file would silently restart from byte zero, which on
+ * the 1 TiB file this feature exists for is hours.
+ */
+MU_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint) {
+	struct dbhandle *db = memdb();
+	int64_t id = put_file(db, "/tree/big", 1, 1, 1);
+	struct block_csum blocks[1] = { { .loff = 0 } };
+	_cleanup_(freep) void *state = NULL;
+	struct scan_checkpoint cp = mkcheckpoint(&state, 1u << 30);
+	/* load_checkpoint copies into buffers the caller owns; a zeroed struct
+	 * would be a write through NULL. */
+	_cleanup_(freep) void *got_file = malloc(running_checksum_state_size());
+	_cleanup_(freep) void *got_ext = malloc(running_checksum_state_size());
+	struct scan_checkpoint got = { .file_state = got_file, .ext_state = got_ext };
+
+	mu_check(dbfile_store_block_hashes(db, id, 1, blocks) == 0);
+	mu_check(dbfile_store_checkpoint(db, id, &cp) == 0);
+	mu_check(rows(db, "blocks") == 1);
+	mu_check(rows(db, "scan_checkpoints") == 1);
+
+	mu_check(dbfile_update_dedupe_seq(db, id, 7) == 0);
+
+	/* The generation moved... */
+	mu_check(dbfile_query_u64(db->db,
+		 "select dedupe_seq from files") == 7);
+	/* ...and nothing else did. */
+	mu_check(rows(db, "files") == 1);
+	mu_check(rows(db, "blocks") == 1);
+	mu_check(dbfile_load_checkpoint(db, id, &got));
+	mu_check(got.loff == cp.loff && got.ext_len == cp.ext_len);
+	mu_check(!memcmp(got.file_state, state, running_checksum_state_size()));
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * The startup prune drops rows that were never hashed - a digest is what says
+ * a file was finished - but it has to spare rows an interrupted run left a
+ * checkpoint for. Before #159 it deleted every digest-less row, which is
+ * exactly what kept a resumable file from surviving to be resumed.
+ */
+MU_TEST(test_dbfile_pruning_unscanned_files_spares_checkpointed_ones) {
+	struct dbhandle *db = memdb();
+	_cleanup_(file_cleanup) struct file partway = {0};
+	_cleanup_(file_cleanup) struct file abandoned = {0};
+	_cleanup_(freep) void *state = NULL;
+	struct scan_checkpoint cp = mkcheckpoint(&state, 4096);
+
+	/* A finished file: has a digest. */
+	put_file(db, "/tree/done", 1, 1, 1);
+
+	/* One interrupted with a checkpoint, one simply never hashed. Neither
+	 * has a digest, which is the only thing the prune looks at. */
+	mu_check(file_set_filename(&partway, "/tree/partway") == 0);
+	partway.ino = 2; partway.subvol = 1; partway.size = 8192;
+	int64_t pid = dbfile_store_file_info(db, &partway);
+
+	mu_check(file_set_filename(&abandoned, "/tree/abandoned") == 0);
+	abandoned.ino = 3; abandoned.subvol = 1; abandoned.size = 8192;
+	dbfile_store_file_info(db, &abandoned);
+
+	mu_check(dbfile_store_checkpoint(db, pid, &cp) == 0);
+	mu_check(rows(db, "files") == 3);
+
+	mu_check(dbfile_prune_unscanned_files(db) == 0);
+
+	/* The finished one and the checkpointed one survive; the third goes. */
+	mu_check(rows(db, "files") == 2);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from files where filename = '/tree/partway'") == 1);
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from files where filename = '/tree/abandoned'") == 0);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * The self-describing hashfile (#182): a 1.7.x file stores
+ * opt_skip_readonly_subvols = -1, the old tri-state "auto". That means "the
+ * user never asked", so a replay must adopt today's default rather than
+ * inheriting a dead one - only an explicit 1 survives. Getting this backwards
+ * silently skips every snapshot on a scheduled run.
+ */
+MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
+	struct dbhandle *db = memdb();
+	char *roots[] = { (char *)"/data", (char *)"/srv" };
+	char *excludes[] = { (char *)"*.iso" };
+	struct scan_config out = {
+		.run_dedupe = 1, .recurse = 1, .skip_zeroes = 0,
+		.skip_readonly_subvols = 1, .only_whole_files = 0,
+		.do_block_hash = 1, .dedupe_same_file = 0,
+		.min_filesize = 1024, .max_filesize = 1u << 20,
+		.roots = roots, .nroots = 2,
+		.excludes = excludes, .nexcludes = 1,
+	};
+	struct scan_config in = {0};
+
+	/* 0 means "nothing stored", which is what a fresh hashfile answers and
+	 * what tells a replay from a first run. */
+	mu_check(dbfile_load_scan_config(db, &in) == 0);
+	mu_check(in.nroots == 0);
+
+	mu_check(dbfile_store_scan_config(db, &out) == 0);
+	mu_check(dbfile_load_scan_config(db, &in) == 1);
+
+	mu_check(in.run_dedupe == 1 && in.recurse == 1 && in.do_block_hash == 1);
+	mu_check(in.min_filesize == 1024 && in.max_filesize == (1u << 20));
+	mu_check(in.skip_readonly_subvols == 1);	/* an explicit 1 survives */
+	mu_check(in.nroots == 2 && in.nexcludes == 1);
+	mu_check(!strcmp(in.roots[0], "/data") && !strcmp(in.roots[1], "/srv"));
+	mu_check(!strcmp(in.excludes[0], "*.iso"));
+	scan_config_free(&in);
+
+	/* What a 1.7.x hashfile holds. */
+	sqlite3_exec(db->db, "update config set keyval = -1 "
+			     "where keyname = 'opt_skip_readonly_subvols'",
+		     NULL, NULL, NULL);
+	memset(&in, 0, sizeof(in));
+	mu_check(dbfile_load_scan_config(db, &in) == 1);
+	mu_check(in.skip_readonly_subvols == 0);	/* coerced to the new default */
+	scan_config_free(&in);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * Run history, which `--history` and `--json` are read straight out of. The
+ * lifetime totals accumulate across runs while the error buckets report only
+ * the *last* one - a monitoring consumer alarms on the second and trends on
+ * the first, so conflating them either hides a fault or re-raises a fixed one
+ * forever.
+ */
+MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
+	struct dbhandle *db = memdb();
+	struct run_record first = {
+		.ts = 1000, .duration_ms = 500, .files_scanned = 10,
+		.reclaimed = 4096, .groups = 2, .deduped = 1,
+		.skip_permission = 3, .skip_unreadable = 1,
+	};
+	struct run_record second = {
+		.ts = 2000, .duration_ms = 700, .files_scanned = 5,
+		.reclaimed = 8192, .groups = 1, .deduped = 1,
+		.skip_permission = 0, .skip_unreadable = 0,
+		.readonly_subvols = 4,
+	};
+	struct run_summary s = {0};
+
+	mu_check(dbfile_record_run(db, &first) == 0);
+	mu_check(dbfile_record_run(db, &second) == 0);
+	mu_check(dbfile_get_run_summary(db, &s) == 0);
+
+	mu_check(s.runs == 2);
+	mu_check(s.total_reclaimed == 4096 + 8192);	/* lifetime */
+	mu_check(s.total_files == 15);
+	mu_check(s.first_ts == 1000 && s.last_ts == 2000);
+
+	/* The most recent run had no permission errors, so the alarm clears
+	 * even though an earlier run had three. */
+	mu_check(s.last_skip_permission == 0);
+	mu_check(s.last_skip_unreadable == 0);
+	mu_check(s.last_readonly_subvols == 4);
+	/* ...while the lifetime figure still remembers them. */
+	mu_check(s.total_skip_errors == 4);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * #206's second bar. A layout key is a 128-bit digest, so it cannot be the
+ * whole test: before copying a donor's hashes the scan re-checks the donor's
+ * stored (loff, poff, len) triples one at a time. A miss costs one redundant
+ * hash; a false hit stores a digest of bytes the file never had, and nothing
+ * downstream could tell that from a file with no duplicate.
+ */
+MU_TEST(test_dbfile_layout_matches_compares_every_record) {
+	struct dbhandle *db = memdb();
+	int64_t donor = put_file(db, "/snap/a", 1, 1, 1);
+	struct extent_csum stored[2] = {
+		{ .loff = 0,    .poff = 4096,  .len = 8192 },
+		{ .loff = 8192, .poff = 65536, .len = 4096 },
+	};
+	struct fm_rec same[]  = { {0, 4096, 8192, 0}, {8192, 65536, 4096, 0} };
+	struct fm_rec moved[] = { {0, 4096, 8192, 0}, {8192, 69632, 4096, 0} };
+	struct fm_rec shortr[] = { {0, 4096, 8192, 0} };
+	struct fm_rec longer[] = { {0, 4096, 8192, 0}, {8192, 65536, 4096, 0},
+				   {12288, 73728, 4096, 0} };
+	struct fiemap *fm;
+
+	mu_check(dbfile_store_extent_hashes(db, donor, 2, stored) == 0);
+
+	fm = mkmap(same, 2);
+	mu_check(dbfile_layout_matches(db, donor, fm) == 1);
+	free(fm);
+
+	/* One address moved: not the same storage. */
+	fm = mkmap(moved, 2);
+	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
+	free(fm);
+
+	/* The candidate has fewer records than the donor... */
+	fm = mkmap(shortr, 1);
+	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
+	free(fm);
+
+	/* ...and more. Both directions, because a prefix match is still a miss. */
+	fm = mkmap(longer, 3);
+	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
+	free(fm);
+
+	/*
+	 * A donor whose rows are gone - an aborted batch, a hardlink cascade -
+	 * verifies as a miss by construction rather than needing a guard, which
+	 * is why the in-memory map can hold only a key and a file id.
+	 */
+	int64_t empty = put_file(db, "/snap/b", 2, 1, 1);
+
+	fm = mkmap(same, 2);
+	mu_check(dbfile_layout_matches(db, empty, fm) == 0);
+	free(fm);
+
+	/*
+	 * And the case that needs saying separately: *both* sides empty. The
+	 * record counts then agree at zero, so a check that only compared them
+	 * would call two files with no extents a match and copy one's digest
+	 * onto the other. "No records" is not evidence of identical storage,
+	 * it is the absence of evidence.
+	 */
+	fm = mkmap(same, 0);
+	mu_check(dbfile_layout_matches(db, empty, fm) == 0);
+	free(fm);
+
+	dbfile_close_handle(db);
+}
+
+/*
+ * The copy itself (#206): the destination ends up with the donor's extent rows,
+ * block rows and digest. Everything downstream reads those, so a copy that
+ * dropped one of the three would leave a file that looks scanned and dedupes
+ * against nothing.
+ */
+MU_TEST(test_dbfile_copying_a_donor_brings_all_three) {
+	struct dbhandle *db = memdb();
+	int64_t donor = put_file(db, "/snap/a", 1, 1, 1);
+	int64_t dst;
+	struct block_csum blocks[2] = { { .loff = 0 }, { .loff = 4096 } };
+	struct extent_csum extents[1] = { { .loff = 0, .poff = 4096, .len = 8192 } };
+	_cleanup_(file_cleanup) struct file f = {0};
+
+	mu_check(dbfile_store_block_hashes(db, donor, 2, blocks) == 0);
+	mu_check(dbfile_store_extent_hashes(db, donor, 1, extents) == 0);
+
+	/* The destination starts with no digest, the way a file does before it
+	 * has been hashed. */
+	mu_check(file_set_filename(&f, "/snap/b") == 0);
+	f.ino = 2; f.subvol = 1; f.size = 8192; f.mtime = 1000;
+	dst = dbfile_store_file_info(db, &f);
+	mu_check(dst > 0);
+
+	mu_check(dbfile_copy_scanned_file(db, dst, donor, 0) == 0);
+
+	mu_check(rows(db, "blocks") == 4);	/* two each */
+	mu_check(rows(db, "extents") == 2);
+	/* And the destination now has a digest, so it reads as scanned. */
+	mu_check(dbfile_query_u64(db->db,
+		 "select count(*) from files where digest is not null") == 2);
+
+	dbfile_close_handle(db);
+}
+
 /*
  * ---------------------------------------------------------------------------
  * Property-based tests. See src/proptest.h for the harness and for why the
@@ -2591,6 +3018,17 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_glob_rejects_malformed);
 	MU_RUN_TEST(test_glob_empty_set_matches_nothing);
 	MU_RUN_TEST(test_dedupe_classify_probe);
+
+	/* The hashfile, against an in-memory SQLite - the same path a run
+	 * without --hashfile takes, so none of this is a test-only seam. */
+	MU_RUN_TEST(test_dbfile_hardlink_replaces_rather_than_adds);
+	MU_RUN_TEST(test_dbfile_dropping_a_file_takes_its_hashes);
+	MU_RUN_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint);
+	MU_RUN_TEST(test_dbfile_pruning_unscanned_files_spares_checkpointed_ones);
+	MU_RUN_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto);
+	MU_RUN_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run);
+	MU_RUN_TEST(test_dbfile_layout_matches_compares_every_record);
+	MU_RUN_TEST(test_dbfile_copying_a_donor_brings_all_three);
 
 	/* Property-based (src/proptest.h). Grouped rather than interleaved: they
 	 * are a different question about the same code, and a failure here names

--- a/src/tests.c
+++ b/src/tests.c
@@ -1784,22 +1784,38 @@ MU_TEST(test_running_checksum_rejects_foreign_state) {
  * file whose stored hashes vanish, a replay that adopts the wrong default.
  */
 
-/* A fresh in-memory hashfile. The shared-cache URI means every handle in this
- * process sees the same database, so each test drops what it made. */
+/*
+ * A fresh in-memory hashfile.
+ *
+ * Nothing is cleared, because there is nothing to clear: a shared-cache
+ * in-memory database exists only while a connection is open, so the moment the
+ * last handle closes SQLite frees it, tables and all. Every caller below takes
+ * its handle with `_cleanup_(sqlite3_close_cleanup)`, which is what makes that
+ * true even when an assertion fails partway - `mu_check()` expands to a bare
+ * `return`, so a hand-written close is skipped exactly when a test goes red.
+ * Isolation by construction rather than by a hand-maintained `delete from`
+ * list, which goes stale silently the first time the schema grows a table.
+ *
+ * Costs one schema build and 30 prepared statements per test, measured at
+ * 1.6 ms. That is 5% of the suite and 0.07% of the mutation tool's hang
+ * timeout, which is the budget that actually binds - a shared handle would buy
+ * the 13 ms back and put isolation on the stale list instead.
+ */
 static struct dbhandle *memdb(void)
 {
 	struct dbhandle *db = dbfile_open_handle(NULL);
 
 	if (!db)
 		abort();	/* the test cannot run at all, not a finding */
-	sqlite3_exec(db->db, "delete from scan_checkpoints; delete from blocks;"
-			     "delete from extents; delete from files;"
-			     "delete from config; delete from scan_roots;"
-			     "delete from scan_excludes; delete from run_history;",
-		     NULL, NULL, NULL);
 	return db;
 }
 
+/*
+ * Row count for the tables no shipped API reports. `files`, `blocks` and
+ * `extents` deliberately go through dbfile_get_stats() instead - that is what
+ * `--stats` and `--json` print, so asserting through it covers the production
+ * counters as well as the tables.
+ */
 static uint64_t rows(struct dbhandle *db, const char *table)
 {
 	char sql[64];
@@ -1808,33 +1824,61 @@ static uint64_t rows(struct dbhandle *db, const char *table)
 	return dbfile_query_u64(db->db, sql);
 }
 
-/*
- * A checkpoint carries a real running-checksum state - `file_state` is bound as
- * a blob of running_checksum_state_size() bytes, so a NULL there is a
- * constraint failure rather than an empty column. Caller frees `*state`.
- */
-static struct scan_checkpoint mkcheckpoint(void **state, uint64_t loff)
+/* The three counts oans itself reports. */
+static struct dbfile_stats stats_of(struct dbhandle *db)
 {
+	struct dbfile_stats st = {0};
+
+	if (dbfile_get_stats(db, &st))
+		abort();
+	return st;
+}
+
+/*
+ * A checkpoint carries a real running-checksum state: `file_state` is bound as
+ * a blob of running_checksum_state_size() bytes, so a NULL there is a
+ * constraint failure rather than an empty column. The caller owns the buffers,
+ * which is also how dbfile_load_checkpoint() reads one back - one convention,
+ * not two.
+ *
+ * `ext_state` is the half that matters most (#159): a checkpoint at an extent
+ * boundary needs none, but btrfs reports a contiguously allocated file as a
+ * single fiemap extent however large it is, so the boundary-only first cut
+ * never fired. Pass NULL for the boundary case and a buffer for the in-flight
+ * one.
+ */
+static struct scan_checkpoint mkcheckpoint(void *file_state, void *ext_state,
+					   uint64_t loff)
+{
+	size_t len = running_checksum_state_size();
 	struct running_checksum *c = start_running_checksum();
 	struct scan_checkpoint cp = {
 		.loff = loff, .size = loff * 2, .mtime = 1000,
-		.ext_loff = 0, .ext_len = 4096, .has_ext_state = false,
+		.ext_loff = 0, .ext_len = 4096,
+		.file_state = file_state,
+		.ext_state = ext_state,
+		.has_ext_state = ext_state != NULL,
 	};
 
-	*state = malloc(running_checksum_state_size());
-	if (!*state)
-		abort();
 	add_to_running_checksum(c, (unsigned char *)"some bytes", 10);
-	if (running_checksum_save(c, *state, running_checksum_state_size()))
+	if (running_checksum_save(c, file_state, len))
 		abort();
 	finish_running_checksum(c, NULL);
-	cp.file_state = *state;
+	if (ext_state)
+		memcpy(ext_state, file_state, len);
 	return cp;
 }
 
 /* Store one file row; returns its id. */
-static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
-			uint64_t subvol, unsigned int seq)
+/*
+ * A row for a file that has been *seen* but not finished - which is what
+ * `dbfile_store_file_info` alone produces, because it deliberately writes no
+ * digest. The digest is precisely what tells a scanned file from one an
+ * interrupted run left partway, so this is the shape the startup prune is
+ * about, and the two helpers are split so a test can ask for either.
+ */
+static int64_t put_unscanned_file(struct dbhandle *db, const char *name,
+				  uint64_t ino, uint64_t subvol)
 {
 	_cleanup_(file_cleanup) struct file f = {0};
 	int64_t id;
@@ -1846,17 +1890,18 @@ static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
 	f.size = 4096;
 	f.blocks = 1;
 	f.mtime = 1000;
-	f.dedupe_seq = seq;
+	f.dedupe_seq = 1;
 	id = dbfile_store_file_info(db, &f);
 	if (id <= 0)
 		abort();
-	/*
-	 * A digest is written separately, and only once the file has been
-	 * hashed all the way through - `dbfile_store_file_info` deliberately
-	 * writes none. That is what tells a scanned row from one an interrupted
-	 * run left partway, so a helper that skipped this would produce rows
-	 * the startup prune deletes.
-	 */
+	return id;
+}
+
+/* ... and the same row finished, the way a completed hash leaves it. */
+static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
+			uint64_t subvol)
+{
+	int64_t id = put_unscanned_file(db, name, ino, subvol);
 	unsigned char digest[DIGEST_LEN];
 
 	memset(digest, (int)ino, DIGEST_LEN);
@@ -1865,63 +1910,76 @@ static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
 	return id;
 }
 
+/* Build the map, ask, free - the shape share() and key_of() above have. */
+static int layout_matches(struct dbhandle *db, int64_t fileid,
+			  const struct fm_rec *recs, unsigned int n)
+{
+	struct fiemap *fm = mkmap(recs, n);
+	int ret = dbfile_layout_matches(db, fileid, fm);
+
+	free(fm);
+	return ret;
+}
+
 /*
- * The hardlink hazard, from CLAUDE.md: `files` has UNIQUE(ino, subvol), and
- * storing a second link to the same inode is an INSERT OR REPLACE - which
- * *deletes* the first row and cascades its hashes away. The scan guards this
- * with an in-memory seen_inodes set rather than in SQL, so what this pins is
- * the shape of the hazard: two names, one inode, one surviving row. A batch
- * that hit this could empty a hashfile while exiting 0.
+ * `files` is unique on the *pair* (ino, subvol), and both halves matter: a
+ * subvolume id and an inode number are each 64 bits and two different files can
+ * share either one alone. Conflating them is the same trap seen_inode() has, so
+ * it is pinned here as a property of the schema.
+ *
+ * What this deliberately does *not* assert is that a second link destroys the
+ * first row. That is true today - storing one is an INSERT OR REPLACE - but it
+ * is the hazard, not the contract: the protection is an in-memory seen_inodes
+ * set in file_scan.c, pinned end-to-end by tests/integration/test_hardlinks.py.
+ * A test demanding the destructive behaviour would go red on the day someone
+ * makes the write safe, and read as a regression while the tests that actually
+ * guard it stayed green. If that day comes, delete this comment rather than
+ * repairing anything.
  */
-MU_TEST(test_dbfile_hardlink_replaces_rather_than_adds) {
-	struct dbhandle *db = memdb();
+MU_TEST(test_dbfile_files_are_unique_on_the_inode_pair) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
 
-	int64_t first = put_file(db, "/tree/a", 42, 1, 1);
+	put_file(db, "/tree/a", 42, 1);
+	mu_check(stats_of(db).num_files == 1);
 
-	mu_check(rows(db, "files") == 1);
+	/* A different inode in the same subvolume is a different file... */
+	put_file(db, "/tree/c", 43, 1);
+	mu_check(stats_of(db).num_files == 2);
 
-	/* A second link to the same inode: same (ino, subvol), different name. */
-	int64_t second = put_file(db, "/tree/b", 42, 1, 1);
+	/* ...and so is the same inode number in a different subvolume. */
+	put_file(db, "/other/a", 42, 2);
+	mu_check(stats_of(db).num_files == 3);
 
-	mu_check(rows(db, "files") == 1);	/* replaced, not added */
-	mu_check(second != first);		/* and it is a *new* row */
-
-	/* A different inode is a different row, so the uniqueness is on the
-	 * inode pair and not on something coarser. */
-	put_file(db, "/tree/c", 43, 1, 1);
-	mu_check(rows(db, "files") == 2);
-
-	/* Different subvol, same inode number: also distinct - the two 64-bit
-	 * fields must not be conflated (the same trap seen_inode() has). */
-	put_file(db, "/other/a", 42, 2, 1);
-	mu_check(rows(db, "files") == 3);
-
-	dbfile_close_handle(db);
 }
 
 /*
  * A file's hashes belong to it: dropping the row takes them with it, via the
- * ON DELETE CASCADE the prune relies on. If that FK is ever lost, pruning a
- * deleted file leaves orphan hashes that later match nothing and are never
- * collected.
+ * ON DELETE CASCADE. If that FK is ever lost, pruning a deleted file leaves
+ * orphan hashes that match nothing and are never collected.
+ *
+ * Driven through dbfile_prune_missing_files() rather than dbfile_remove_file(),
+ * so it exercises the caller the comment is about. That needs no filesystem:
+ * the rule is stat-based, and "/tree/a" genuinely does not exist, which is
+ * exactly the ENOENT the prune looks for. It is stat-based rather than
+ * "delete what this run did not walk" precisely so that scanning a subdirectory
+ * cannot wipe rows that are merely out of scope.
  */
-MU_TEST(test_dbfile_dropping_a_file_takes_its_hashes) {
-	struct dbhandle *db = memdb();
-	int64_t id = put_file(db, "/tree/a", 1, 1, 1);
+MU_TEST(test_dbfile_pruning_a_deleted_file_takes_its_hashes) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t id = put_file(db, "/tree/a", 1, 1);
 	struct block_csum blocks[2] = { { .loff = 0 }, { .loff = 4096 } };
 	struct extent_csum extents[1] = { { .loff = 0, .poff = 8192, .len = 8192 } };
 
 	mu_check(dbfile_store_block_hashes(db, id, 2, blocks) == 0);
 	mu_check(dbfile_store_extent_hashes(db, id, 1, extents) == 0);
-	mu_check(rows(db, "blocks") == 2);
-	mu_check(rows(db, "extents") == 1);
+	mu_check(stats_of(db).num_b_hashes == 2);
+	mu_check(stats_of(db).num_e_hashes == 1);
 
-	mu_check(dbfile_remove_file(db, "/tree/a") == 0);
-	mu_check(rows(db, "files") == 0);
-	mu_check(rows(db, "blocks") == 0);	/* cascaded */
-	mu_check(rows(db, "extents") == 0);
+	mu_check(dbfile_prune_missing_files(db, NULL) == 1);
+	mu_check(stats_of(db).num_files == 0);
+	mu_check(stats_of(db).num_b_hashes == 0);	/* cascaded */
+	mu_check(stats_of(db).num_e_hashes == 0);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -1933,15 +1991,20 @@ MU_TEST(test_dbfile_dropping_a_file_takes_its_hashes) {
  * the 1 TiB file this feature exists for is hours.
  */
 MU_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint) {
-	struct dbhandle *db = memdb();
-	int64_t id = put_file(db, "/tree/big", 1, 1, 1);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t id = put_file(db, "/tree/big", 1, 1);
 	struct block_csum blocks[1] = { { .loff = 0 } };
-	_cleanup_(freep) void *state = NULL;
-	struct scan_checkpoint cp = mkcheckpoint(&state, 1u << 30);
+	size_t len = running_checksum_state_size();
+	_cleanup_(freep) void *file_state = malloc(len);
+	_cleanup_(freep) void *ext_state = malloc(len);
+	/* Interrupted mid-extent, which is the case that fires in practice:
+	 * btrfs reports a contiguously allocated file as one fiemap extent
+	 * however large it is, so a boundary-only checkpoint never happens. */
+	struct scan_checkpoint cp = mkcheckpoint(file_state, ext_state, 1u << 30);
 	/* load_checkpoint copies into buffers the caller owns; a zeroed struct
 	 * would be a write through NULL. */
-	_cleanup_(freep) void *got_file = malloc(running_checksum_state_size());
-	_cleanup_(freep) void *got_ext = malloc(running_checksum_state_size());
+	_cleanup_(freep) void *got_file = malloc(len);
+	_cleanup_(freep) void *got_ext = malloc(len);
 	struct scan_checkpoint got = { .file_state = got_file, .ext_state = got_ext };
 
 	mu_check(dbfile_store_block_hashes(db, id, 1, blocks) == 0);
@@ -1959,9 +2022,12 @@ MU_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint) {
 	mu_check(rows(db, "blocks") == 1);
 	mu_check(dbfile_load_checkpoint(db, id, &got));
 	mu_check(got.loff == cp.loff && got.ext_len == cp.ext_len);
-	mu_check(!memcmp(got.file_state, state, running_checksum_state_size()));
+	mu_check(!memcmp(got.file_state, file_state, len));
+	/* The in-flight extent digest rides along, or a resume that lands inside
+	 * an extent has to discard the checkpoint and start the file over. */
+	mu_check(got.has_ext_state);
+	mu_check(!memcmp(got.ext_state, ext_state, len));
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -1971,38 +2037,34 @@ MU_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint) {
  * exactly what kept a resumable file from surviving to be resumed.
  */
 MU_TEST(test_dbfile_pruning_unscanned_files_spares_checkpointed_ones) {
-	struct dbhandle *db = memdb();
-	_cleanup_(file_cleanup) struct file partway = {0};
-	_cleanup_(file_cleanup) struct file abandoned = {0};
-	_cleanup_(freep) void *state = NULL;
-	struct scan_checkpoint cp = mkcheckpoint(&state, 4096);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(freep) void *state = malloc(running_checksum_state_size());
+	/* No ext_state: a checkpoint that happened to land on an extent
+	 * boundary, which is the other half of what dbfile_load_checkpoint
+	 * validates. */
+	struct scan_checkpoint cp = mkcheckpoint(state, NULL, 4096);
 
 	/* A finished file: has a digest. */
-	put_file(db, "/tree/done", 1, 1, 1);
+	put_file(db, "/tree/done", 1, 1);
 
 	/* One interrupted with a checkpoint, one simply never hashed. Neither
 	 * has a digest, which is the only thing the prune looks at. */
-	mu_check(file_set_filename(&partway, "/tree/partway") == 0);
-	partway.ino = 2; partway.subvol = 1; partway.size = 8192;
-	int64_t pid = dbfile_store_file_info(db, &partway);
+	int64_t pid = put_unscanned_file(db, "/tree/partway", 2, 1);
 
-	mu_check(file_set_filename(&abandoned, "/tree/abandoned") == 0);
-	abandoned.ino = 3; abandoned.subvol = 1; abandoned.size = 8192;
-	dbfile_store_file_info(db, &abandoned);
+	put_unscanned_file(db, "/tree/abandoned", 3, 1);
 
 	mu_check(dbfile_store_checkpoint(db, pid, &cp) == 0);
-	mu_check(rows(db, "files") == 3);
+	mu_check(stats_of(db).num_files == 3);
 
 	mu_check(dbfile_prune_unscanned_files(db) == 0);
 
 	/* The finished one and the checkpointed one survive; the third goes. */
-	mu_check(rows(db, "files") == 2);
+	mu_check(stats_of(db).num_files == 2);
 	mu_check(dbfile_query_u64(db->db,
 		 "select count(*) from files where filename = '/tree/partway'") == 1);
 	mu_check(dbfile_query_u64(db->db,
 		 "select count(*) from files where filename = '/tree/abandoned'") == 0);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -2013,7 +2075,7 @@ MU_TEST(test_dbfile_pruning_unscanned_files_spares_checkpointed_ones) {
  * silently skips every snapshot on a scheduled run.
  */
 MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
-	struct dbhandle *db = memdb();
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
 	char *roots[] = { (char *)"/data", (char *)"/srv" };
 	char *excludes[] = { (char *)"*.iso" };
 	struct scan_config out = {
@@ -2051,7 +2113,6 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	mu_check(in.skip_readonly_subvols == 0);	/* coerced to the new default */
 	scan_config_free(&in);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -2062,7 +2123,7 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
  * forever.
  */
 MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
-	struct dbhandle *db = memdb();
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
 	struct run_record first = {
 		.ts = 1000, .duration_ms = 500, .files_scanned = 10,
 		.reclaimed = 4096, .groups = 2, .deduped = 1,
@@ -2093,7 +2154,6 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
 	/* ...while the lifetime figure still remembers them. */
 	mu_check(s.total_skip_errors == 4);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -2104,8 +2164,8 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
  * downstream could tell that from a file with no duplicate.
  */
 MU_TEST(test_dbfile_layout_matches_compares_every_record) {
-	struct dbhandle *db = memdb();
-	int64_t donor = put_file(db, "/snap/a", 1, 1, 1);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t donor = put_file(db, "/snap/a", 1, 1);
 	struct extent_csum stored[2] = {
 		{ .loff = 0,    .poff = 4096,  .len = 8192 },
 		{ .loff = 8192, .poff = 65536, .len = 4096 },
@@ -2115,39 +2175,25 @@ MU_TEST(test_dbfile_layout_matches_compares_every_record) {
 	struct fm_rec shortr[] = { {0, 4096, 8192, 0} };
 	struct fm_rec longer[] = { {0, 4096, 8192, 0}, {8192, 65536, 4096, 0},
 				   {12288, 73728, 4096, 0} };
-	struct fiemap *fm;
 
 	mu_check(dbfile_store_extent_hashes(db, donor, 2, stored) == 0);
 
-	fm = mkmap(same, 2);
-	mu_check(dbfile_layout_matches(db, donor, fm) == 1);
-	free(fm);
-
+	mu_check(layout_matches(db, donor, same, ARRAY_SIZE(same)) == 1);
 	/* One address moved: not the same storage. */
-	fm = mkmap(moved, 2);
-	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
-	free(fm);
-
-	/* The candidate has fewer records than the donor... */
-	fm = mkmap(shortr, 1);
-	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
-	free(fm);
-
-	/* ...and more. Both directions, because a prefix match is still a miss. */
-	fm = mkmap(longer, 3);
-	mu_check(dbfile_layout_matches(db, donor, fm) == 0);
-	free(fm);
+	mu_check(layout_matches(db, donor, moved, ARRAY_SIZE(moved)) == 0);
+	/* The candidate has fewer records than the donor, and more. Both
+	 * directions, because a prefix match is still a miss. */
+	mu_check(layout_matches(db, donor, shortr, ARRAY_SIZE(shortr)) == 0);
+	mu_check(layout_matches(db, donor, longer, ARRAY_SIZE(longer)) == 0);
 
 	/*
 	 * A donor whose rows are gone - an aborted batch, a hardlink cascade -
 	 * verifies as a miss by construction rather than needing a guard, which
 	 * is why the in-memory map can hold only a key and a file id.
 	 */
-	int64_t empty = put_file(db, "/snap/b", 2, 1, 1);
+	int64_t empty = put_file(db, "/snap/b", 2, 1);
 
-	fm = mkmap(same, 2);
-	mu_check(dbfile_layout_matches(db, empty, fm) == 0);
-	free(fm);
+	mu_check(layout_matches(db, empty, same, ARRAY_SIZE(same)) == 0);
 
 	/*
 	 * And the case that needs saying separately: *both* sides empty. The
@@ -2156,11 +2202,8 @@ MU_TEST(test_dbfile_layout_matches_compares_every_record) {
 	 * onto the other. "No records" is not evidence of identical storage,
 	 * it is the absence of evidence.
 	 */
-	fm = mkmap(same, 0);
-	mu_check(dbfile_layout_matches(db, empty, fm) == 0);
-	free(fm);
+	mu_check(layout_matches(db, empty, same, 0) == 0);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -2170,32 +2213,27 @@ MU_TEST(test_dbfile_layout_matches_compares_every_record) {
  * against nothing.
  */
 MU_TEST(test_dbfile_copying_a_donor_brings_all_three) {
-	struct dbhandle *db = memdb();
-	int64_t donor = put_file(db, "/snap/a", 1, 1, 1);
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t donor = put_file(db, "/snap/a", 1, 1);
 	int64_t dst;
 	struct block_csum blocks[2] = { { .loff = 0 }, { .loff = 4096 } };
 	struct extent_csum extents[1] = { { .loff = 0, .poff = 4096, .len = 8192 } };
-	_cleanup_(file_cleanup) struct file f = {0};
 
 	mu_check(dbfile_store_block_hashes(db, donor, 2, blocks) == 0);
 	mu_check(dbfile_store_extent_hashes(db, donor, 1, extents) == 0);
 
 	/* The destination starts with no digest, the way a file does before it
 	 * has been hashed. */
-	mu_check(file_set_filename(&f, "/snap/b") == 0);
-	f.ino = 2; f.subvol = 1; f.size = 8192; f.mtime = 1000;
-	dst = dbfile_store_file_info(db, &f);
-	mu_check(dst > 0);
+	dst = put_unscanned_file(db, "/snap/b", 2, 1);
 
 	mu_check(dbfile_copy_scanned_file(db, dst, donor, 0) == 0);
 
-	mu_check(rows(db, "blocks") == 4);	/* two each */
-	mu_check(rows(db, "extents") == 2);
+	mu_check(stats_of(db).num_b_hashes == 4);	/* two each */
+	mu_check(stats_of(db).num_e_hashes == 2);
 	/* And the destination now has a digest, so it reads as scanned. */
 	mu_check(dbfile_query_u64(db->db,
 		 "select count(*) from files where digest is not null") == 2);
 
-	dbfile_close_handle(db);
 }
 
 /*
@@ -3021,8 +3059,8 @@ MU_TEST_SUITE(test_suite) {
 
 	/* The hashfile, against an in-memory SQLite - the same path a run
 	 * without --hashfile takes, so none of this is a test-only seam. */
-	MU_RUN_TEST(test_dbfile_hardlink_replaces_rather_than_adds);
-	MU_RUN_TEST(test_dbfile_dropping_a_file_takes_its_hashes);
+	MU_RUN_TEST(test_dbfile_files_are_unique_on_the_inode_pair);
+	MU_RUN_TEST(test_dbfile_pruning_a_deleted_file_takes_its_hashes);
 	MU_RUN_TEST(test_dbfile_advancing_the_generation_keeps_hashes_and_checkpoint);
 	MU_RUN_TEST(test_dbfile_pruning_unscanned_files_spares_checkpointed_ones);
 	MU_RUN_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto);

--- a/src/tests.c
+++ b/src/tests.c
@@ -2139,6 +2139,7 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	memset(&out, 0, sizeof(out));
 	out.roots = roots;
 	out.nroots = 2;
+	out.min_filesize = 4096;
 	mu_check(dbfile_store_scan_config(db, &out) == 0);
 	memset(&in, 0, sizeof(in));
 	mu_check(dbfile_load_scan_config(db, &in) == 1);
@@ -2154,11 +2155,26 @@ MU_TEST(test_dbfile_scan_config_round_trips_and_coerces_the_old_auto) {
 	 */
 	exec(db, "delete from config where keyname in "
 		 "('opt_min_filesize', 'opt_max_filesize')");
-	memset(&in, 0, sizeof(in));
-	in.min_filesize = 99;
-	in.max_filesize = 99;
+	memset(&in, 0x5a, sizeof(in));
 	mu_check(dbfile_load_scan_config(db, &in) == 1);
 	mu_check(in.min_filesize == 0 && in.max_filesize == 0);
+	mu_check(in.run_dedupe == 0 && in.nroots == 2);
+	scan_config_free(&in);
+
+	/*
+	 * Only the additive one missing, which is what a hashfile written
+	 * before --max-filesize existed actually looks like. The two limits
+	 * are read through one scratch variable, so a reset dropped between
+	 * them silently gives max_filesize the value of min - and every file
+	 * above the lower limit stops being scanned, on a run that otherwise
+	 * looks identical.
+	 */
+	mu_check(dbfile_store_scan_config(db, &out) == 0);
+	exec(db, "delete from config where keyname = 'opt_max_filesize'");
+	memset(&in, 0x5a, sizeof(in));
+	mu_check(dbfile_load_scan_config(db, &in) == 1);
+	mu_check(in.min_filesize == 4096);
+	mu_check(in.max_filesize == 0);
 	scan_config_free(&in);
 }
 
@@ -2176,11 +2192,18 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
 		.reclaimed = 4096, .groups = 2, .deduped = 1,
 		.skip_permission = 3, .skip_unreadable = 1,
 	};
+	/* Five adjacent columns read back by index, so five distinct values:
+	 * two buckets that share one cannot tell a swapped pair apart, and
+	 * a bucket left at 0 cannot tell a dropped read from a real zero. */
 	struct run_record second = {
 		.ts = 2000, .duration_ms = 700, .files_scanned = 5,
 		.reclaimed = 8192, .groups = 1, .deduped = 1,
-		.skip_permission = 0, .skip_unreadable = 0,
-		.readonly_subvols = 4,
+		.skip_permission = 11, .skip_unreadable = 22,
+		.skip_path_too_long = 33, .skip_unsupported_fs = 44,
+		.readonly_subvols = 55,
+	};
+	struct run_record third = {
+		.ts = 3000, .duration_ms = 100, .files_scanned = 1,
 	};
 	/* Deliberately not zeroed: the summary clears what it does not fill,
 	 * so a caller's stack garbage cannot be read back as a lifetime total. */
@@ -2188,6 +2211,22 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
 
 	memset(&s, 0x5a, sizeof(s));
 
+	/*
+	 * A hashfile nobody has run against yet. Every field must be zero,
+	 * which is what says the summary clears the caller's struct rather
+	 * than filling in only what its two queries return - with no rows,
+	 * they return nothing at all. (It has to be asked here: memdb()
+	 * handles all share one in-memory database, so there is no such thing
+	 * as a second, empty one within a test.)
+	 */
+	mu_check(dbfile_get_run_summary(db, &s) == 0);
+	mu_check(s.runs == 0 && s.total_reclaimed == 0 && s.total_files == 0);
+	mu_check(s.first_ts == 0 && s.last_ts == 0 && s.total_skip_errors == 0);
+	mu_check(s.last_skip_permission == 0 && s.last_skip_unreadable == 0);
+	mu_check(s.last_skip_path_too_long == 0);
+	mu_check(s.last_skip_unsupported_fs == 0 && s.last_readonly_subvols == 0);
+
+	memset(&s, 0x5a, sizeof(s));
 	mu_check(dbfile_record_run(db, &first) == 0);
 	mu_check(dbfile_record_run(db, &second) == 0);
 	mu_check(dbfile_get_run_summary(db, &s) == 0);
@@ -2197,13 +2236,28 @@ MU_TEST(test_dbfile_run_history_totals_accumulate_but_skips_are_the_last_run) {
 	mu_check(s.total_files == 15);
 	mu_check(s.first_ts == 1000 && s.last_ts == 2000);
 
-	/* The most recent run had no permission errors, so the alarm clears
-	 * even though an earlier run had three. */
-	mu_check(s.last_skip_permission == 0);
-	mu_check(s.last_skip_unreadable == 0);
-	mu_check(s.last_readonly_subvols == 4);
-	/* ...while the lifetime figure still remembers them. */
-	mu_check(s.total_skip_errors == 4);
+	/* Each bucket, from the most recent run only. */
+	mu_check(s.last_skip_permission == 11);
+	mu_check(s.last_skip_unreadable == 22);
+	mu_check(s.last_skip_path_too_long == 33);
+	mu_check(s.last_skip_unsupported_fs == 44);
+	mu_check(s.last_readonly_subvols == 55);
+	/* ...while the lifetime figure sums both runs. readonly_subvols is not
+	 * an error, so it is not in the total. */
+	mu_check(s.total_skip_errors == 3 + 1 + 11 + 22 + 33 + 44);
+
+	/*
+	 * A later clean run clears the alarm. A lifetime total only ever
+	 * grows, so it cannot tell "last night lost a subtree" from "one run
+	 * did, months ago" - which is the whole reason these are read
+	 * separately from the sums above.
+	 */
+	mu_check(dbfile_record_run(db, &third) == 0);
+	mu_check(dbfile_get_run_summary(db, &s) == 0);
+	mu_check(s.last_skip_permission == 0 && s.last_skip_unreadable == 0);
+	mu_check(s.last_skip_path_too_long == 0);
+	mu_check(s.last_skip_unsupported_fs == 0 && s.last_readonly_subvols == 0);
+	mu_check(s.total_skip_errors == 3 + 1 + 11 + 22 + 33 + 44);
 
 }
 
@@ -2434,11 +2488,23 @@ MU_TEST(test_dbfile_load_checkpoint_declines_what_it_cannot_vouch_for) {
 	struct scan_checkpoint cp = mkcheckpoint(state, NULL, 4096);
 	struct scan_checkpoint got = { .file_state = got_file, .ext_state = got_ext };
 
+	/* Distinct throughout: these are five adjacent columns read by index,
+	 * so two that share a value cannot tell a swapped pair apart. */
+	cp.size = 123456;
+	cp.mtime = 777;
+	cp.ext_loff = 2048;
+	cp.ext_len = 999;
+
 	/* Nothing stored yet: not an error, but not a checkpoint either. */
 	mu_check(!dbfile_load_checkpoint(db, id, &got));
 
 	mu_check(dbfile_store_checkpoint(db, id, &cp) == 0);
 	mu_check(dbfile_load_checkpoint(db, id, &got));
+	mu_check(got.loff == 4096 && got.size == 123456 && got.mtime == 777);
+	mu_check(got.ext_loff == 2048 && got.ext_len == 999);
+	mu_check(!got.has_ext_state);	/* none was stored, so none comes back */
+	/* The saved hash state itself, which is the point of the whole row. */
+	mu_check(!memcmp(got_file, state, len));
 
 	/* A file that has one tells nothing about a file that does not. */
 	int64_t other = put_unscanned_file(db, "/tree/other", 2, 1);
@@ -2510,6 +2576,42 @@ MU_TEST(test_dbfile_pruning_keeps_what_still_exists) {
 	seen_oracle_id = 0;
 	mu_check(dbfile_prune_missing_files(db, claims_seen) == 1);
 	mu_check(stats_of(db).num_files == 1);
+
+	/*
+	 * ENOTDIR, the other way a path stops naming a file: a component of it
+	 * is now a regular file rather than a directory. It is a separate
+	 * errno from ENOENT and the check names both, so a test that only
+	 * deletes files leaves half of that condition free.
+	 */
+	char under[sizeof(present) + 8];
+
+	snprintf(under, sizeof(under), "%s/child", present);
+	put_file(db, under, 4, 1);
+	mu_check(stats_of(db).num_files == 2);
+	mu_check(dbfile_prune_missing_files(db, NULL) == 1);
+	mu_check(dbfile_query_u64(db->db, "select ino from files") == 1);
+
+	/*
+	 * A stat that failed for any *other* reason is not "gone", and the row
+	 * has to survive: EACCES on a directory whose permissions changed, or
+	 * EIO on a disk going bad, would otherwise delete the hashes for files
+	 * that are still there - so the run that was meant to notice the disk
+	 * is failing rebuilds the cache instead. A symlink loop stands in for
+	 * that class, because it is the only one of them a test can produce
+	 * without being root or breaking hardware.
+	 */
+	char loop[] = "/tmp/oans-prune-loop-XXXXXX";
+
+	if (!mkdtemp(loop))
+		abort();
+	rmdir(loop);
+	if (symlink(loop, loop))
+		abort();
+	put_file(db, loop, 5, 1);
+	mu_check(stats_of(db).num_files == 2);
+	mu_check(dbfile_prune_missing_files(db, NULL) == 0);
+	mu_check(stats_of(db).num_files == 2);
+	unlink(loop);
 
 	unlink(present);
 }


### PR DESCRIPTION
First of the "make more of oans reachable from the unit suite" series. Picked by measurement: `dbfile.c` was the largest file the unit suite could not see at all — 1,253 executable lines, none reached, holding the invariants CLAUDE.md carries the most scar tissue about.

## It needs no seam

`dbfile_open_handle(NULL)` opens a shared-cache in-memory SQLite — the same path a run without `--hashfile` already takes. The tests open one, use it, drop it. No filesystem, no btrfs, no scan, and nothing test-only added to production.

## Where it ended up

Four sweeps of `src/dbfile.c`, 1,879 mutants each, same flags, same box:

| | survivors | in the nine targeted functions |
|---|---|---|
| before this PR | 901 | 177 / 371 (48%) |
| after the first pass of tests | 810 | — |
| after strengthening against the sweep | 786 | **95 / 371 (26%)** |
| with three properties added | **785** | — |

`dbfile.c` goes **0% → 47% line coverage**; the unit suite overall **13% → 23%**. But coverage is not catching, which is why the table above is survivors and not percentages of lines.

## Reading the survivors by function is the whole method

A total says nothing — it measures *absent* tests and *weak* tests with one number. Grouped by function, it twice said the fix was wrong:

- **`dbfile_get_run_summary` barely moved, 22 → 21.** Its five error buckets are adjacent columns read by index, and my fixture had three of them at 0 — indistinguishable from each other *and* from a read that was dropped. Distinct values (11/22/33/44/55) plus a third clean run for the alarm-clearing property fixed it.
- **`dbfile_load_scan_config` still let `mfs = 0` be deleted.** The two size limits are read through one scratch variable, so without the reset a hashfile written before `--max-filesize` existed gets `max = min` — and silently stops scanning every file above the lower limit. My fixture hid it by deleting *both* keys; it now deletes only the additive one, which is what such a hashfile actually looks like.

Both tests looked thorough. Only the number said otherwise.

Equally worth saying: **`dbfile_describe_file` went 41/41 → 10/41, and all ten remaining are `perror_sqlite` + `goto out` on a bind or step failure.** That is residue, not a hole — the next honest move there is a fault-injection seam, not a bigger fixture.

## What the strengthening actually asserts

The first pass asserted that rows appeared. That leaves every `sqlite3_bind_*` free to write the right value into the wrong column, which counts as one row just as well:

- Every column `store_file_info()` and `update_scanned_file()` write, read back through `dbfile_describe_file()` — the change-detection path every scan runs per file, which had no test of its own. `digest_valid` in both states, since it is the only thing that tells a finished file from one an interrupted run left partway.
- Block and extent hashes with `(loff, poff, len, digest)` *together*, so a digest bound into the wrong slot shows.
- The checkpoint reader declining what it cannot vouch for: no row, another file's row, a state blob of the wrong length — the length being all that stands between a truncated row and a `memcpy` into the caller's buffer. Plus every field it loads, with distinct values.
- The prune from the side that was missing: **a file that still exists is kept.** "Delete the rows this run did not walk" passed everything here before, and that is the implementation the rule exists to prevent. Also the `seen` oracle, 600 missing rows to reach the array growth, ENOTDIR, and — for "a stat that failed for some *other* reason is not gone" — a self-referential symlink, which is the only member of that class a test can produce without being root or breaking hardware.

## Three properties, and an honest number for them

`src/proptest.h` properties over the hashfile's layout matching:

- **A layout matches only itself** — the records it stored match, and no single-field change to any one record still does. Both halves, because for #206 misses are free and false hits are catastrophic.
- **A split record is not the layout it covers** — splitting one record in two covers byte for byte what the donor covers, at the same addresses, so a check reasoning about *coverage* says yes and must say no.
- **Stored extents come back where they were put, and nothing else does** — the second clause is what turns the zero-length-extent skip into a property: an extent naming no bytes must not be stored at any count, at any position, including as the only element.

None is a tautology: the first two relate a `struct fiemap` to the rows `dbfile_store_extent_hashes()` wrote, which only the loop under test connects; the third reads back with SQL, so a bind index shifted consistently in both directions cannot round-trip.

**The A/B is 786 → 785. One mutant.** That is thin and I am not dressing it up — it is the same unevenness the glob properties showed when they gained nothing at all. But *which* one matters: `i > 0` → `i > 1` in `dbfile_layout_matches`, i.e. **a donor with exactly one stored extent stops matching.** Every fixture in the table has two records, so nothing there could see it — and a single-extent file is the common case, since btrfs reports a contiguously allocated file as one fiemap record however large it is. A snapshot-aware scan would have silently stopped copying anything on the most ordinary layout there is.

And **the sweep cannot score the split-record property at all.** "Normalize adjacent records before comparing" is a design change, not a single-token edit or a statement deletion, so no operator generates it. A property's `caught` count is a lower bound on what it guards, never the measure.

Two properties were considered and **rejected**: one over the prune (needs real filesystem objects per case, and the suite's ~0.3 s is load-bearing — the tool derives a mutant's hang timeout from a green run, so a slower suite reclassifies slow mutants as `hang`), and an int64 round-trip of the size limits (bit-preserving by construction, the same reinterpretation on both sides, so it could only ever pass).

## `bugs/dbfile.txt`: 9 → 17 blocks, all caught

New ones pin the scope-based prune, a stat failing for a reason other than ENOENT, the ignored `seen` oracle, the checkpoint length guard, change detection losing `digest is not null`, the unreset size-limit scratch variable, and two one-column-across shifts (the run summary's buckets, the checkpoint's position).

`make mutation-replay` across all five bug files: **49/49, nothing survived.**

## Two fixture bugs of the kind that pass while proving nothing

A 32-character hex digest literal against `DIGEST_LEN` 16, and an `UPDATE` naming a column that does not exist (`file_state`, where the column is `state`) which `sqlite3_exec` accepted silently. Hence `exec()`, which aborts rather than returning a code nobody reads.

Also found and now written down: **`memdb()` handles all share one database.** Shared-cache in-memory means a second `dbfile_open_handle(NULL)` is the *same* database, not an empty one — so "what does this answer against a fresh hashfile" has to be asked before the test stores anything.

## Three API shapes a test gets wrong first

- **`dbfile_store_file_info()` writes no digest** — `dbfile_update_scanned_file()` does, and rows built without it are exactly what the startup prune deletes.
- **`dbfile_load_scan_config()` returns 1** for "a config was stored". The header says so; I asserted `== 0` without reading it.
- **`dbfile_load_checkpoint()` copies into caller-owned buffers.** Not documented, and a zeroed struct is a write through NULL — it segfaulted. **The header now says so, and that comment is the only production change in this PR.**

`mu_check()` expands to a bare `return;`, so it cannot be used in a value-returning helper — gcc warns, clang refuses. The helpers `abort()`, matching `gs_hit()`.

## Lanes now build at `-O0`

A mutant is one compile of a ~20,000-line translation unit, so the flags are the whole lever. Measured, interleaved: 5.6 s → 1.3 s compile, suite 0.24 s → 0.30 s, i.e. **5.84 s → 1.60 s per mutant**.

Validated over the whole file rather than a sample — `dbfile.c` swept both ways: **908 survivors at `-O2`, 901 at `-O0`, 17 of 1,879 (0.9%) differing.** Every one of the 17 is a statement deletion, which leaves a function falling off the end or a value uninitialised — undefined behaviour, so its verdict is not a stable property of the tests under any build. No token mutant moved. Wall clock 2,290 s → 699 s.

`--make-arg CFLAGS=…` overrides it; sanitizer runs are unaffected (the makefile appends its own `-O1 -fsanitize=…` last).

## Verification

`WERROR=1 make` (no warnings) · `make lint` clean · `make test` — **74 tests, 1,248,563 assertions, 0.29 s** · `make test CC=clang SANITIZE=address,undefined` clean · valgrind **0 errors, 0 bytes lost, 0 suppressed** · `make mutation-replay` **49/49**.

**Not run locally: the Python integration suite.** This container is ext4 with no reflink filesystem, so all 106 failures are `this filesystem does not support FIDEDUPERANGE`. That is provably not this branch: `Makefile:46` is `CFILES := $(filter-out src/tests.c, …)`, so `src/tests.c` is not linked into `oans` at all, and the only other `src/` change is a comment in a header — the binary is functionally identical to master's. The btrfs and xfs legs are CI's.

## Next

The sweep names the work: a `hash_tree`/`results_tree` fixture for the four dedupe loaders (67–75% survival, the biggest reachable block left), then `rbtree.c` (226 lines), `hash-tree.c` (185), `results-tree.c` (192), `filerec.c` (178), `list_sort.c` (55), `threads.c` (73) — all at 0%, all pure.

Separately worth deciding: `oans.c` (2,177 lines) and `run_dedupe.c` (1,340) are not compiled into `./test` at all, so the mutation tool reports **0% killed** on them rather than refusing. That is a false report in the flattering direction, not a coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ