### PR TITLE
test: the in-memory dedupe model (502 → 135 mutation survivors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,44 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
   the equivalents rather than assuming them: three that looked equivalent were
   not, and one of those wrote a byte past a buffer.
 
+### The dedupe model is unit-testable too, and needs no fixture at all
+
+`filerec.c`, `hash-tree.c` and `results-tree.c` are pure memory. They were at a
+**0% kill rate** - 502 mutants, not one caught - and are now at **73%** (135
+survivors) on nineteen tests, with `bugs/{filerec,hash-tree,results-tree}.txt`
+putting nine of the invariants back.
+
+- **They are the only callers of the vendored kernel rbtree**, which is why
+  `src/rbtree.c` and `src/list_sort.c` get no tests of their own: they are
+  verbatim `linux/lib` code with no oans-specific API, so sweeping them would
+  measure upstream's design. Generated insert *and erase* orders here are what
+  make that copy rebalance - an ascending sweep only ever unlinks a spine.
+- **`free_all_filerecs()` ignores `refs`.** So "a filerec survives until its
+  last reference goes" is *not* true of this module: that rule lives in
+  `run_dedupe.c`'s batch refs and is not a unit-testable claim. What is
+  testable is that `filerec_free()` erases the fileid node, so a later
+  `filerec_find()` cannot hand back a dead pointer. A comment claiming the
+  bigger thing shipped in the first draft and was caught by review.
+- **Three contracts a fixture gets wrong first.** `insert_result()`'s length is
+  `endoff[0] - startoff[0] + 1` - inclusive, and from the *first* pair alone.
+  `remove_extent()` collapses a group that drops to one member, so removing
+  from a *pair* takes both extents and answers 0 where a decrement would say 1.
+  And `remove_hashed_block()` answers 1 only when it freed the whole list,
+  which is how `find_dupes` knows not to keep walking it.
+- **Several files, or the test sees nothing.** A `file_hash_head` is freed when
+  *that file's* sublist drains; with one file that always coincides with the
+  block list being freed, so the leak is invisible. Likewise
+  `sort_file_hash_heads()` is two nested walks, so one digest leaves the outer
+  one unobservable.
+- **The fd refcount needs a read, not a counter.** `filerec_open()` hands back
+  the descriptor already open; what separates that from close-every-time is
+  that the fd stays *usable* across an inner close, so the test reads a byte
+  through it.
+- **Read the residue by function.** The first pass looked like an ordinary 56%,
+  but three blocks had not moved by a single mutant - and two were code the
+  tests never called (`insert_result`, the whole fd group). The total hid that
+  completely; only the grouping showed it.
+
 ### The hashfile is unit-testable, in memory
 
 `dbfile_open_handle(NULL)` opens a shared-cache in-memory SQLite - the same path

--- a/scripts/mutate/bugs/filerec.txt
+++ b/scripts/mutate/bugs/filerec.txt
@@ -1,0 +1,52 @@
+# file: src/filerec.c
+#
+# Invariants of the in-memory dedupe model, each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/filerec.txt
+#
+# Like the hashfile's, every one of these fails *silently*. The trees decide
+# what oans compares and what it opens; nothing downstream validates them, so a
+# count that drifts or a group that collapses early just means a run that
+# deduplicates less than it should and says nothing at all.
+#
+# Pure memory, no filesystem - except the two file-descriptor blocks, which use
+# a temp file the test makes for itself.
+
+# the descriptor is closed on every filerec_close
+# The dedupe phase opens one file from several groups at once, so an inner
+# close must not pull the descriptor out from under the outer holder. The
+# counter still reaches zero either way; what breaks is that reads through the
+# fd start failing in the middle of a batch.
+<<<
+	file->fd_refs--;
+
+	if (file->fd_refs == 0) {
+		close(file->fd);
+		file->fd = -1;
+	}
+===
+	file->fd_refs--;
+	close(file->fd);
+	file->fd = -1;
+>>>
+
+# open_once forgets what it has already opened
+# Every member of a group is then opened once per group it appears in, while
+# the close list only ever releases one reference each - so a long dedupe run
+# leaks descriptors until it hits the process limit, having deduplicated
+# correctly right up to that point.
+<<<
+	if (find_filerec_token_rb(&open_files->root, file))
+		return 0;
+
+===
+>>>
+
+# a filerec keeps its place in the lookup tree after it is freed
+# filerec_find() then returns a pointer into freed memory. Nothing here
+# crashes: the node's contents survive long enough to look plausible.
+<<<
+		if (!RB_EMPTY_NODE(&file->fileid_node))
+			rb_erase(&file->fileid_node, &filerec_by_fileid);
+===
+>>>

--- a/scripts/mutate/bugs/hash-tree.txt
+++ b/scripts/mutate/bugs/hash-tree.txt
@@ -1,0 +1,50 @@
+# file: src/hash-tree.c
+#
+# Invariants of the in-memory dedupe model, each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/hash-tree.txt
+#
+# Like the hashfile's, every one of these fails *silently*. The trees decide
+# what oans compares and what it opens; nothing downstream validates them, so a
+# count that drifts or a group that collapses early just means a run that
+# deduplicates less than it should and says nothing at all.
+#
+# Pure memory, no filesystem - except the two file-descriptor blocks, which use
+# a temp file the test makes for itself.
+
+# removing the last block of a digest no longer says so
+# The return value is how find_dupes learns the list is gone. Answer 0 and the
+# caller keeps walking a list that has just been freed - which is a
+# use-after-free that the counters, being correct, do nothing to reveal.
+<<<
+		free_dupe_blocks_list(blocklist);
+		ret = 1;
+===
+		free_dupe_blocks_list(blocklist);
+>>>
+
+# a drained file's hash head is left behind
+# The head is freed when that file's sublist empties, which with one file in
+# the group coincides with the whole list being freed - so this leaks only when
+# several files share a digest, and only a multi-file fixture can see it.
+<<<
+	head = find_file_hash_head(blocklist, file);
+	if (head && list_empty(&head->h_blocks))
+		free_one_hash_head(blocklist, head);
+===
+>>>
+
+# only the first block list gets its heads sorted
+# find_dupes requires increasing offsets per file, and the blocks arrive that
+# way only because the scan happens to produce them so. Sorting one list looks
+# right in any fixture that uses a single digest.
+<<<
+	for (dups_node = rb_first(&tree->root); dups_node;
+	     dups_node = rb_next(dups_node)) {
+===
+	for (dups_node = rb_first(&tree->root); dups_node;
+	     dups_node = NULL) {
+>>>
+
+# ---------------------------------------------------------------- filerecs
+

--- a/scripts/mutate/bugs/results-tree.txt
+++ b/scripts/mutate/bugs/results-tree.txt
@@ -1,0 +1,70 @@
+# file: src/results-tree.c
+#
+# Invariants of the in-memory dedupe model, each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/results-tree.txt
+#
+# Like the hashfile's, every one of these fails *silently*. The trees decide
+# what oans compares and what it opens; nothing downstream validates them, so a
+# count that drifts or a group that collapses early just means a run that
+# deduplicates less than it should and says nothing at all.
+#
+# Pure memory, no filesystem - except the two file-descriptor blocks, which use
+# a temp file the test makes for itself.
+#
+# Invariants of the in-memory dedupe model, each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/dedupe-model.txt
+#
+# Like the hashfile's, every one of these fails *silently*. The trees decide
+# what oans compares and what it opens; nothing downstream validates them, so a
+# count that drifts or a group that collapses early just means a run that
+# deduplicates less than it should and says nothing at all.
+#
+# These need no filesystem: the model is pure memory, and the two file-
+# descriptor blocks use a temp file the test makes for itself.
+
+# ---------------------------------------------------------------- grouping
+
+# the pair-wise insert reads its length as exclusive
+# endoff is inclusive, and the length keys the group - so one byte short files
+# every pair under a length no other extent will ever be filed under. The pair
+# still becomes a group, so nothing is empty and nothing errors; those two
+# extents simply never meet the rest of their duplicates.
+<<<
+	uint64_t len = endoff[0] - startoff[0] + 1;
+===
+	uint64_t len = endoff[0] - startoff[0];
+>>>
+
+# a group of one is left in the tree instead of collapsing
+# There is nothing for a lone extent to be deduplicated against, so dropping to
+# one member has to take that member too. Leaving it behind strands an extent
+# in a group that can never be acted on, and the counters still add up.
+<<<
+	if (p->de_num_dupes == 1) {
+		/* It doesn't make sense to have one extent in a dup
+		 * list. */
+		abort_on(RB_EMPTY_ROOT(&p->de_extents_root));/* logic error */
+
+		n = rb_first(&p->de_extents_root);
+		extent = rb_entry(n, struct extent, e_node);
+		goto again;
+	}
+===
+>>>
+
+# the anchor flag is assigned rather than latched
+# A group spanning several dedupe passes must keep the target the first pass
+# chose, or each pass converges the copies onto a different physical extent and
+# the run never settles. The mutation only shows if a *later* member arrives
+# without the flag, which is the shape a test has to be written for.
+<<<
+	if (is_anchor)
+		dext->de_anchored = true;
+===
+	dext->de_anchored = is_anchor;
+>>>
+
+# ---------------------------------------------------------------- hash tree
+

--- a/src/tests.c
+++ b/src/tests.c
@@ -3566,187 +3566,199 @@ MU_TEST(test_prop_stored_extents_come_back_where_they_were_put) {
  *
  * All three are pure memory - no filesystem, no btrfs, no scan - and all three
  * were at a 0% mutation kill rate before this: 502 mutants, nothing caught.
- * They are also the only callers of the vendored kernel rbtree, so hammering
- * them with generated insert/erase sequences is a better test of that copy
- * than testing it directly would be.
+ * They are also the only callers of the vendored kernel rbtree, so generated
+ * insert and *erase* orders here are what exercise that copy's rebalancing;
+ * inserting and removing in one ascending sweep would only ever walk a spine.
  * ---------------------------------------------------------------------------
  */
 
-/* Every test here shares one global registry, so each one starts it over. */
-static void filerecs_reset(void)
-{
-	free_all_filerecs();
-	init_filerec();
-}
+#define PROP_FILES	4
+#define PROP_DIGESTS	5
+#define PROP_BLOCKS	24
 
-/* A digest that differs in every byte for each n, so a comparator that reads
- * the wrong end of it still sees a difference. */
+/*
+ * Offsets and extent lengths use their own constant rather than the global
+ * `blocksize`, which an earlier test sets to 100 and never restores. Nothing
+ * here depends on the value, only on it being fixed.
+ */
+#define PROP_LEN	4096
+
+/* A digest that differs in every byte for each n, so a comparator reading the
+ * wrong end of it still sees a difference. */
 static void digest_of(unsigned char *out, unsigned int n)
 {
 	for (unsigned int i = 0; i < DIGEST_LEN; i++)
 		out[i] = (unsigned char)(n * 7 + i * 31);
 }
 
-static struct filerec *mkfilerec(unsigned int n)
+/* Takes the fileid it will actually have: the tests look filerecs up by id,
+ * so a helper that invented its own numbering had to be bypassed by the one
+ * property that chooses ids. */
+static struct filerec *mkfilerec(int64_t fileid)
 {
 	char name[64];
 	struct filerec *f;
 
-	snprintf(name, sizeof(name), "/tree/f%u", n);
-	f = filerec_new(name, (int64_t)n + 1, 4096 * (n + 1));
+	snprintf(name, sizeof(name), "/tree/f%lld", (long long)fileid);
+	f = filerec_new(name, fileid, PROP_LEN * (uint64_t)fileid);
 	if (!f)
 		abort();
 	return f;
 }
 
+static void prop_shuffle_u64(struct prop *p, uint64_t *a, unsigned int n)
+{
+	for (unsigned int i = n; i > 1; i--) {
+		unsigned int j = (unsigned int)prop_below(p, i);
+		uint64_t t = a[i - 1];
+
+		a[i - 1] = a[j];
+		a[j] = t;
+	}
+}
+
 MU_TEST(test_filerec_the_registry_finds_what_was_put_in_it) {
 	struct filerec *a, *b;
 
-	filerecs_reset();
+	/* One global registry serves every test, so each starts it over. */
+	free_all_filerecs();
 	a = mkfilerec(1);
 	b = mkfilerec(2);
 
-	mu_check(filerec_find(2) == a);		/* fileid is n + 1 */
-	mu_check(filerec_find(3) == b);
+	mu_check(filerec_find(1) == a);
+	mu_check(filerec_find(2) == b);
 	mu_check(filerec_find(99) == NULL);	/* never inserted */
 
-	/* The fields it was created with, not just its identity. */
 	mu_check(!strcmp(a->filename, "/tree/f1"));
-	mu_check(a->size == 4096 * 2);
+	mu_check(a->size == PROP_LEN);
 	mu_check(a->fd == -1);			/* not opened yet */
 
-	filerecs_reset();
-	mu_check(filerec_find(2) == NULL);	/* and teardown really clears */
+	free_all_filerecs();
+	mu_check(filerec_find(1) == NULL);	/* and teardown really clears */
 }
 
 /*
- * The lifetime refcount that keeps a filerec alive while a dedupe batch still
- * references it. CLAUDE.md calls this the rule that prevents a heap
- * use-after-free across batches - a cross-window anchor is referenced by two
- * in-flight batches at once - and until now it was pinned only by the
- * integration suite and valgrind, which see it as a crash rather than as a
- * count.
+ * The reference count balances, and the free that ends it takes the filerec
+ * out of the lookup tree - so a later filerec_find() cannot hand back a
+ * pointer to freed memory.
+ *
+ * Deliberately *not* claiming this pins the cross-batch lifetime rule from
+ * CLAUDE.md. That rule is about run_dedupe.c holding a ref per batch, and it
+ * is not even true of this module in isolation: free_all_filerecs() frees
+ * every filerec whatever its refs, which is what the teardown on the last
+ * line of this test does. What is testable here is the smaller claim above.
  */
-MU_TEST(test_filerec_survives_until_the_last_reference_goes) {
+MU_TEST(test_filerec_is_unfindable_once_its_last_reference_goes) {
 	struct filerec *f;
 
-	filerecs_reset();
+	free_all_filerecs();
 	f = mkfilerec(1);
-	mu_check(f->refs == 0);		/* created unreferenced; teardown frees it */
+	mu_check(f->refs == 0);		/* created unreferenced */
 
-	/* Two batches take a reference, as two windows sharing an anchor do. */
 	filerec_get(f);
 	filerec_get(f);
 	mu_check(f->refs == 2);
 
-	/* The first batch reaps: still alive, still findable. */
 	filerec_put(f);
-	mu_check(filerec_find(2) == f);
+	mu_check(f->refs == 1);
+	mu_check(filerec_find(1) == f);	/* one holder left: still live */
 
-	/* The second reaps, and only now is it gone from the registry - so a
-	 * later lookup cannot hand out a freed pointer. */
 	filerec_put(f);
-	mu_check(filerec_find(2) == NULL);
+	mu_check(filerec_find(1) == NULL);
 
-	filerecs_reset();
+	free_all_filerecs();
 }
 
 /*
- * Every filerec inserted is findable by its own id and by no other, for any
- * insertion order. The registry is an rbtree keyed by fileid, so this is the
- * property that makes cmp_filerecs' answer observable: a comparator that
- * inverts, or that compares the wrong field, still builds *a* tree - just one
- * that cannot find things again.
+ * Every filerec is findable by its own id and by no other, for any insertion
+ * order. The registry is an rbtree keyed on fileid, so this is what makes
+ * cmp_filerecs' answer observable: a comparator that inverts, or that reads
+ * the wrong field, still builds *a* tree - just one that cannot find things
+ * again.
  */
 MU_TEST(test_prop_every_filerec_is_findable_by_its_own_id) {
 	declare_prop(p, 200);
 
 	while (prop_next(&p)) {
-		unsigned int n = (unsigned int)prop_range(&p, 1, 24);
-		int64_t ids[24];
-		struct filerec *made[24];
+		uint64_t ids[PROP_BLOCKS];
+		struct filerec *made[PROP_BLOCKS];
+		unsigned int n = (unsigned int)prop_range(&p, 1, ARRAY_SIZE(ids));
+		uint64_t id = 0;
 
-		filerecs_reset();
+		free_all_filerecs();
 
-		/* Ids spread over a range wider than the count, so there are
-		 * gaps to look up as well as hits. */
+		/* Ascending with gaps makes them distinct by construction; the
+		 * shuffle is what makes the insertion order arbitrary. The gaps
+		 * double as ids to look up and miss on. */
 		for (unsigned int i = 0; i < n; i++) {
-			char name[64];
-			int64_t id;
-			bool dup;
-
-			do {
-				id = (int64_t)prop_range(&p, 1, 200);
-				dup = false;
-				for (unsigned int j = 0; j < i; j++)
-					if (ids[j] == id)
-						dup = true;
-			} while (dup);
+			id += prop_range(&p, 1, 8);
 			ids[i] = id;
-			snprintf(name, sizeof(name), "/tree/%lld",
-				 (long long)id);
-			made[i] = filerec_new(name, id, 4096 * (uint64_t)id);
-			if (!made[i])
-				abort();
 		}
+		prop_shuffle_u64(&p, ids, n);
+
+		for (unsigned int i = 0; i < n; i++)
+			made[i] = mkfilerec((int64_t)ids[i]);
 
 		for (unsigned int i = 0; i < n; i++) {
-			prop_check(&p, filerec_find(ids[i]) == made[i]);
-			prop_check(&p, made[i]->fileid == ids[i]);
-			prop_check(&p, made[i]->size == 4096 * (uint64_t)ids[i]);
+			prop_check(&p, filerec_find((int64_t)ids[i]) == made[i]);
+			prop_check(&p, made[i]->fileid == (int64_t)ids[i]);
 		}
 
-		/* And an id nobody inserted is not answered with a neighbour. */
-		for (int64_t probe = 201; probe <= 205; probe++)
-			prop_check(&p, filerec_find(probe) == NULL);
+		/* Past every id inserted: not answered with a neighbour. */
+		for (uint64_t probe = id + 1; probe <= id + 4; probe++)
+			prop_check(&p, filerec_find((int64_t)probe) == NULL);
 	}
-	filerecs_reset();
+	free_all_filerecs();
 }
 
 /*
  * Everything the hash tree counts stays consistent with what is in it, for any
- * mix of files, digests and offsets - and then survives having every block
- * taken back out again.
+ * mix of files, digests and offsets.
  *
- * Three counters have to agree with three different things: tree->num_blocks
- * with the blocks inserted, tree->num_hashes with the *distinct* digests, and
- * each dl_num_elem with that digest's share. Nothing downstream validates
- * them; find_dupes reads them to decide what to compare, so a count that
- * drifts makes oans quietly compare the wrong set.
+ * Three counters must agree with three different things: tree->num_blocks with
+ * the blocks inserted, tree->num_hashes with the *distinct* digests, and each
+ * dl_num_elem with that digest's share. Nothing downstream validates them;
+ * find_dupes reads them to decide what to compare, so a count that drifts
+ * makes oans quietly compare the wrong set.
+ *
+ * The shadow model (per_digest, next_loff) is kept independently of the tree
+ * rather than read back out of it, which is what stops this being a
+ * restatement of the code under test.
  */
 MU_TEST(test_prop_the_hash_tree_counts_what_it_holds) {
 	declare_prop(p, 120);
-#define PROP_HT_FILES	4
-#define PROP_HT_DIGESTS	5
-#define PROP_HT_BLOCKS	24
+	struct filerec *files[PROP_FILES];
+	unsigned char digests[PROP_DIGESTS][DIGEST_LEN];
+
+	/* Loop-invariant: the tree is torn down each iteration, and that walks
+	 * every block out of the filerecs' own trees, so these come back
+	 * clean. */
+	free_all_filerecs();
+	for (unsigned int i = 0; i < PROP_FILES; i++)
+		files[i] = mkfilerec((int64_t)i + 1);
+	for (unsigned int i = 0; i < PROP_DIGESTS; i++)
+		digest_of(digests[i], i);
 
 	while (prop_next(&p)) {
 		struct hash_tree tree;
-		struct filerec *files[PROP_HT_FILES];
-		unsigned char digests[PROP_HT_DIGESTS][DIGEST_LEN];
-		unsigned int per_digest[PROP_HT_DIGESTS] = {0};
-		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_HT_BLOCKS);
+		unsigned int per_digest[PROP_DIGESTS] = {0};
+		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_BLOCKS);
 		unsigned int distinct = 0;
-		uint64_t next_loff[PROP_HT_FILES] = {0};
+		uint64_t next_loff[PROP_FILES] = {0};
 
-		filerecs_reset();
 		init_hash_tree(&tree);
-		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
-			files[i] = mkfilerec(i);
-		for (unsigned int i = 0; i < PROP_HT_DIGESTS; i++)
-			digest_of(digests[i], i);
 
 		for (unsigned int i = 0; i < nb; i++) {
-			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
-			unsigned int d = (unsigned int)prop_below(&p, PROP_HT_DIGESTS);
+			unsigned int f = (unsigned int)prop_below(&p, PROP_FILES);
+			unsigned int d = (unsigned int)prop_below(&p, PROP_DIGESTS);
 
-			/* Distinct offsets per file: two blocks of one file at
-			 * one offset is not a shape the scan produces, and the
-			 * filerec block tree is keyed on it. */
+			/* Distinct offsets per file: the filerec block tree is
+			 * keyed on the offset, and two blocks of one file at one
+			 * offset is not a shape the scan produces. */
 			if (insert_hashed_block(&tree, digests[d], files[f],
 						next_loff[f]))
 				abort();
-			next_loff[f] += blocksize;
+			next_loff[f] += PROP_LEN;
 			if (per_digest[d]++ == 0)
 				distinct++;
 		}
@@ -3754,7 +3766,7 @@ MU_TEST(test_prop_the_hash_tree_counts_what_it_holds) {
 		prop_check(&p, tree.num_blocks == nb);
 		prop_check(&p, tree.num_hashes == distinct);
 
-		for (unsigned int d = 0; d < PROP_HT_DIGESTS; d++) {
+		for (unsigned int d = 0; d < PROP_DIGESTS; d++) {
 			struct dupe_blocks_list *dl =
 				find_block_list(&tree, digests[d]);
 
@@ -3765,216 +3777,294 @@ MU_TEST(test_prop_the_hash_tree_counts_what_it_holds) {
 				continue;
 			}
 			prop_check(&p, dl != NULL);
-			prop_check(&p, dl && dl->dl_num_elem == per_digest[d]);
-			prop_check(&p, dl && !memcmp(dl->dl_hash, digests[d],
-						     DIGEST_LEN));
+			prop_check(&p, dl->dl_num_elem == per_digest[d]);
+			prop_check(&p, !memcmp(dl->dl_hash, digests[d], DIGEST_LEN));
 		}
 
-		/* Every block is findable at the offset it was filed under. */
-		for (unsigned int f = 0; f < PROP_HT_FILES; f++) {
-			for (uint64_t off = 0; off < next_loff[f];
-			     off += blocksize) {
+		for (unsigned int f = 0; f < PROP_FILES; f++) {
+			for (uint64_t off = 0; off < next_loff[f]; off += PROP_LEN) {
 				struct file_block *b =
 					find_filerec_block(files[f], off);
 
 				prop_check(&p, b != NULL);
-				prop_check(&p, b && b->b_loff == off);
-				prop_check(&p, b && b->b_file == files[f]);
+				prop_check(&p, b->b_loff == off);
+				prop_check(&p, b->b_file == files[f]);
 			}
 			prop_check(&p, find_filerec_block(files[f],
 							  next_loff[f]) == NULL);
 		}
 
 		free_hash_tree(&tree);
-		filerecs_reset();
 	}
+	free_all_filerecs();
 }
 
 /*
- * Taking blocks back out is the other half, and it has a return value nobody
- * checks: remove_hashed_block answers 1 exactly when it removed the *last*
- * block carrying that digest, having freed the list. find_dupes uses that to
- * know the group is gone, so an answer that is right about the tree and wrong
- * about the verdict leaves a caller holding a freed list.
+ * Taking blocks back out, in an order unrelated to the one they went in.
+ *
+ * Two things here that a simpler shape cannot see. remove_hashed_block answers
+ * 1 exactly when it removed the *last* block carrying that digest and freed
+ * the list - find_dupes uses that to know the group is gone, so an answer
+ * right about the tree and wrong about the verdict leaves a caller holding a
+ * freed list. And a file_hash_head is freed when *that file's* sublist drains,
+ * which with a single file would always coincide with the list itself being
+ * freed; several files make the two instants different, so dropping the head
+ * free leaks it somewhere a counter can still notice.
+ *
+ * The removal order is generated, which is also the only thing in these tests
+ * that makes the vendored rbtree rebalance on erase rather than unlink a
+ * spine.
  */
 MU_TEST(test_prop_removing_every_block_empties_the_hash_tree) {
 	declare_prop(p, 120);
+	struct filerec *files[PROP_FILES];
+	unsigned char digests[PROP_DIGESTS][DIGEST_LEN];
+
+	free_all_filerecs();
+	for (unsigned int i = 0; i < PROP_FILES; i++)
+		files[i] = mkfilerec((int64_t)i + 1);
+	for (unsigned int i = 0; i < PROP_DIGESTS; i++)
+		digest_of(digests[i], i);
 
 	while (prop_next(&p)) {
 		struct hash_tree tree;
-		struct filerec *file;
-		unsigned char digests[PROP_HT_DIGESTS][DIGEST_LEN];
-		unsigned int per_digest[PROP_HT_DIGESTS] = {0};
-		unsigned int which[PROP_HT_BLOCKS];
-		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_HT_BLOCKS);
+		unsigned int per_digest[PROP_DIGESTS] = {0};
+		unsigned int per_pair[PROP_DIGESTS][PROP_FILES] = {{0}};
+		unsigned int wd[PROP_BLOCKS], wf[PROP_BLOCKS];
+		uint64_t order[PROP_BLOCKS];
+		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_BLOCKS);
 		unsigned int distinct = 0;
+		uint64_t next_loff[PROP_FILES] = {0};
+		uint64_t loffs[PROP_BLOCKS];
 
-		filerecs_reset();
 		init_hash_tree(&tree);
-		file = mkfilerec(0);
-		for (unsigned int i = 0; i < PROP_HT_DIGESTS; i++)
-			digest_of(digests[i], i);
 
 		for (unsigned int i = 0; i < nb; i++) {
-			unsigned int d = (unsigned int)prop_below(&p, PROP_HT_DIGESTS);
+			unsigned int f = (unsigned int)prop_below(&p, PROP_FILES);
+			unsigned int d = (unsigned int)prop_below(&p, PROP_DIGESTS);
 
-			which[i] = d;
-			if (insert_hashed_block(&tree, digests[d], file,
-						blocksize * i))
+			wd[i] = d;
+			wf[i] = f;
+			loffs[i] = next_loff[f];
+			order[i] = i;
+			if (insert_hashed_block(&tree, digests[d], files[f],
+						next_loff[f]))
 				abort();
+			next_loff[f] += PROP_LEN;
+			per_pair[d][f]++;
 			if (per_digest[d]++ == 0)
 				distinct++;
 		}
 
-		/* Remove in insertion order, so the last block of a digest is
-		 * reached at a different point for each one. */
-		for (unsigned int i = 0; i < nb; i++) {
-			unsigned int d = which[i];
+		prop_shuffle_u64(&p, order, nb);
+
+		for (unsigned int k = 0; k < nb; k++) {
+			unsigned int i = (unsigned int)order[k];
+			unsigned int d = wd[i], f = wf[i];
+			struct dupe_blocks_list *dl =
+				find_block_list(&tree, digests[d]);
 			struct file_block *b =
-				find_filerec_block(file, blocksize * i);
-			bool last = --per_digest[d] == 0;
+				find_filerec_block(files[f], loffs[i]);
+			bool last_of_digest = per_digest[d] == 1;
+			bool last_of_pair = per_pair[d][f] == 1;
 			int ret;
 
+			prop_check(&p, dl != NULL);
 			prop_check(&p, b != NULL);
-			if (!b)
-				break;
+
+			per_digest[d]--;
+			per_pair[d][f]--;
 			ret = remove_hashed_block(&tree, b);
-			prop_check(&p, ret == (last ? 1 : 0));
-			if (last)
+			prop_check(&p, ret == (last_of_digest ? 1 : 0));
+
+			/* That file's head is gone once its share drains, while
+			 * the list itself lives on for the other files. */
+			if (!last_of_digest)
+				prop_check(&p,
+					   (find_file_hash_head(dl, files[f])
+					    == NULL) == last_of_pair);
+
+			if (last_of_digest)
 				distinct--;
 			prop_check(&p, tree.num_hashes == distinct);
-			prop_check(&p, tree.num_blocks == nb - i - 1);
+			prop_check(&p, tree.num_blocks == nb - k - 1);
+			prop_check(&p, find_filerec_block(files[f],
+							  loffs[i]) == NULL);
 		}
 
 		prop_check(&p, tree.num_blocks == 0 && tree.num_hashes == 0);
 		prop_check(&p, RB_EMPTY_ROOT(&tree.root));
-
 		free_hash_tree(&tree);
-		filerecs_reset();
 	}
+	free_all_filerecs();
 }
 
 /*
  * find_dupes walks each file's blocks under a hash expecting increasing
- * offsets, and says so at sort_file_hash_heads' declaration. The blocks arrive
- * in offset order only because the scan happens to produce them that way, so
- * the sort is what makes the requirement true rather than merely usual - and a
- * fixture that inserts in order cannot tell a working sort from no sort at all.
- * Hence a deliberately shuffled insertion order here.
+ * offsets, and says so where sort_file_hash_heads is declared. The blocks
+ * arrive that way only because the scan happens to produce them so, which is
+ * why the sort exists - and why a fixture that inserts in order cannot tell a
+ * working sort from no sort at all. Hence a shuffled insertion order.
+ *
+ * Two digests, not one: the sort is two nested walks, and with a single block
+ * list the outer one runs exactly once for the life of the property, so a
+ * mutant that stops after the first list would be invisible.
  */
 MU_TEST(test_prop_sorting_puts_every_hash_head_in_offset_order) {
 	declare_prop(p, 120);
+	struct filerec *files[PROP_FILES];
+	unsigned char digests[2][DIGEST_LEN];
+
+	free_all_filerecs();
+	for (unsigned int i = 0; i < PROP_FILES; i++)
+		files[i] = mkfilerec((int64_t)i + 1);
+	digest_of(digests[0], 0);
+	digest_of(digests[1], 1);
 
 	while (prop_next(&p)) {
 		struct hash_tree tree;
-		struct filerec *files[PROP_HT_FILES];
-		unsigned char digest[DIGEST_LEN];
-		uint64_t offs[PROP_HT_BLOCKS];
-		unsigned int nb = (unsigned int)prop_range(&p, 2, PROP_HT_BLOCKS);
-		struct dupe_blocks_list *dl;
-		struct rb_node *n;
+		uint64_t offs[PROP_BLOCKS];
+		unsigned int nb = (unsigned int)prop_range(&p, 2, PROP_BLOCKS);
+		unsigned int heads = 0;
+		struct rb_node *dn;
 
-		filerecs_reset();
 		init_hash_tree(&tree);
-		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
-			files[i] = mkfilerec(i);
-		digest_of(digest, 0);
-
-		/* Distinct offsets, then shuffled, so the insertion order is
-		 * unrelated to the order the sort has to produce. */
 		for (unsigned int i = 0; i < nb; i++)
-			offs[i] = blocksize * i;
-		for (unsigned int i = nb; i > 1; i--) {
-			unsigned int j = (unsigned int)prop_below(&p, i);
-			uint64_t t = offs[i - 1];
-
-			offs[i - 1] = offs[j];
-			offs[j] = t;
-		}
+			offs[i] = PROP_LEN * i;
+		prop_shuffle_u64(&p, offs, nb);
 
 		for (unsigned int i = 0; i < nb; i++) {
-			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
+			unsigned int f = (unsigned int)prop_below(&p, PROP_FILES);
+			unsigned int d = (unsigned int)prop_below(&p, 2);
 
-			if (insert_hashed_block(&tree, digest, files[f], offs[i]))
+			if (insert_hashed_block(&tree, digests[d], files[f],
+						offs[i]))
 				abort();
 		}
 
 		sort_file_hash_heads(&tree);
 
-		dl = find_block_list(&tree, digest);
-		prop_check(&p, dl != NULL);
-		for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
-			struct file_hash_head *h =
-				rb_entry(n, struct file_hash_head, h_node);
-			struct file_block *b;
-			uint64_t prev = 0;
-			bool first = true;
+		for (dn = rb_first(&tree.root); dn; dn = rb_next(dn)) {
+			struct dupe_blocks_list *dl =
+				rb_entry(dn, struct dupe_blocks_list, dl_node);
+			struct rb_node *n;
 
-			list_for_each_entry(b, &h->h_blocks, b_head_list) {
-				prop_check(&p, b->b_file == h->h_file);
-				prop_check(&p, first || b->b_loff > prev);
-				prev = b->b_loff;
-				first = false;
+			for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
+				struct file_hash_head *h =
+					rb_entry(n, struct file_hash_head, h_node);
+				struct file_block *b;
+				uint64_t prev = 0;
+				bool first = true;
+
+				heads++;
+				list_for_each_entry(b, &h->h_blocks, b_head_list) {
+					prop_check(&p, b->b_file == h->h_file);
+					prop_check(&p, first || b->b_loff > prev);
+					prev = b->b_loff;
+					first = false;
+				}
 			}
-			prop_check(&p, !first);	/* no empty heads left behind */
 		}
+		/* Every list reached, not just the first. */
+		prop_check(&p, heads >= tree.num_hashes);
 
 		free_hash_tree(&tree);
-		filerecs_reset();
 	}
+	free_all_filerecs();
 }
 
 /*
- * A group's member count and its work figure must agree with the list it
- * actually holds, for any insertion sequence including repeats.
+ * A results tree's groups and their members stay consistent with what was
+ * inserted, across several digests *and* several lengths.
  *
- * dext_work() is the single definition of a group's work, and four separate
- * consumers depend on them agreeing: the largest-first sort key, the
- * per-thread status total, the byte-progress settlement target and the upfront
- * SQL total. A de_num_dupes that drifts from the list makes the bar wrong and
- * the settlement short, and nothing raises.
+ * A group is keyed on (digest, length) together, so drawing both is what makes
+ * the keying observable at all - with one digest at one length every case
+ * builds a one-node tree, num_dupes is never in question, and the comparator's
+ * second level never runs.
+ *
+ * dext_work() is the single definition of a group's work and four consumers
+ * depend on them agreeing: the largest-first sort key, the per-thread status
+ * total, the byte-progress settlement target and the upfront SQL total. It is
+ * restated here as arithmetic rather than called, so a change to the formula
+ * makes the two sides disagree instead of moving together.
  */
 MU_TEST(test_prop_a_dup_group_counts_its_own_members) {
 	declare_prop(p, 150);
-#define PROP_RT_LEN	4096
+#define PROP_LENS	3
+	struct filerec *files[PROP_FILES];
+	unsigned char digests[PROP_DIGESTS][DIGEST_LEN];
+	static const uint64_t lens[PROP_LENS] = {
+		PROP_LEN, PROP_LEN * 2, PROP_LEN * 3
+	};
+
+	free_all_filerecs();
+	for (unsigned int i = 0; i < PROP_FILES; i++)
+		files[i] = mkfilerec((int64_t)i + 1);
+	for (unsigned int i = 0; i < PROP_DIGESTS; i++)
+		digest_of(digests[i], i);
 
 	while (prop_next(&p)) {
 		struct results_tree res;
-		struct filerec *files[PROP_HT_FILES];
-		unsigned char digest[DIGEST_LEN];
 		unsigned int n = (unsigned int)prop_range(&p, 1, 16);
-		unsigned int unique = 0;
-		bool seen[PROP_HT_FILES][8];
+		unsigned int unique = 0, groups = 0;
+		/* Shadow model: which (digest, len) groups exist, and which
+		 * (digest, len, file, slot) extents are in them. */
+		bool has_group[PROP_DIGESTS][PROP_LENS] = {{false}};
+		bool seen[PROP_DIGESTS][PROP_LENS][PROP_FILES][4];
+		unsigned int members[PROP_DIGESTS][PROP_LENS] = {{0}};
 		struct rb_node *node;
 
-		filerecs_reset();
 		init_results_tree(&res);
-		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
-			files[i] = mkfilerec(i);
-		digest_of(digest, 1);
 		memset(seen, 0, sizeof(seen));
 
 		for (unsigned int i = 0; i < n; i++) {
-			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
-			unsigned int slot = (unsigned int)prop_below(&p, 8);
+			unsigned int d = (unsigned int)prop_below(&p, PROP_DIGESTS);
+			unsigned int l = (unsigned int)prop_below(&p, PROP_LENS);
+			unsigned int f = (unsigned int)prop_below(&p, PROP_FILES);
+			unsigned int slot = (unsigned int)prop_below(&p, 4);
 
 			/*
 			 * Repeats on purpose: the same (file, offset) twice is
 			 * one extent, not two, and the second insert must free
 			 * its own allocation rather than counting it.
 			 */
-			if (insert_one_result(&res, digest, files[f],
-					      slot * PROP_RT_LEN, PROP_RT_LEN,
+			if (insert_one_result(&res, digests[d], files[f],
+					      slot * PROP_LEN * 4, lens[l],
 					      0, false))
 				abort();
-			if (!seen[f][slot]) {
-				seen[f][slot] = true;
+			if (!has_group[d][l]) {
+				has_group[d][l] = true;
+				groups++;
+			}
+			if (!seen[d][l][f][slot]) {
+				seen[d][l][f][slot] = true;
+				members[d][l]++;
 				unique++;
 			}
 		}
 
 		prop_check(&p, res.num_extents == unique);
+		prop_check(&p, res.num_dupes == groups);
 
+		/* Each group is findable under its own key, and holds exactly
+		 * the members the model says. */
+		for (unsigned int d = 0; d < PROP_DIGESTS; d++) {
+			for (unsigned int l = 0; l < PROP_LENS; l++) {
+				struct dupe_extents *g =
+					find_dupe_extents(&res, digests[d], lens[l]);
+
+				if (!has_group[d][l]) {
+					prop_check(&p, g == NULL);
+					continue;
+				}
+				prop_check(&p, g != NULL);
+				prop_check(&p, g->de_num_dupes == members[d][l]);
+				prop_check(&p, g->de_len == lens[l]);
+			}
+		}
+
+		/* The list, the rbtree and the counter are three views of one
+		 * membership and must never disagree. */
 		for (node = rb_first(&res.root); node; node = rb_next(node)) {
 			struct dupe_extents *d =
 				rb_entry(node, struct dupe_extents, de_node);
@@ -3989,18 +4079,15 @@ MU_TEST(test_prop_a_dup_group_counts_its_own_members) {
 			for (m = rb_first(&d->de_extents_root); m; m = rb_next(m))
 				in_tree++;
 
-			/* The list, the tree and the counter are three views of
-			 * one membership and must never disagree. */
 			prop_check(&p, listed == d->de_num_dupes);
 			prop_check(&p, in_tree == d->de_num_dupes);
-			prop_check(&p, d->de_len == PROP_RT_LEN);
 			prop_check(&p, dext_work(d) ==
-				   (uint64_t)PROP_RT_LEN * (d->de_num_dupes - 1));
+				   d->de_len * (d->de_num_dupes - 1));
 		}
 
 		free_results_tree(&res);
-		filerecs_reset();
 	}
+	free_all_filerecs();
 }
 
 /*
@@ -4008,105 +4095,125 @@ MU_TEST(test_prop_a_dup_group_counts_its_own_members) {
  *
  * A group of one is meaningless - there is nothing left to dedupe against - so
  * dropping to one member removes that member too and frees the group. Removing
- * from a pair therefore takes *both* extents and answers 0, while removing
- * from a larger group takes one and answers the new count. A test written
- * against a three-member group alone never sees the cascade at all.
+ * from a pair therefore takes *both* extents and answers 0, where a straight
+ * decrement would say 1. A test written against a three-member group alone
+ * never reaches the cascade.
  */
 MU_TEST(test_removing_an_extent_collapses_a_group_of_one) {
 	struct results_tree res;
 	unsigned char digest[DIGEST_LEN];
-	struct filerec *a, *b, *c;
 	struct dupe_extents *d;
 	struct extent *e;
 
-	filerecs_reset();
+	free_all_filerecs();
 	init_results_tree(&res);
-	a = mkfilerec(0);
-	b = mkfilerec(1);
-	c = mkfilerec(2);
 	digest_of(digest, 1);
 
-	/* Three members: one comes out, two remain, and it says so. */
-	mu_check(insert_one_result(&res, digest, a, 0, PROP_RT_LEN, 0, false) == 0);
-	mu_check(insert_one_result(&res, digest, b, 0, PROP_RT_LEN, 0, false) == 0);
-	mu_check(insert_one_result(&res, digest, c, 0, PROP_RT_LEN, 0, false) == 0);
+	for (unsigned int i = 0; i < 3; i++)
+		mu_check(insert_one_result(&res, digest, mkfilerec(i + 1), 0,
+					   PROP_LEN, 0, false) == 0);
 	mu_check(res.num_extents == 3 && res.num_dupes == 1);
 
-	d = rb_entry(rb_first(&res.root), struct dupe_extents, de_node);
-	mu_check(d->de_num_dupes == 3);
+	/* Three members: one comes out, two remain, and it says so. */
+	d = find_dupe_extents(&res, digest, PROP_LEN);
+	mu_check(d && d->de_num_dupes == 3);
 	e = list_first_entry(&d->de_extents, struct extent, e_list);
 	mu_check(remove_extent(&res, e) == 2);
 	mu_check(res.num_extents == 2);
 	mu_check(res.num_dupes == 1);		/* the group survives */
 
-	/*
-	 * Two members: removing one leaves a group of one, which is removed
-	 * too. So the count drops by two, the group goes, and the answer is 0
-	 * rather than the 1 a straight decrement would give.
-	 */
-	d = rb_entry(rb_first(&res.root), struct dupe_extents, de_node);
+	/* Two members: removing one leaves a group of one, which goes too. */
+	d = find_dupe_extents(&res, digest, PROP_LEN);
+	mu_check(d != NULL);
 	e = list_first_entry(&d->de_extents, struct extent, e_list);
 	mu_check(remove_extent(&res, e) == 0);
 	mu_check(res.num_extents == 0);
 	mu_check(res.num_dupes == 0);
 	mu_check(RB_EMPTY_ROOT(&res.root));
+	mu_check(find_dupe_extents(&res, digest, PROP_LEN) == NULL);
 
 	free_results_tree(&res);
-	filerecs_reset();
+	free_all_filerecs();
 }
 
 /*
  * Groups are keyed on (digest, length) together, not on digest alone: two runs
- * of identical bytes of different lengths are not duplicates of each other,
- * and insert_one_result abort_on()s a length that disagrees with the group it
- * landed in. So the same digest at two lengths must make two groups.
+ * of identical bytes at different lengths are not duplicates of each other,
+ * and insert_one_result abort_on()s a length disagreeing with the group it
+ * landed in.
  */
 MU_TEST(test_a_group_is_keyed_on_digest_and_length_together) {
 	struct results_tree res;
 	unsigned char digest[DIGEST_LEN], other[DIGEST_LEN];
 	struct filerec *a, *b;
 
-	filerecs_reset();
+	free_all_filerecs();
 	init_results_tree(&res);
-	a = mkfilerec(0);
-	b = mkfilerec(1);
+	a = mkfilerec(1);
+	b = mkfilerec(2);
 	digest_of(digest, 1);
 	digest_of(other, 2);
 
-	mu_check(insert_one_result(&res, digest, a, 0, 4096, 0, false) == 0);
-	mu_check(insert_one_result(&res, digest, b, 0, 4096, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, a, 0, PROP_LEN, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, b, 0, PROP_LEN, 0, false) == 0);
 	mu_check(res.num_dupes == 1);
 
 	/* Same digest, different length: a second group, not an abort. */
-	mu_check(insert_one_result(&res, digest, a, 8192, 8192, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, a, PROP_LEN * 2, PROP_LEN * 2,
+				   0, false) == 0);
 	mu_check(res.num_dupes == 2);
 
 	/* Different digest, same length: a third. */
-	mu_check(insert_one_result(&res, other, a, 16384, 4096, 0, false) == 0);
+	mu_check(insert_one_result(&res, other, a, PROP_LEN * 8, PROP_LEN, 0,
+				   false) == 0);
 	mu_check(res.num_dupes == 3);
 	mu_check(res.num_extents == 4);
 
-	/* The anchor flag is set by the member that claims it and then sticks,
-	 * which is what pins a cross-pass group to one target. */
-	mu_check(insert_one_result(&res, other, b, 16384, 4096, 0, true) == 0);
-	{
-		struct rb_node *n;
-		bool found = false;
-
-		for (n = rb_first(&res.root); n; n = rb_next(n)) {
-			struct dupe_extents *d =
-				rb_entry(n, struct dupe_extents, de_node);
-
-			if (!memcmp(d->de_hash, other, DIGEST_LEN)) {
-				mu_check(d->de_anchored);
-				found = true;
-			}
-		}
-		mu_check(found);
-	}
+	/* Each is findable under its own key and not under the other's. */
+	mu_check(find_dupe_extents(&res, digest, PROP_LEN) != NULL);
+	mu_check(find_dupe_extents(&res, digest, PROP_LEN * 2) != NULL);
+	mu_check(find_dupe_extents(&res, other, PROP_LEN) != NULL);
+	mu_check(find_dupe_extents(&res, other, PROP_LEN * 2) == NULL);
 
 	free_results_tree(&res);
-	filerecs_reset();
+	free_all_filerecs();
+}
+
+/*
+ * The anchor flag latches: once a member claims it, later members that do not
+ * cannot clear it. That is what pins a group spanning several dedupe passes to
+ * one target instead of re-picking a least-fragmented one per pass.
+ *
+ * The order matters, and it is the whole test. Asserting it right after the
+ * anchored insert would pass just as well against `de_anchored = is_anchor`,
+ * because nothing follows to overwrite it - so "sticks" is only a claim if a
+ * non-anchored insert comes afterwards.
+ */
+MU_TEST(test_the_anchor_flag_latches_once_claimed) {
+	struct results_tree res;
+	unsigned char digest[DIGEST_LEN];
+	struct dupe_extents *d;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+	digest_of(digest, 1);
+
+	mu_check(insert_one_result(&res, digest, mkfilerec(1), 0, PROP_LEN, 0,
+				   false) == 0);
+	d = find_dupe_extents(&res, digest, PROP_LEN);
+	mu_check(d && !d->de_anchored);
+
+	mu_check(insert_one_result(&res, digest, mkfilerec(2), 0, PROP_LEN, 0,
+				   true) == 0);
+	mu_check(d->de_anchored);
+
+	/* The one that matters: a later plain member must not clear it. */
+	mu_check(insert_one_result(&res, digest, mkfilerec(3), 0, PROP_LEN, 0,
+				   false) == 0);
+	mu_check(d->de_anchored);
+
+	free_results_tree(&res);
+	free_all_filerecs();
 }
 
 MU_TEST(test_dedupe_classify_probe)
@@ -4203,7 +4310,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_prop_a_split_record_is_not_the_layout_it_covers);
 	MU_RUN_TEST(test_prop_stored_extents_come_back_where_they_were_put);
 	MU_RUN_TEST(test_filerec_the_registry_finds_what_was_put_in_it);
-	MU_RUN_TEST(test_filerec_survives_until_the_last_reference_goes);
+	MU_RUN_TEST(test_filerec_is_unfindable_once_its_last_reference_goes);
 	MU_RUN_TEST(test_prop_every_filerec_is_findable_by_its_own_id);
 	MU_RUN_TEST(test_prop_the_hash_tree_counts_what_it_holds);
 	MU_RUN_TEST(test_prop_removing_every_block_empties_the_hash_tree);
@@ -4211,6 +4318,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_prop_a_dup_group_counts_its_own_members);
 	MU_RUN_TEST(test_removing_an_extent_collapses_a_group_of_one);
 	MU_RUN_TEST(test_a_group_is_keyed_on_digest_and_length_together);
+	MU_RUN_TEST(test_the_anchor_flag_latches_once_claimed);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -3560,6 +3560,555 @@ MU_TEST(test_prop_stored_extents_come_back_where_they_were_put) {
 	}
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * The in-memory dedupe model: filerecs, the hash tree, the results tree
+ *
+ * All three are pure memory - no filesystem, no btrfs, no scan - and all three
+ * were at a 0% mutation kill rate before this: 502 mutants, nothing caught.
+ * They are also the only callers of the vendored kernel rbtree, so hammering
+ * them with generated insert/erase sequences is a better test of that copy
+ * than testing it directly would be.
+ * ---------------------------------------------------------------------------
+ */
+
+/* Every test here shares one global registry, so each one starts it over. */
+static void filerecs_reset(void)
+{
+	free_all_filerecs();
+	init_filerec();
+}
+
+/* A digest that differs in every byte for each n, so a comparator that reads
+ * the wrong end of it still sees a difference. */
+static void digest_of(unsigned char *out, unsigned int n)
+{
+	for (unsigned int i = 0; i < DIGEST_LEN; i++)
+		out[i] = (unsigned char)(n * 7 + i * 31);
+}
+
+static struct filerec *mkfilerec(unsigned int n)
+{
+	char name[64];
+	struct filerec *f;
+
+	snprintf(name, sizeof(name), "/tree/f%u", n);
+	f = filerec_new(name, (int64_t)n + 1, 4096 * (n + 1));
+	if (!f)
+		abort();
+	return f;
+}
+
+MU_TEST(test_filerec_the_registry_finds_what_was_put_in_it) {
+	struct filerec *a, *b;
+
+	filerecs_reset();
+	a = mkfilerec(1);
+	b = mkfilerec(2);
+
+	mu_check(filerec_find(2) == a);		/* fileid is n + 1 */
+	mu_check(filerec_find(3) == b);
+	mu_check(filerec_find(99) == NULL);	/* never inserted */
+
+	/* The fields it was created with, not just its identity. */
+	mu_check(!strcmp(a->filename, "/tree/f1"));
+	mu_check(a->size == 4096 * 2);
+	mu_check(a->fd == -1);			/* not opened yet */
+
+	filerecs_reset();
+	mu_check(filerec_find(2) == NULL);	/* and teardown really clears */
+}
+
+/*
+ * The lifetime refcount that keeps a filerec alive while a dedupe batch still
+ * references it. CLAUDE.md calls this the rule that prevents a heap
+ * use-after-free across batches - a cross-window anchor is referenced by two
+ * in-flight batches at once - and until now it was pinned only by the
+ * integration suite and valgrind, which see it as a crash rather than as a
+ * count.
+ */
+MU_TEST(test_filerec_survives_until_the_last_reference_goes) {
+	struct filerec *f;
+
+	filerecs_reset();
+	f = mkfilerec(1);
+	mu_check(f->refs == 0);		/* created unreferenced; teardown frees it */
+
+	/* Two batches take a reference, as two windows sharing an anchor do. */
+	filerec_get(f);
+	filerec_get(f);
+	mu_check(f->refs == 2);
+
+	/* The first batch reaps: still alive, still findable. */
+	filerec_put(f);
+	mu_check(filerec_find(2) == f);
+
+	/* The second reaps, and only now is it gone from the registry - so a
+	 * later lookup cannot hand out a freed pointer. */
+	filerec_put(f);
+	mu_check(filerec_find(2) == NULL);
+
+	filerecs_reset();
+}
+
+/*
+ * Every filerec inserted is findable by its own id and by no other, for any
+ * insertion order. The registry is an rbtree keyed by fileid, so this is the
+ * property that makes cmp_filerecs' answer observable: a comparator that
+ * inverts, or that compares the wrong field, still builds *a* tree - just one
+ * that cannot find things again.
+ */
+MU_TEST(test_prop_every_filerec_is_findable_by_its_own_id) {
+	declare_prop(p, 200);
+
+	while (prop_next(&p)) {
+		unsigned int n = (unsigned int)prop_range(&p, 1, 24);
+		int64_t ids[24];
+		struct filerec *made[24];
+
+		filerecs_reset();
+
+		/* Ids spread over a range wider than the count, so there are
+		 * gaps to look up as well as hits. */
+		for (unsigned int i = 0; i < n; i++) {
+			char name[64];
+			int64_t id;
+			bool dup;
+
+			do {
+				id = (int64_t)prop_range(&p, 1, 200);
+				dup = false;
+				for (unsigned int j = 0; j < i; j++)
+					if (ids[j] == id)
+						dup = true;
+			} while (dup);
+			ids[i] = id;
+			snprintf(name, sizeof(name), "/tree/%lld",
+				 (long long)id);
+			made[i] = filerec_new(name, id, 4096 * (uint64_t)id);
+			if (!made[i])
+				abort();
+		}
+
+		for (unsigned int i = 0; i < n; i++) {
+			prop_check(&p, filerec_find(ids[i]) == made[i]);
+			prop_check(&p, made[i]->fileid == ids[i]);
+			prop_check(&p, made[i]->size == 4096 * (uint64_t)ids[i]);
+		}
+
+		/* And an id nobody inserted is not answered with a neighbour. */
+		for (int64_t probe = 201; probe <= 205; probe++)
+			prop_check(&p, filerec_find(probe) == NULL);
+	}
+	filerecs_reset();
+}
+
+/*
+ * Everything the hash tree counts stays consistent with what is in it, for any
+ * mix of files, digests and offsets - and then survives having every block
+ * taken back out again.
+ *
+ * Three counters have to agree with three different things: tree->num_blocks
+ * with the blocks inserted, tree->num_hashes with the *distinct* digests, and
+ * each dl_num_elem with that digest's share. Nothing downstream validates
+ * them; find_dupes reads them to decide what to compare, so a count that
+ * drifts makes oans quietly compare the wrong set.
+ */
+MU_TEST(test_prop_the_hash_tree_counts_what_it_holds) {
+	declare_prop(p, 120);
+#define PROP_HT_FILES	4
+#define PROP_HT_DIGESTS	5
+#define PROP_HT_BLOCKS	24
+
+	while (prop_next(&p)) {
+		struct hash_tree tree;
+		struct filerec *files[PROP_HT_FILES];
+		unsigned char digests[PROP_HT_DIGESTS][DIGEST_LEN];
+		unsigned int per_digest[PROP_HT_DIGESTS] = {0};
+		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_HT_BLOCKS);
+		unsigned int distinct = 0;
+		uint64_t next_loff[PROP_HT_FILES] = {0};
+
+		filerecs_reset();
+		init_hash_tree(&tree);
+		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
+			files[i] = mkfilerec(i);
+		for (unsigned int i = 0; i < PROP_HT_DIGESTS; i++)
+			digest_of(digests[i], i);
+
+		for (unsigned int i = 0; i < nb; i++) {
+			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
+			unsigned int d = (unsigned int)prop_below(&p, PROP_HT_DIGESTS);
+
+			/* Distinct offsets per file: two blocks of one file at
+			 * one offset is not a shape the scan produces, and the
+			 * filerec block tree is keyed on it. */
+			if (insert_hashed_block(&tree, digests[d], files[f],
+						next_loff[f]))
+				abort();
+			next_loff[f] += blocksize;
+			if (per_digest[d]++ == 0)
+				distinct++;
+		}
+
+		prop_check(&p, tree.num_blocks == nb);
+		prop_check(&p, tree.num_hashes == distinct);
+
+		for (unsigned int d = 0; d < PROP_HT_DIGESTS; d++) {
+			struct dupe_blocks_list *dl =
+				find_block_list(&tree, digests[d]);
+
+			if (!per_digest[d]) {
+				/* Never inserted: not answered with a
+				 * neighbouring digest's list. */
+				prop_check(&p, dl == NULL);
+				continue;
+			}
+			prop_check(&p, dl != NULL);
+			prop_check(&p, dl && dl->dl_num_elem == per_digest[d]);
+			prop_check(&p, dl && !memcmp(dl->dl_hash, digests[d],
+						     DIGEST_LEN));
+		}
+
+		/* Every block is findable at the offset it was filed under. */
+		for (unsigned int f = 0; f < PROP_HT_FILES; f++) {
+			for (uint64_t off = 0; off < next_loff[f];
+			     off += blocksize) {
+				struct file_block *b =
+					find_filerec_block(files[f], off);
+
+				prop_check(&p, b != NULL);
+				prop_check(&p, b && b->b_loff == off);
+				prop_check(&p, b && b->b_file == files[f]);
+			}
+			prop_check(&p, find_filerec_block(files[f],
+							  next_loff[f]) == NULL);
+		}
+
+		free_hash_tree(&tree);
+		filerecs_reset();
+	}
+}
+
+/*
+ * Taking blocks back out is the other half, and it has a return value nobody
+ * checks: remove_hashed_block answers 1 exactly when it removed the *last*
+ * block carrying that digest, having freed the list. find_dupes uses that to
+ * know the group is gone, so an answer that is right about the tree and wrong
+ * about the verdict leaves a caller holding a freed list.
+ */
+MU_TEST(test_prop_removing_every_block_empties_the_hash_tree) {
+	declare_prop(p, 120);
+
+	while (prop_next(&p)) {
+		struct hash_tree tree;
+		struct filerec *file;
+		unsigned char digests[PROP_HT_DIGESTS][DIGEST_LEN];
+		unsigned int per_digest[PROP_HT_DIGESTS] = {0};
+		unsigned int which[PROP_HT_BLOCKS];
+		unsigned int nb = (unsigned int)prop_range(&p, 1, PROP_HT_BLOCKS);
+		unsigned int distinct = 0;
+
+		filerecs_reset();
+		init_hash_tree(&tree);
+		file = mkfilerec(0);
+		for (unsigned int i = 0; i < PROP_HT_DIGESTS; i++)
+			digest_of(digests[i], i);
+
+		for (unsigned int i = 0; i < nb; i++) {
+			unsigned int d = (unsigned int)prop_below(&p, PROP_HT_DIGESTS);
+
+			which[i] = d;
+			if (insert_hashed_block(&tree, digests[d], file,
+						blocksize * i))
+				abort();
+			if (per_digest[d]++ == 0)
+				distinct++;
+		}
+
+		/* Remove in insertion order, so the last block of a digest is
+		 * reached at a different point for each one. */
+		for (unsigned int i = 0; i < nb; i++) {
+			unsigned int d = which[i];
+			struct file_block *b =
+				find_filerec_block(file, blocksize * i);
+			bool last = --per_digest[d] == 0;
+			int ret;
+
+			prop_check(&p, b != NULL);
+			if (!b)
+				break;
+			ret = remove_hashed_block(&tree, b);
+			prop_check(&p, ret == (last ? 1 : 0));
+			if (last)
+				distinct--;
+			prop_check(&p, tree.num_hashes == distinct);
+			prop_check(&p, tree.num_blocks == nb - i - 1);
+		}
+
+		prop_check(&p, tree.num_blocks == 0 && tree.num_hashes == 0);
+		prop_check(&p, RB_EMPTY_ROOT(&tree.root));
+
+		free_hash_tree(&tree);
+		filerecs_reset();
+	}
+}
+
+/*
+ * find_dupes walks each file's blocks under a hash expecting increasing
+ * offsets, and says so at sort_file_hash_heads' declaration. The blocks arrive
+ * in offset order only because the scan happens to produce them that way, so
+ * the sort is what makes the requirement true rather than merely usual - and a
+ * fixture that inserts in order cannot tell a working sort from no sort at all.
+ * Hence a deliberately shuffled insertion order here.
+ */
+MU_TEST(test_prop_sorting_puts_every_hash_head_in_offset_order) {
+	declare_prop(p, 120);
+
+	while (prop_next(&p)) {
+		struct hash_tree tree;
+		struct filerec *files[PROP_HT_FILES];
+		unsigned char digest[DIGEST_LEN];
+		uint64_t offs[PROP_HT_BLOCKS];
+		unsigned int nb = (unsigned int)prop_range(&p, 2, PROP_HT_BLOCKS);
+		struct dupe_blocks_list *dl;
+		struct rb_node *n;
+
+		filerecs_reset();
+		init_hash_tree(&tree);
+		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
+			files[i] = mkfilerec(i);
+		digest_of(digest, 0);
+
+		/* Distinct offsets, then shuffled, so the insertion order is
+		 * unrelated to the order the sort has to produce. */
+		for (unsigned int i = 0; i < nb; i++)
+			offs[i] = blocksize * i;
+		for (unsigned int i = nb; i > 1; i--) {
+			unsigned int j = (unsigned int)prop_below(&p, i);
+			uint64_t t = offs[i - 1];
+
+			offs[i - 1] = offs[j];
+			offs[j] = t;
+		}
+
+		for (unsigned int i = 0; i < nb; i++) {
+			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
+
+			if (insert_hashed_block(&tree, digest, files[f], offs[i]))
+				abort();
+		}
+
+		sort_file_hash_heads(&tree);
+
+		dl = find_block_list(&tree, digest);
+		prop_check(&p, dl != NULL);
+		for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
+			struct file_hash_head *h =
+				rb_entry(n, struct file_hash_head, h_node);
+			struct file_block *b;
+			uint64_t prev = 0;
+			bool first = true;
+
+			list_for_each_entry(b, &h->h_blocks, b_head_list) {
+				prop_check(&p, b->b_file == h->h_file);
+				prop_check(&p, first || b->b_loff > prev);
+				prev = b->b_loff;
+				first = false;
+			}
+			prop_check(&p, !first);	/* no empty heads left behind */
+		}
+
+		free_hash_tree(&tree);
+		filerecs_reset();
+	}
+}
+
+/*
+ * A group's member count and its work figure must agree with the list it
+ * actually holds, for any insertion sequence including repeats.
+ *
+ * dext_work() is the single definition of a group's work, and four separate
+ * consumers depend on them agreeing: the largest-first sort key, the
+ * per-thread status total, the byte-progress settlement target and the upfront
+ * SQL total. A de_num_dupes that drifts from the list makes the bar wrong and
+ * the settlement short, and nothing raises.
+ */
+MU_TEST(test_prop_a_dup_group_counts_its_own_members) {
+	declare_prop(p, 150);
+#define PROP_RT_LEN	4096
+
+	while (prop_next(&p)) {
+		struct results_tree res;
+		struct filerec *files[PROP_HT_FILES];
+		unsigned char digest[DIGEST_LEN];
+		unsigned int n = (unsigned int)prop_range(&p, 1, 16);
+		unsigned int unique = 0;
+		bool seen[PROP_HT_FILES][8];
+		struct rb_node *node;
+
+		filerecs_reset();
+		init_results_tree(&res);
+		for (unsigned int i = 0; i < PROP_HT_FILES; i++)
+			files[i] = mkfilerec(i);
+		digest_of(digest, 1);
+		memset(seen, 0, sizeof(seen));
+
+		for (unsigned int i = 0; i < n; i++) {
+			unsigned int f = (unsigned int)prop_below(&p, PROP_HT_FILES);
+			unsigned int slot = (unsigned int)prop_below(&p, 8);
+
+			/*
+			 * Repeats on purpose: the same (file, offset) twice is
+			 * one extent, not two, and the second insert must free
+			 * its own allocation rather than counting it.
+			 */
+			if (insert_one_result(&res, digest, files[f],
+					      slot * PROP_RT_LEN, PROP_RT_LEN,
+					      0, false))
+				abort();
+			if (!seen[f][slot]) {
+				seen[f][slot] = true;
+				unique++;
+			}
+		}
+
+		prop_check(&p, res.num_extents == unique);
+
+		for (node = rb_first(&res.root); node; node = rb_next(node)) {
+			struct dupe_extents *d =
+				rb_entry(node, struct dupe_extents, de_node);
+			struct extent *e;
+			unsigned int listed = 0, in_tree = 0;
+			struct rb_node *m;
+
+			list_for_each_entry(e, &d->de_extents, e_list) {
+				prop_check(&p, e->e_parent == d);
+				listed++;
+			}
+			for (m = rb_first(&d->de_extents_root); m; m = rb_next(m))
+				in_tree++;
+
+			/* The list, the tree and the counter are three views of
+			 * one membership and must never disagree. */
+			prop_check(&p, listed == d->de_num_dupes);
+			prop_check(&p, in_tree == d->de_num_dupes);
+			prop_check(&p, d->de_len == PROP_RT_LEN);
+			prop_check(&p, dext_work(d) ==
+				   (uint64_t)PROP_RT_LEN * (d->de_num_dupes - 1));
+		}
+
+		free_results_tree(&res);
+		filerecs_reset();
+	}
+}
+
+/*
+ * remove_extent's cascade, which is the part a fixture gets wrong.
+ *
+ * A group of one is meaningless - there is nothing left to dedupe against - so
+ * dropping to one member removes that member too and frees the group. Removing
+ * from a pair therefore takes *both* extents and answers 0, while removing
+ * from a larger group takes one and answers the new count. A test written
+ * against a three-member group alone never sees the cascade at all.
+ */
+MU_TEST(test_removing_an_extent_collapses_a_group_of_one) {
+	struct results_tree res;
+	unsigned char digest[DIGEST_LEN];
+	struct filerec *a, *b, *c;
+	struct dupe_extents *d;
+	struct extent *e;
+
+	filerecs_reset();
+	init_results_tree(&res);
+	a = mkfilerec(0);
+	b = mkfilerec(1);
+	c = mkfilerec(2);
+	digest_of(digest, 1);
+
+	/* Three members: one comes out, two remain, and it says so. */
+	mu_check(insert_one_result(&res, digest, a, 0, PROP_RT_LEN, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, b, 0, PROP_RT_LEN, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, c, 0, PROP_RT_LEN, 0, false) == 0);
+	mu_check(res.num_extents == 3 && res.num_dupes == 1);
+
+	d = rb_entry(rb_first(&res.root), struct dupe_extents, de_node);
+	mu_check(d->de_num_dupes == 3);
+	e = list_first_entry(&d->de_extents, struct extent, e_list);
+	mu_check(remove_extent(&res, e) == 2);
+	mu_check(res.num_extents == 2);
+	mu_check(res.num_dupes == 1);		/* the group survives */
+
+	/*
+	 * Two members: removing one leaves a group of one, which is removed
+	 * too. So the count drops by two, the group goes, and the answer is 0
+	 * rather than the 1 a straight decrement would give.
+	 */
+	d = rb_entry(rb_first(&res.root), struct dupe_extents, de_node);
+	e = list_first_entry(&d->de_extents, struct extent, e_list);
+	mu_check(remove_extent(&res, e) == 0);
+	mu_check(res.num_extents == 0);
+	mu_check(res.num_dupes == 0);
+	mu_check(RB_EMPTY_ROOT(&res.root));
+
+	free_results_tree(&res);
+	filerecs_reset();
+}
+
+/*
+ * Groups are keyed on (digest, length) together, not on digest alone: two runs
+ * of identical bytes of different lengths are not duplicates of each other,
+ * and insert_one_result abort_on()s a length that disagrees with the group it
+ * landed in. So the same digest at two lengths must make two groups.
+ */
+MU_TEST(test_a_group_is_keyed_on_digest_and_length_together) {
+	struct results_tree res;
+	unsigned char digest[DIGEST_LEN], other[DIGEST_LEN];
+	struct filerec *a, *b;
+
+	filerecs_reset();
+	init_results_tree(&res);
+	a = mkfilerec(0);
+	b = mkfilerec(1);
+	digest_of(digest, 1);
+	digest_of(other, 2);
+
+	mu_check(insert_one_result(&res, digest, a, 0, 4096, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, b, 0, 4096, 0, false) == 0);
+	mu_check(res.num_dupes == 1);
+
+	/* Same digest, different length: a second group, not an abort. */
+	mu_check(insert_one_result(&res, digest, a, 8192, 8192, 0, false) == 0);
+	mu_check(res.num_dupes == 2);
+
+	/* Different digest, same length: a third. */
+	mu_check(insert_one_result(&res, other, a, 16384, 4096, 0, false) == 0);
+	mu_check(res.num_dupes == 3);
+	mu_check(res.num_extents == 4);
+
+	/* The anchor flag is set by the member that claims it and then sticks,
+	 * which is what pins a cross-pass group to one target. */
+	mu_check(insert_one_result(&res, other, b, 16384, 4096, 0, true) == 0);
+	{
+		struct rb_node *n;
+		bool found = false;
+
+		for (n = rb_first(&res.root); n; n = rb_next(n)) {
+			struct dupe_extents *d =
+				rb_entry(n, struct dupe_extents, de_node);
+
+			if (!memcmp(d->de_hash, other, DIGEST_LEN)) {
+				mu_check(d->de_anchored);
+				found = true;
+			}
+		}
+		mu_check(found);
+	}
+
+	free_results_tree(&res);
+	filerecs_reset();
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -3653,6 +4202,15 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_prop_a_layout_matches_only_itself);
 	MU_RUN_TEST(test_prop_a_split_record_is_not_the_layout_it_covers);
 	MU_RUN_TEST(test_prop_stored_extents_come_back_where_they_were_put);
+	MU_RUN_TEST(test_filerec_the_registry_finds_what_was_put_in_it);
+	MU_RUN_TEST(test_filerec_survives_until_the_last_reference_goes);
+	MU_RUN_TEST(test_prop_every_filerec_is_findable_by_its_own_id);
+	MU_RUN_TEST(test_prop_the_hash_tree_counts_what_it_holds);
+	MU_RUN_TEST(test_prop_removing_every_block_empties_the_hash_tree);
+	MU_RUN_TEST(test_prop_sorting_puts_every_hash_head_in_offset_order);
+	MU_RUN_TEST(test_prop_a_dup_group_counts_its_own_members);
+	MU_RUN_TEST(test_removing_an_extent_collapses_a_group_of_one);
+	MU_RUN_TEST(test_a_group_is_keyed_on_digest_and_length_together);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -4216,6 +4216,229 @@ MU_TEST(test_the_anchor_flag_latches_once_claimed) {
 	free_all_filerecs();
 }
 
+/*
+ * insert_result() is the pair-wise entry point find_dupes actually calls;
+ * insert_one_result() above is the single-extent variant. Testing the helper
+ * and not this one left 36 of results-tree.c's mutants untouched.
+ *
+ * Two things here that only this signature has. The group's length comes from
+ * `endoff[0] - startoff[0] + 1` - **inclusive**, and taken from the *first*
+ * pair alone - so an off-by-one silently files the pair under a neighbouring
+ * key, where it can never meet the extents it duplicates. And both extents go
+ * into one group, so a pair that is really the same extent twice must count
+ * once.
+ */
+MU_TEST(test_insert_result_files_a_pair_under_one_length) {
+	struct results_tree res;
+	unsigned char digest[DIGEST_LEN];
+	struct filerec *recs[2];
+	uint64_t startoff[2], endoff[2];
+	struct dupe_extents *d;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+	digest_of(digest, 1);
+	recs[0] = mkfilerec(1);
+	recs[1] = mkfilerec(2);
+
+	/* An inclusive range of exactly PROP_LEN bytes. */
+	startoff[0] = 0;
+	endoff[0] = PROP_LEN - 1;
+	startoff[1] = PROP_LEN * 4;
+	endoff[1] = PROP_LEN * 5 - 1;
+	mu_check(insert_result(&res, digest, recs, startoff, endoff) == 0);
+
+	mu_check(res.num_dupes == 1);
+	mu_check(res.num_extents == 2);
+	d = find_dupe_extents(&res, digest, PROP_LEN);
+	mu_check(d != NULL);			/* not PROP_LEN - 1, nor + 1 */
+	mu_check(d && d->de_num_dupes == 2);
+	mu_check(find_dupe_extents(&res, digest, PROP_LEN - 1) == NULL);
+	mu_check(find_dupe_extents(&res, digest, PROP_LEN + 1) == NULL);
+
+	/* The second file's offset is its own, not a copy of the first's. */
+	{
+		struct extent *e;
+		bool at_0 = false, at_4 = false;
+
+		list_for_each_entry(e, &d->de_extents, e_list) {
+			if (e->e_file == recs[0] && e->e_loff == 0)
+				at_0 = true;
+			if (e->e_file == recs[1] && e->e_loff == PROP_LEN * 4)
+				at_4 = true;
+		}
+		mu_check(at_0 && at_4);
+	}
+
+	/* The same extent named twice is one member, not two. */
+	recs[1] = recs[0];
+	startoff[1] = startoff[0];
+	endoff[1] = endoff[0];
+	mu_check(insert_result(&res, digest, recs, startoff, endoff) == 0);
+	mu_check(res.num_extents == 2);		/* unchanged */
+	mu_check(d->de_num_dupes == 2);
+
+	free_results_tree(&res);
+	free_all_filerecs();
+}
+
+/* A real file to open. Any filesystem will do - this is fd bookkeeping, not
+ * dedupe - so it does not need the reflink scratch dir. */
+static struct filerec *mkrealfile(char *path, size_t sz)
+{
+	int fd;
+
+	snprintf(path, sz, "/tmp/oans-filerec-XXXXXX");
+	fd = mkstemp(path);
+	if (fd < 0 || write(fd, "hello", 5) != 5)
+		abort();
+	close(fd);
+	return filerec_new(path, 1, 5);
+}
+
+/*
+ * The file descriptor is reference counted, and that is the whole point: the
+ * dedupe phase opens the same file from several groups at once, so a nested
+ * open must hand back the descriptor already open rather than a second one.
+ * Opening twice and closing twice looks correct either way from the outside -
+ * what separates a real refcount from open-and-close-every-time is that the
+ * descriptor stays *usable* across the inner close, which is why this reads a
+ * byte through it rather than only inspecting the counter.
+ */
+MU_TEST(test_filerec_holds_one_descriptor_however_often_it_is_opened) {
+	char path[64];
+	struct filerec *f;
+	char buf[1];
+	int first_fd;
+
+	free_all_filerecs();
+	f = mkrealfile(path, sizeof(path));
+	mu_check(f->fd == -1 && f->fd_refs == 0);
+
+	mu_check(filerec_open(f, false) == 0);
+	mu_check(f->fd != -1 && f->fd_refs == 1);
+	first_fd = f->fd;
+
+	/* Nested open: the same descriptor, not a second one. */
+	mu_check(filerec_open(f, false) == 0);
+	mu_check(f->fd == first_fd);
+	mu_check(f->fd_refs == 2);
+
+	filerec_close(f);
+	mu_check(f->fd_refs == 1);
+	mu_check(f->fd == first_fd);
+	/* Still open, which a close-every-time implementation would fail. */
+	mu_check(pread(f->fd, buf, 1, 0) == 1 && buf[0] == 'h');
+
+	filerec_close(f);
+	mu_check(f->fd_refs == 0 && f->fd == -1);
+
+	/* A file that is not there reports the errno and leaves the filerec
+	 * closed rather than counting a descriptor it never got. */
+	unlink(path);
+	mu_check(filerec_open(f, true) == ENOENT);
+	mu_check(f->fd == -1 && f->fd_refs == 0);
+
+	free_all_filerecs();
+}
+
+/*
+ * filerec_open_once() is what the dedupe phase uses to open every member of a
+ * group without opening any of them twice. It remembers what it has opened in
+ * a token tree keyed on the filerec, so asking again is a no-op - and the test
+ * of that is the *refcount*, since a second real open would leave a
+ * descriptor no close in the batch will ever release.
+ */
+MU_TEST(test_filerec_open_once_opens_each_file_exactly_once) {
+	char path[64];
+	struct filerec *f;
+	OPEN_ONCE(open_files);
+
+	free_all_filerecs();
+	f = mkrealfile(path, sizeof(path));
+
+	mu_check(filerec_open_once(f, &open_files) == 0);
+	mu_check(f->fd_refs == 1);
+
+	/* Asked twice, opened once. */
+	mu_check(filerec_open_once(f, &open_files) == 0);
+	mu_check(f->fd_refs == 1);
+	mu_check(filerec_open_once(f, &open_files) == 0);
+	mu_check(f->fd_refs == 1);
+
+	filerec_close_open_list(&open_files);
+	mu_check(f->fd_refs == 0 && f->fd == -1);
+	mu_check(RB_EMPTY_ROOT(&open_files.root));
+
+	/* A missing file is reported, and leaves no token behind claiming it
+	 * was opened - otherwise a later pass would skip opening it. */
+	unlink(path);
+	mu_check(filerec_open_once(f, &open_files) == ENOENT);
+	mu_check(RB_EMPTY_ROOT(&open_files.root));
+	mu_check(f->fd_refs == 0);
+
+	free_all_filerecs();
+}
+
+/*
+ * The token tree is keyed on the filerec *pointer*, which is what makes the
+ * lookup above cheap. Worth its own case because pointer ordering is the one
+ * comparator here whose operands a test cannot choose: the property below
+ * inserts whatever addresses the allocator hands out, so it fails only if the
+ * comparator disagrees with itself.
+ */
+MU_TEST(test_prop_a_filerec_token_is_found_by_its_filerec) {
+	declare_prop(p, 120);
+	struct filerec *files[PROP_FILES];
+
+	free_all_filerecs();
+	for (unsigned int i = 0; i < PROP_FILES; i++)
+		files[i] = mkfilerec((int64_t)i + 1);
+
+	while (prop_next(&p)) {
+		struct rb_root root = RB_ROOT;
+		bool inserted[PROP_FILES] = {false};
+		uint64_t order[PROP_FILES];
+		unsigned int n = (unsigned int)prop_range(&p, 1, PROP_FILES);
+
+		for (unsigned int i = 0; i < PROP_FILES; i++)
+			order[i] = i;
+		prop_shuffle_u64(&p, order, PROP_FILES);
+
+		for (unsigned int i = 0; i < n; i++) {
+			struct filerec *f = files[order[i]];
+			struct filerec_token *t = filerec_token_new(f);
+
+			if (!t)
+				abort();
+			insert_filerec_token_rb(&root, t);
+			inserted[order[i]] = true;
+		}
+
+		for (unsigned int i = 0; i < PROP_FILES; i++) {
+			struct filerec_token *t =
+				find_filerec_token_rb(&root, files[i]);
+
+			if (!inserted[i]) {
+				prop_check(&p, t == NULL);
+				continue;
+			}
+			prop_check(&p, t != NULL);
+			prop_check(&p, t->t_file == files[i]);
+		}
+
+		while (!RB_EMPTY_ROOT(&root)) {
+			struct filerec_token *t =
+				rb_entry(rb_first(&root), struct filerec_token,
+					 t_node);
+
+			rb_erase(&t->t_node, &root);
+			filerec_token_free(t);
+		}
+	}
+	free_all_filerecs();
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -4319,6 +4542,10 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_removing_an_extent_collapses_a_group_of_one);
 	MU_RUN_TEST(test_a_group_is_keyed_on_digest_and_length_together);
 	MU_RUN_TEST(test_the_anchor_flag_latches_once_claimed);
+	MU_RUN_TEST(test_insert_result_files_a_pair_under_one_length);
+	MU_RUN_TEST(test_filerec_holds_one_descriptor_however_often_it_is_opened);
+	MU_RUN_TEST(test_filerec_open_once_opens_each_file_exactly_once);
+	MU_RUN_TEST(test_prop_a_filerec_token_is_found_by_its_filerec);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run


### PR DESCRIPTION
Second of the "make more of oans reachable from the unit suite" series, after #234. Picked by measurement again: `filerec.c`, `hash-tree.c` and `results-tree.c` are 1,055 lines of pure memory — no filesystem, no btrfs, no scan — and were at a **0% mutation kill rate**. 502 live mutants, not one caught.

| | recon | after pass 1 | final | killed |
|---|---|---|---|---|
| `src/hash-tree.c` | 141 / 141 | 37 | **37** | 73% |
| `src/results-tree.c` | 207 / 207 | 76 | **50** | 75% |
| `src/filerec.c` | 154 / 154 | 106 | **48** | 68% |
| | **502 / 502** | 219 | **135** | **73%** |

## Why not `rbtree.c` and `list_sort.c`

They were the planned target and the plan's premise was wrong. Both are verbatim `linux/lib` code exposing only the kernel's own API, so sweeping them would measure upstream's design, not oans's tests — the same reasoning as "`mutate_core.py` is vendored, never edit it here."

These three files are their **only callers**, so generated insert *and erase* orders here exercise that copy through the interface oans actually uses. The erase order matters specifically: inserting and removing in one ascending sweep only ever unlinks a spine and never makes the tree rebalance.

## Reading the residue by function found two blocks the tests never called

The first pass came back at 56% — a perfectly respectable-looking number. Grouped by function, three blocks had not moved by a *single* mutant, and two of them were my omissions rather than unreachable code:

- **`insert_result` 36 → 36.** It is the pair-wise entry point `find_dupes` actually calls; I had tested `insert_one_result`, its single-extent sibling, and stopped.
- **`filerec_open`/`close`/`open_once` 53 → 53.** These need a real file, which is all that was missing — it is fd bookkeeping, so any filesystem does.
- **`insert_filerec_token_rb` 8 → 8.** The token tree, untouched.

Closing those took the total from 219 to 135: `insert_result` 36→10, `filerec_open` 23→3, `filerec_close` 19→6, `filerec_open_once` 11→2, `insert_filerec_token_rb` 8→3. The total hid all of that; only the grouping showed it.

## Contracts a fixture gets wrong first

- **`insert_result()`'s length is `endoff[0] - startoff[0] + 1`** — inclusive, and taken from the *first* pair alone. One byte short files every pair under a length no other extent is ever filed under: the group still forms, nothing errors, those extents simply never meet their duplicates. Pinned by looking the group up at `len`, `len - 1` and `len + 1`.
- **`remove_extent()` collapses a group that drops to one member** — there is nothing left to dedupe against — so removing from a *pair* takes both extents and answers 0 where a straight decrement says 1. A test written against a three-member group never reaches the cascade.
- **`remove_hashed_block()` answers 1 only when it freed the whole list.** That is how `find_dupes` learns not to keep walking it, so an answer right about the tree and wrong about the verdict is a use-after-free the counters do nothing to reveal.
- **Several files, or the test sees nothing.** A `file_hash_head` is freed when *that file's* sublist drains; with one file that always coincides with the block list being freed, so the leak is invisible. `sort_file_hash_heads()` is two nested walks, so one digest leaves the outer one unobservable.
- **The fd refcount needs a read, not a counter.** What separates a real refcount from close-every-time is that the descriptor stays *usable* across an inner close, so the test reads a byte through it.

## The `/simplify` pass caught a comment of mine that was false

I had written that the refcount test pins CLAUDE.md's cross-batch lifetime rule. **`free_all_filerecs()` frees every filerec whatever its `refs`** — so "survives until the last reference goes" is not true of this module at all, and the teardown on that test's own last line disproves it. That rule lives in `run_dedupe.c`'s batch refs and is not a unit-testable claim. The test now claims the smaller true thing: the free erases the fileid node, so a later lookup cannot return a dead pointer.

Three more findings were tests that could not see the mutation they existed for:

- The anchor assertion sat immediately after the anchored insert, so it passed just as well against `de_anchored = is_anchor`. "Latches" is only a claim if a non-anchored insert follows — one now does, in its own test.
- The sort property used one digest (see above).
- The dup-group property fixed both digest *and* length, which are exactly the group key — so all 150 cases built a one-node tree and `num_dupes` was never in question. Both are drawn now.

Reuse findings: `find_dupe_extents()` already existed, replacing a hand-rolled tree scan and an assumption about which group sorts first; `init_filerec()` in the reset helper was dead; `PROP_RT_LEN` duplicated `PROP_BLOCK`. Efficiency: the fixtures are hoisted out of four property loops (~1,680 create/destroy cycles), verified safe first — `free_hash_tree()` drives `remove_hashed_block` over every block, which `rb_erase`s each from its filerec's own tree.

**Skipped**, with the reason: merging the two hash-tree properties into one lifecycle test. The altitude findings pull the removal half toward its own multi-file fixture and generated erase order, so they are now less alike, not more.

## Bug files

Nine invariants put back, in **three** files rather than one. A bug file names a single source on its own first line, so a mixed file silently fails to apply six of nine blocks — the flattering direction, and exactly why the tool refuses a block matching zero times. All nine caught; `make mutation-replay` is now **58 across eight files, nothing surviving**.

## Verification

`WERROR=1 make` clean · `make lint` clean · `make test` — **88 tests, 1,283,536 assertions, 0.30 s** · `make test CC=clang SANITIZE=address,undefined` clean · valgrind **0 lost, 0 errors, 0 suppressed** · `make mutation-replay` 58/58.

**Not run locally: the Python integration suite.** This container is ext4 with no reflink filesystem. As with #234 the change is test-only — `Makefile:46` filters `src/tests.c` out of the binary — so the btrfs and xfs legs are CI's.

## Next

The residue is now mostly `filerec_open`'s error paths and allocation-failure branches no unit test can provoke. The named next step is the four `GET_DUPLICATE_*` loaders in `dbfile.c` (67–75% survival), which were deferred from #234 precisely because they need the `hash_tree`/`results_tree` fixture this PR builds.

Still worth deciding separately: `oans.c` and `run_dedupe.c` are not compiled into `./test`, so the mutation tool reports **0% killed** on them rather than refusing — a false report in the flattering direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_