### PR TITLE
test: the dedupe-phase loaders (155 → 41 mutation survivors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,47 @@ sweep from **901 survivors to 785**.
   to a bare `return;`; gcc warns, clang refuses. Conditions that mean "the test
   itself is broken" `abort()` instead, the way `gs_hit()` already did.
 
+### The dedupe-phase loaders
+
+Where the hashfile meets the in-memory model. **155 mutants, 0% killed → 73%**
+(41 survivors) on ten tests, and they need *both* fixtures at once - `memdb()`
+and `mkfilerec()`/`free_all_filerecs()` - which is why they came last.
+
+- **`GET_DUPLICATE_FILES` is the richest thing in the file**, because its
+  invariants are the ones with issue numbers: the target election ranks
+  read-only first (#172 - the kernel will not write into one, so it must be the
+  source), then fewest extents, then lowest id, all from columns fixed at scan
+  time so that **every window elects the same target** (#197). Members load at
+  `poff = 0`, which is why they skip `clean_deduped()` (#186).
+- **A fixture whose winner leads on every column proves nothing.** The first
+  #197 test had one that was lowest-id *and* tidiest *and* oldest, so a
+  pre-#197 `min(id)` election passed it too. The winner must be one that only
+  the real ranking picks - and the same trap sat in the tie-break case, where
+  names, inos and ids all ascended together so a comparator with no tie-break
+  at all still answered correctly.
+- **`is_anchor` is the one C statement in `dbfile_load_same_files()` that
+  exists for #197, and nothing observed it** - deleting it left every other
+  test green. It is asserted as a pair now (`de_anchored` on the whole-file
+  group, `!de_anchored` on an extent group), which pins the asymmetry rather
+  than each half looking arbitrary. Nothing *reads* the flag in production
+  (#237); that assertion is how the disconnection would be noticed.
+- **The tool does not mutate string literals**, so the `GET_DUPLICATE_*` SQL
+  cannot be swept - a test that only exercises SQL filtering guards against
+  hand edits but moves no kill rate. `bugs/dbfile.txt` is where those go, and
+  one of them showed a fixture hole a C sweep never could: dropping the
+  inlined-file filter from the `grp` CTE is invisible with two real copies,
+  because the group qualifies on them alone. It shows only when the group
+  exists *because* of the inlined file.
+- **A helper that cannot fail hides the test.** `target_of()` wrapped
+  `list_first_entry()`, which on an empty list returns a pointer derived from
+  the head rather than NULL - so every `mu_check(t != NULL)` around it held
+  whatever the loader did. Helpers that mean "the fixture is broken" `abort()`,
+  like `gs_hit()` and `exec()`.
+- **`mu_check` returns on failure** (`minunit.h:149`), exactly like
+  `prop_check`. So an `x && ...` guard after `mu_check(x != NULL)` is dead;
+  `mu_assert_string_eq` is better still where the value matters, since it
+  prints what was actually there.
+
 ### `src/proptest.h` — properties, not tables
 
 An ordinary test names an input and its answer; a property names a relationship

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -235,3 +235,83 @@
 	cp->size = sqlite3_column_int64(stmt, 2);
 	cp->mtime = sqlite3_column_int64(stmt, 1);
 >>>
+
+# ---------------------------------------------------------------- loaders
+
+# a read-only member stops being preferred as the target
+# The kernel will not write into a read-only subvolume, so such a member has to
+# be the source rather than a destination. Rank it like any other and the
+# dedupe simply fails on every group that has one - having read every byte
+# first.
+<<<
+"			order by (flags & 2) desc, nr_extents, id) rn "	\
+===
+"			order by nr_extents, id) rn "			\
+>>>
+
+# the target is elected by lowest id rather than least fragmented
+# Every copy inherits the target's fragmentation, so deduping a group against
+# its most shredded member leaves all of them shredded - measured roughly
+# linear in the target's extent count. Nothing reports it; the run succeeds and
+# the tree is quietly worse laid out than before.
+<<<
+"			order by (flags & 2) desc, nr_extents, id) rn "	\
+===
+"			order by (flags & 2) desc, id) rn "		\
+>>>
+
+# an inlined file is loaded as a duplicate member
+# oans stores no extents for an inlined file and the kernel declines to
+# deduplicate it, so every group formed around one is work that can only fail.
+<<<
+"	where dedupe_seq <= ?2 and not (flags & 1) and (digest, size) in ( "	\
+===
+"	where dedupe_seq <= ?2 and (digest, size) in ( "			\
+>>>
+
+# the anchor flag never reaches the group
+# The one C statement in the loader that exists for #197. Nothing reads the
+# flag today (#237), so this survives everything except a test that asserts it
+# - which is the point: it is how the disconnection would be noticed.
+<<<
+		ret = insert_one_result(res, digest, file, 0, size, 0, is_anchor);
+===
+		ret = insert_one_result(res, digest, file, 0, size, 0, false);
+>>>
+
+# block hashes reach find_dupes in whatever order the query yielded
+# GET_DUPLICATE_BLOCKS orders by fileid, not by offset, and the hash heads are
+# appended in arrival order - so this is the only place the ordering find_dupes
+# requires is established.
+<<<
+	sort_file_hash_heads(hash_tree);
+
+===
+>>>
+
+# a missing fileid is reported as an error rather than as no file
+# The dedupe phase asks about ids from rows that may have been pruned since,
+# so a missing file is ordinary. Returning an error there aborts a whole batch
+# over one file somebody deleted mid-run.
+<<<
+	if (ret == SQLITE_DONE) {
+		dprintf("dbfile_load_one_filerec: no file found in hashdb: fileid = %lu\n", fileid);
+		return 0;
+	}
+===
+	if (ret == SQLITE_DONE)
+		return ENOENT;
+>>>
+
+# the nondupe scan keeps extents another file also has
+# --dedupe-options=partial searches these block by block for matches the
+# extent pass missed. Include the shared ones and every one of them is
+# rediscovered as a duplicate of something already handled: pure wasted search,
+# reported as nothing at all.
+<<<
+"(SELECT 1 FROM extents as e where e.digest = extents.digest "		\
+"and e.rowid <> extents.rowid);"
+===
+"(SELECT 1 FROM extents as e where e.digest = extents.digest "		\
+"and e.rowid = extents.rowid);"
+>>>

--- a/src/tests.c
+++ b/src/tests.c
@@ -4689,17 +4689,33 @@ MU_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate) {
 	struct results_tree res;
 	struct dupe_extents *d;
 	struct extent *e;
+	unsigned char solo[DIGEST_LEN];
 	int64_t inlined;
 
 	free_all_filerecs();
 	init_results_tree(&res);
+	digest_of(solo, 9);
 
 	/* Two real copies and one inlined, all the same digest and size. */
 	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);
 	put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 1);
 	inlined = put_dupe(db, "/tree/inline", 3, 7, 8192, 1, FILE_INLINED, 0);
 
+	/*
+	 * And a pair that is a pair *only* because of the inlined file. The
+	 * group must not exist at all: excluding the inlined file from the
+	 * membership but not from the count leaves a group of one real copy,
+	 * which has nothing to be deduplicated against and whose work figure
+	 * is zero. A fixture with two real copies cannot see that, because the
+	 * group qualifies on them alone.
+	 */
+	put_dupe(db, "/tree/solo", 4, 9, 4096, 1, 0, 1);
+	put_dupe(db, "/tree/solo-inl", 5, 9, 4096, 1, FILE_INLINED, 0);
+
 	mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+
+	mu_check(res.num_dupes == 1);		/* the digest-7 group, only */
+	mu_check(find_dupe_extents(&res, solo, 4096) == NULL);
 
 	d = only_group(&res);
 	mu_check(d->de_num_dupes == 2);
@@ -4885,6 +4901,143 @@ MU_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets) {
 	free_all_filerecs();
 }
 
+/*
+ * The extents of one file that nothing else in the hashfile shares.
+ *
+ * `--dedupe-options=partial` asks this for each file, then searches those
+ * extents block by block for matches the extent-level pass could not see. So
+ * an extent wrongly included is work the search can only waste, and one
+ * wrongly excluded is a duplicate nobody ever finds - and neither shows up
+ * anywhere, since both produce a run that exits 0 having deduplicated slightly
+ * less than it could.
+ *
+ * The uniqueness test is over the *whole* extents table, not the file: an
+ * extent shared with any other file, including one outside this run's windows,
+ * is not a candidate.
+ */
+MU_TEST(test_nondupe_extents_are_the_ones_nothing_else_shares) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(freep) struct file_extent *got = NULL;
+	struct filerec *f;
+	unsigned char uniq[DIGEST_LEN], shared[DIGEST_LEN];
+	struct extent_csum mine[3], theirs[1];
+	unsigned int n = 99;
+	int64_t a, b;
+
+	free_all_filerecs();
+	a = put_dupe(db, "/tree/a", 1, 7, 65536, 1, 0, 3);
+	b = put_dupe(db, "/tree/b", 2, 8, 65536, 1, 0, 1);
+	f = filerec_new("/tree/a", a, 65536);
+	if (!f)
+		abort();
+	digest_of(uniq, 11);
+	digest_of(shared, 12);
+
+	/* Two of a's extents are unique; the middle one is also in b. */
+	mine[0].loff = 0;      mine[0].poff = 4096;  mine[0].len = 4096;
+	memcpy(mine[0].digest, uniq, DIGEST_LEN);
+	mine[1].loff = 4096;   mine[1].poff = 8192;  mine[1].len = 4096;
+	memcpy(mine[1].digest, shared, DIGEST_LEN);
+	mine[2].loff = 8192;   mine[2].poff = 16384; mine[2].len = 8192;
+	digest_of(mine[2].digest, 13);
+	theirs[0].loff = 0;    theirs[0].poff = 32768; theirs[0].len = 4096;
+	memcpy(theirs[0].digest, shared, DIGEST_LEN);
+
+	mu_check(dbfile_store_extent_hashes(db, a, 3, mine) == 0);
+	mu_check(dbfile_store_extent_hashes(db, b, 1, theirs) == 0);
+
+	mu_check(dbfile_load_nondupe_file_extents(db, f, &got, &n) == 0);
+	mu_check(n == 2);		/* the shared one is not a candidate */
+	mu_check(got != NULL);
+
+	/* All three columns, paired - a loader reading len where poff is
+	 * returns the right number of extents describing the wrong bytes. */
+	mu_check(got[0].loff == 0 && got[0].poff == 4096 && got[0].len == 4096);
+	mu_check(got[1].loff == 8192 && got[1].poff == 16384 && got[1].len == 8192);
+
+	free_all_filerecs();
+}
+
+/*
+ * More extents than the array starts with, so the geometric growth runs.
+ *
+ * It begins at 16 and doubles, and the count is the only thing that says how
+ * much of the buffer is live - so a growth that loses the tail, or an index
+ * that runs past it, is invisible below 17 extents. Deliberately just over two
+ * doublings.
+ */
+MU_TEST(test_nondupe_extents_grow_past_the_initial_capacity) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(freep) struct file_extent *got = NULL;
+	struct filerec *f;
+	struct extent_csum ext[40];
+	unsigned int n = 0;
+	int64_t a;
+
+	free_all_filerecs();
+	a = put_dupe(db, "/tree/a", 1, 7, 1u << 20, 1, 0, 40);
+	f = filerec_new("/tree/a", a, 1u << 20);
+	if (!f)
+		abort();
+
+	for (unsigned int i = 0; i < ARRAY_SIZE(ext); i++) {
+		ext[i].loff = i * 4096;
+		ext[i].poff = (i + 100) * 4096;
+		ext[i].len = 4096;
+		digest_of(ext[i].digest, 100 + i);	/* all distinct */
+	}
+	mu_check(dbfile_store_extent_hashes(db, a, ARRAY_SIZE(ext), ext) == 0);
+
+	mu_check(dbfile_load_nondupe_file_extents(db, f, &got, &n) == 0);
+	mu_check(n == ARRAY_SIZE(ext));
+
+	/* Every one of them, at its own offsets: a lost tail would still leave
+	 * a plausible array of a plausible length. */
+	for (unsigned int i = 0; i < n; i++) {
+		mu_check(got[i].loff == i * 4096);
+		mu_check(got[i].poff == (i + 100) * 4096);
+		mu_check(got[i].len == 4096);
+	}
+
+	free_all_filerecs();
+}
+
+/*
+ * A file whose every extent is shared has no candidates, and says so with a
+ * count of zero rather than by leaving the caller's count untouched -
+ * find_dupes tests `!num_extents` before it looks at the array.
+ */
+MU_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(freep) struct file_extent *got = NULL;
+	struct filerec *f;
+	unsigned char dg[DIGEST_LEN];
+	struct extent_csum mine[1], theirs[1];
+	unsigned int n = 99;			/* must be overwritten */
+	int64_t a, b;
+
+	free_all_filerecs();
+	a = put_dupe(db, "/tree/a", 1, 7, 4096, 1, 0, 1);
+	b = put_dupe(db, "/tree/b", 2, 8, 4096, 1, 0, 1);
+	f = filerec_new("/tree/a", a, 4096);
+	if (!f)
+		abort();
+	digest_of(dg, 21);
+
+	mine[0].loff = 0;   mine[0].poff = 4096;  mine[0].len = 4096;
+	memcpy(mine[0].digest, dg, DIGEST_LEN);
+	theirs[0].loff = 0; theirs[0].poff = 8192; theirs[0].len = 4096;
+	memcpy(theirs[0].digest, dg, DIGEST_LEN);
+	mu_check(dbfile_store_extent_hashes(db, a, 1, mine) == 0);
+	mu_check(dbfile_store_extent_hashes(db, b, 1, theirs) == 0);
+
+	mu_check(dbfile_load_nondupe_file_extents(db, f, &got, &n) == 0);
+	mu_check(n == 0);
+	mu_check(got == NULL);		/* nothing allocated, nothing to free */
+
+	free_all_filerecs();
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -4999,6 +5152,9 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_loading_one_filerec_treats_a_missing_id_as_success);
 	MU_RUN_TEST(test_block_hashes_load_into_the_tree_in_offset_order);
 	MU_RUN_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets);
+	MU_RUN_TEST(test_nondupe_extents_are_the_ones_nothing_else_shares);
+	MU_RUN_TEST(test_nondupe_extents_grow_past_the_initial_capacity);
+	MU_RUN_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -4439,6 +4439,434 @@ MU_TEST(test_prop_a_filerec_token_is_found_by_its_filerec) {
 	free_all_filerecs();
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * The dedupe-phase loaders
+ *
+ * Where the hashfile meets the in-memory model: five functions turning rows
+ * into filerecs, hash trees and results trees. They were 155 mutants with a 0%
+ * kill rate, and they need both fixtures at once - memdb() from the hashfile
+ * tests, mkfilerec()/free_all_filerecs() from the model ones - which is why
+ * they waited until both existed.
+ *
+ * What they get wrong fails silently in the usual way: a target elected
+ * differently in two overlapping windows deduplicates into a file the other
+ * window is still relocating, and the summary looks exactly the same.
+ * ---------------------------------------------------------------------------
+ */
+
+/* A scanned row with every column the whole-file loader ranks on. */
+static int64_t put_dupe(struct dbhandle *db, const char *name, uint64_t ino,
+			unsigned int dg, uint64_t size, unsigned int seq,
+			unsigned int flags, unsigned int nr_extents)
+{
+	_cleanup_(file_cleanup) struct file f = {0};
+	unsigned char digest[DIGEST_LEN];
+	int64_t id;
+
+	if (file_set_filename(&f, name))
+		abort();
+	f.ino = ino;
+	f.subvol = 1;
+	f.size = size;
+	f.mtime = 1000;
+	f.dedupe_seq = seq;
+	id = dbfile_store_file_info(db, &f);
+	if (id <= 0)
+		abort();
+	digest_of(digest, dg);
+	if (dbfile_update_scanned_file(db, id, digest, flags, nr_extents))
+		abort();
+	return id;
+}
+
+/* The group's dedupe target: the loader orders it first, and
+ * dedupe_extent_list() always dedupes against list_first_entry(). */
+static struct filerec *target_of(struct dupe_extents *d)
+{
+	return list_first_entry(&d->de_extents, struct extent, e_list)->e_file;
+}
+
+static struct dupe_extents *only_group(struct results_tree *res)
+{
+	if (RB_EMPTY_ROOT(&res->root))
+		return NULL;
+	return rb_entry(rb_first(&res->root), struct dupe_extents, de_node);
+}
+
+/*
+ * A whole-file duplicate group loads every member of the window with its
+ * target first, and every member at poff 0.
+ *
+ * That zero is not incidental. GET_DUPLICATE_FILES has no fiemap to draw on,
+ * so whole-file members carry no physical offset - which is exactly why they
+ * skip clean_deduped() and why `--dedupe-options=only_whole_files` converged
+ * while the extent path did not (#186). A loader that invented a poff here
+ * would put them back on the path that failed to converge.
+ */
+MU_TEST(test_whole_file_dupes_load_with_their_target_first) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct results_tree res;
+	struct dupe_extents *d;
+	struct extent *e;
+	unsigned int n = 0;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+
+	/* Three copies of one 8 KiB file, all scanned in this window. */
+	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 1);
+	/* A file of the same size but a different digest is not a duplicate. */
+	put_dupe(db, "/tree/d", 4, 8, 8192, 1, 0, 1);
+	/* ...and neither is one of the same digest at a different size. */
+	put_dupe(db, "/tree/e", 5, 7, 4096, 1, 0, 1);
+
+	mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+
+	mu_check(res.num_dupes == 1);
+	d = only_group(&res);
+	mu_check(d && d->de_num_dupes == 3);
+	mu_check(d->de_len == 8192);
+
+	list_for_each_entry(e, &d->de_extents, e_list) {
+		mu_check(e->e_loff == 0);
+		mu_check(e->e_poff == 0);	/* no fiemap here, and #186 */
+		n++;
+	}
+	mu_check(n == 3);
+
+	free_results_tree(&res);
+	free_all_filerecs();
+}
+
+/*
+ * Which member becomes the target, and the ranking is the whole point.
+ *
+ * A read-only member wins outright: the kernel will not write into one, so it
+ * has to be the source rather than a destination (#172). Below that, the
+ * least-fragmented member wins, because every copy inherits the target's
+ * fragmentation. Both are read from columns fixed at scan time rather than
+ * probed live, so that every generation window reaches the same answer (#197).
+ */
+MU_TEST(test_the_whole_file_target_prefers_readonly_then_fewest_extents) {
+	struct results_tree res;
+	struct filerec *tgt;
+
+	/* Fewest extents wins, even against a lower id. */
+	{
+		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+		free_all_filerecs();
+		init_results_tree(&res);
+		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 9);	/* id 1, ragged */
+		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 2);	/* id 2, tidiest */
+		put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 5);
+		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+		tgt = target_of(only_group(&res));
+		mu_check(tgt && !strcmp(tgt->filename, "/tree/b"));
+		free_results_tree(&res);
+		free_all_filerecs();
+	}
+
+	/* A read-only member wins even when it is both later and worse. */
+	{
+		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+		free_all_filerecs();
+		init_results_tree(&res);
+		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);	/* id 1, tidiest */
+		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 3);
+		put_dupe(db, "/tree/c", 3, 7, 8192, 1,
+			 FILE_RO_SUBVOL, 9);			/* worst, wins */
+		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+		tgt = target_of(only_group(&res));
+		mu_check(tgt && !strcmp(tgt->filename, "/tree/c"));
+		free_results_tree(&res);
+		free_all_filerecs();
+	}
+
+	/* Everything else equal, the lowest id breaks the tie. */
+	{
+		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+
+		free_all_filerecs();
+		init_results_tree(&res);
+		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 4);
+		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 4);
+		put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 4);
+		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+		tgt = target_of(only_group(&res));
+		mu_check(tgt && !strcmp(tgt->filename, "/tree/a"));
+		free_results_tree(&res);
+		free_all_filerecs();
+	}
+}
+
+/*
+ * #197 itself: two overlapping generation windows must elect the *same*
+ * target.
+ *
+ * The bug was a window free to choose someone else, so a group spanning passes
+ * converged on one cluster per pass instead of a single extent - and each pass
+ * deduplicated into a file an earlier pass was still relocating. The election
+ * is over every member of the group, not just the window's, which is what makes
+ * the answer window-invariant; a loader that ranked only the rows it loaded
+ * would pass every single-window test and fail this one.
+ */
+MU_TEST(test_every_window_elects_the_same_whole_file_target) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct results_tree first = {0}, second = {0};
+	struct filerec *t1, *t2;
+
+	free_all_filerecs();
+
+	/* The tidiest copy is old; the later windows never see it as new. */
+	put_dupe(db, "/tree/old", 1, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/mid", 2, 7, 8192, 2, 0, 6);
+	put_dupe(db, "/tree/new", 3, 7, 8192, 3, 0, 4);
+
+	init_results_tree(&first);
+	mu_check(dbfile_load_same_files(db, &first, 1, 2) == 0);
+	t1 = target_of(only_group(&first));
+	mu_check(t1 != NULL);
+
+	init_results_tree(&second);
+	mu_check(dbfile_load_same_files(db, &second, 2, 3) == 0);
+	t2 = target_of(only_group(&second));
+	mu_check(t2 != NULL);
+
+	/* Same file, in both - and it is the one outside either window. */
+	mu_check(t1 == t2);
+	mu_check(t1 && !strcmp(t1->filename, "/tree/old"));
+
+	/* Each window loads its own new member plus that target, and nothing
+	 * else: two members, not three. */
+	mu_check(only_group(&first)->de_num_dupes == 2);
+	mu_check(only_group(&second)->de_num_dupes == 2);
+
+	free_results_tree(&first);
+	free_results_tree(&second);
+	free_all_filerecs();
+}
+
+/*
+ * An inlined file is not a group member, not a target, and cannot make a group
+ * exist at all. oans stores no extents for one and the kernel will not
+ * deduplicate it, so a group formed around one is work that can only fail.
+ */
+MU_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct results_tree res;
+	struct dupe_extents *d;
+	struct extent *e;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+
+	/* Two real copies and one inlined: the inlined one must not appear. */
+	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/inline", 3, 7, 8192, 1, FILE_INLINED, 0);
+	mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
+
+	d = only_group(&res);
+	mu_check(d && d->de_num_dupes == 2);
+	list_for_each_entry(e, &d->de_extents, e_list)
+		mu_check(strcmp(e->e_file->filename, "/tree/inline") != 0);
+	free_results_tree(&res);
+
+	/*
+	 * And a pair that is only a pair *because* of the inlined file is no
+	 * group at all: the one real copy has nothing left to be deduplicated
+	 * against, so the group must not exist rather than exist with one
+	 * member.
+	 */
+	{
+		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db2 = memdb();
+
+		free_all_filerecs();
+		init_results_tree(&res);
+		put_dupe(db2, "/t/real", 1, 9, 4096, 1, 0, 1);
+		put_dupe(db2, "/t/inl", 2, 9, 4096, 1, FILE_INLINED, 0);
+		mu_check(dbfile_load_same_files(db2, &res, 0, 1) == 0);
+		mu_check(res.num_dupes == 0);
+		free_results_tree(&res);
+	}
+
+	free_all_filerecs();
+}
+
+/*
+ * dbfile_load_one_filerec() answers "no such file" with success and a NULL
+ * out-parameter, not an error. The dedupe phase calls it for ids it read from
+ * rows that may since have been pruned, so a missing file is ordinary; a
+ * loader returning an error there would abort a whole batch over a file
+ * somebody deleted mid-run.
+ */
+MU_TEST(test_loading_one_filerec_treats_a_missing_id_as_success) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct filerec *f = NULL;
+	int64_t id;
+
+	free_all_filerecs();
+	id = put_dupe(db, "/tree/only", 1, 7, 12288, 1, 0, 1);
+
+	mu_check(dbfile_load_one_filerec(db, id, &f) == 0);
+	mu_check(f != NULL);
+	mu_check(f && !strcmp(f->filename, "/tree/only"));
+	mu_check(f && f->fileid == id);
+	mu_check(f && f->size == 12288);	/* the row's size, not a default */
+
+	/* Absent: success, and the caller's pointer cleared rather than left
+	 * holding whatever it had. */
+	f = (struct filerec *)(uintptr_t)0x1;
+	mu_check(dbfile_load_one_filerec(db, id + 999, &f) == 0);
+	mu_check(f == NULL);
+
+	free_all_filerecs();
+}
+
+/*
+ * Block hashes load into a hash tree, and come out of it sorted.
+ *
+ * The loader ends with sort_file_hash_heads() because find_dupes walks each
+ * file's blocks under a hash expecting increasing offsets. Rows arrive in
+ * whatever order the query yields, so this is the one place that ordering is
+ * established for the dedupe phase - and a fixture whose rows happen to be
+ * stored in ascending order cannot tell the sort from its absence, which is
+ * why these go in deliberately jumbled.
+ */
+MU_TEST(test_block_hashes_load_into_the_tree_in_offset_order) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct hash_tree tree;
+	unsigned char dg[DIGEST_LEN];
+	struct block_csum blocks[3];
+	struct dupe_blocks_list *dl;
+	struct rb_node *n;
+	int64_t a, b;
+
+	free_all_filerecs();
+	init_hash_tree(&tree);
+	digest_of(dg, 3);
+
+	a = put_dupe(db, "/tree/a", 1, 7, 12288, 1, 0, 1);
+	b = put_dupe(db, "/tree/b", 2, 8, 12288, 1, 0, 1);
+
+	/* Deliberately not ascending. */
+	blocks[0].loff = 8192;
+	blocks[1].loff = 0;
+	blocks[2].loff = 4096;
+	for (unsigned int i = 0; i < 3; i++)
+		memcpy(blocks[i].digest, dg, DIGEST_LEN);
+	mu_check(dbfile_store_block_hashes(db, a, 3, blocks) == 0);
+	mu_check(dbfile_store_block_hashes(db, b, 3, blocks) == 0);
+
+	mu_check(dbfile_load_block_hashes(db, &tree, 0, 1) == 0);
+
+	mu_check(tree.num_blocks == 6);
+	mu_check(tree.num_hashes == 1);
+	dl = find_block_list(&tree, dg);
+	mu_check(dl != NULL);
+	mu_check(dl && dl->dl_num_elem == 6);
+
+	/* Both files present, each with its blocks in increasing offset. */
+	{
+		unsigned int heads = 0;
+
+		for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
+			struct file_hash_head *h =
+				rb_entry(n, struct file_hash_head, h_node);
+			struct file_block *blk;
+			uint64_t prev = 0;
+			bool first = true;
+
+			heads++;
+			list_for_each_entry(blk, &h->h_blocks, b_head_list) {
+				mu_check(first || blk->b_loff > prev);
+				prev = blk->b_loff;
+				first = false;
+			}
+			mu_check(prev == 8192);	/* reached the last one */
+		}
+		mu_check(heads == 2);
+	}
+
+	free_hash_tree(&tree);
+	free_all_filerecs();
+}
+
+/*
+ * Extent hashes load as a group per (digest, length), carrying the physical
+ * offset the scan recorded - which is what the extent path needs and the
+ * whole-file path deliberately lacks.
+ *
+ * A group needs two members: one extent with a digest nothing else shares is
+ * not a duplicate of anything, and loading it would put a group into the tree
+ * that the worker can only throw away.
+ */
+MU_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct results_tree res;
+	struct dupe_extents *d;
+	struct extent *e;
+	unsigned char shared[DIGEST_LEN], lonely[DIGEST_LEN];
+	struct extent_csum ea[2], eb[1];
+	int64_t a, b;
+	unsigned int seen = 0;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+	digest_of(shared, 4);
+	digest_of(lonely, 5);
+
+	a = put_dupe(db, "/tree/a", 1, 7, 65536, 1, 0, 2);
+	b = put_dupe(db, "/tree/b", 2, 8, 65536, 1, 0, 2);
+
+	/* One extent shared between the files, one only file a has. */
+	ea[0].loff = 0;
+	ea[0].poff = 4096;
+	ea[0].len = 4096;
+	memcpy(ea[0].digest, shared, DIGEST_LEN);
+	ea[1].loff = 4096;
+	ea[1].poff = 8192;
+	ea[1].len = 4096;
+	memcpy(ea[1].digest, lonely, DIGEST_LEN);
+	eb[0].loff = 16384;
+	eb[0].poff = 65536;
+	eb[0].len = 4096;
+	memcpy(eb[0].digest, shared, DIGEST_LEN);
+
+	mu_check(dbfile_store_extent_hashes(db, a, 2, ea) == 0);
+	mu_check(dbfile_store_extent_hashes(db, b, 1, eb) == 0);
+
+	mu_check(dbfile_load_extent_hashes(db, &res, 0, 1) == 0);
+
+	/* Only the shared digest makes a group. */
+	mu_check(res.num_dupes == 1);
+	mu_check(res.num_extents == 2);
+	d = only_group(&res);
+	mu_check(d && d->de_len == 4096);
+	mu_check(d && !memcmp(d->de_hash, shared, DIGEST_LEN));
+
+	/* Each member keeps the physical offset its row recorded - the extent
+	 * path reads it to decide what is already shared. */
+	list_for_each_entry(e, &d->de_extents, e_list) {
+		if (e->e_loff == 0)
+			mu_check(e->e_poff == 4096);
+		else if (e->e_loff == 16384)
+			mu_check(e->e_poff == 65536);
+		else
+			mu_check(false);	/* an offset nobody stored */
+		seen++;
+	}
+	mu_check(seen == 2);
+
+	free_results_tree(&res);
+	free_all_filerecs();
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -4546,6 +4974,13 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_filerec_holds_one_descriptor_however_often_it_is_opened);
 	MU_RUN_TEST(test_filerec_open_once_opens_each_file_exactly_once);
 	MU_RUN_TEST(test_prop_a_filerec_token_is_found_by_its_filerec);
+	MU_RUN_TEST(test_whole_file_dupes_load_with_their_target_first);
+	MU_RUN_TEST(test_the_whole_file_target_prefers_readonly_then_fewest_extents);
+	MU_RUN_TEST(test_every_window_elects_the_same_whole_file_target);
+	MU_RUN_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate);
+	MU_RUN_TEST(test_loading_one_filerec_treats_a_missing_id_as_success);
+	MU_RUN_TEST(test_block_hashes_load_into_the_tree_in_offset_order);
+	MU_RUN_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -1892,8 +1892,18 @@ static struct scan_checkpoint mkcheckpoint(void *file_state, void *ext_state,
  * interrupted run left partway, so this is the shape the startup prune is
  * about, and the two helpers are split so a test can ask for either.
  */
-static int64_t put_unscanned_file(struct dbhandle *db, const char *name,
-				  uint64_t ino, uint64_t subvol)
+/* A digest that differs in every byte for each n, so a comparator reading the
+ * wrong end of it still sees a difference. */
+static void digest_of(unsigned char *out, unsigned int n)
+{
+	for (unsigned int i = 0; i < DIGEST_LEN; i++)
+		out[i] = (unsigned char)(n * 7 + i * 31);
+}
+/* The one row builder. Everything below adds columns to it rather than
+ * repeating the build - two near-identical copies differing by an inert line
+ * is what this replaced. */
+static int64_t put_row(struct dbhandle *db, const char *name, uint64_t ino,
+		       uint64_t subvol, uint64_t size, unsigned int seq)
 {
 	_cleanup_(file_cleanup) struct file f = {0};
 	int64_t id;
@@ -1902,14 +1912,18 @@ static int64_t put_unscanned_file(struct dbhandle *db, const char *name,
 		abort();
 	f.ino = ino;
 	f.subvol = subvol;
-	f.size = 4096;
-	f.blocks = 1;
+	f.size = size;
 	f.mtime = 1000;
-	f.dedupe_seq = 1;
+	f.dedupe_seq = seq;
 	id = dbfile_store_file_info(db, &f);
 	if (id <= 0)
 		abort();
 	return id;
+}
+static int64_t put_unscanned_file(struct dbhandle *db, const char *name,
+				  uint64_t ino, uint64_t subvol)
+{
+	return put_row(db, name, ino, subvol, 4096, 1);
 }
 
 /* ... and the same row finished, the way a completed hash leaves it. */
@@ -1919,7 +1933,7 @@ static int64_t put_file(struct dbhandle *db, const char *name, uint64_t ino,
 	int64_t id = put_unscanned_file(db, name, ino, subvol);
 	unsigned char digest[DIGEST_LEN];
 
-	memset(digest, (int)ino, DIGEST_LEN);
+	digest_of(digest, (unsigned int)ino);
 	if (dbfile_update_scanned_file(db, id, digest, 0, 1))
 		abort();
 	return id;
@@ -3583,14 +3597,6 @@ MU_TEST(test_prop_stored_extents_come_back_where_they_were_put) {
  */
 #define PROP_LEN	4096
 
-/* A digest that differs in every byte for each n, so a comparator reading the
- * wrong end of it still sees a difference. */
-static void digest_of(unsigned char *out, unsigned int n)
-{
-	for (unsigned int i = 0; i < DIGEST_LEN; i++)
-		out[i] = (unsigned char)(n * 7 + i * 31);
-}
-
 /* Takes the fileid it will actually have: the tests look filerecs up by id,
  * so a helper that invented its own numbering had to be bypassed by the one
  * property that chooses ids. */
@@ -4452,6 +4458,11 @@ MU_TEST(test_prop_a_filerec_token_is_found_by_its_filerec) {
  * What they get wrong fails silently in the usual way: a target elected
  * differently in two overlapping windows deduplicates into a file the other
  * window is still relocating, and the summary looks exactly the same.
+ *
+ * Note when reading these: the mutation tool does not mutate string literals,
+ * so the GET_DUPLICATE_* queries themselves cannot be mutated. Assertions that
+ * only exercise SQL filtering guard against hand edits but move no kill rate;
+ * the ones that matter are on the C around them.
  * ---------------------------------------------------------------------------
  */
 
@@ -4460,43 +4471,45 @@ static int64_t put_dupe(struct dbhandle *db, const char *name, uint64_t ino,
 			unsigned int dg, uint64_t size, unsigned int seq,
 			unsigned int flags, unsigned int nr_extents)
 {
-	_cleanup_(file_cleanup) struct file f = {0};
+	int64_t id = put_row(db, name, ino, 1, size, seq);
 	unsigned char digest[DIGEST_LEN];
-	int64_t id;
 
-	if (file_set_filename(&f, name))
-		abort();
-	f.ino = ino;
-	f.subvol = 1;
-	f.size = size;
-	f.mtime = 1000;
-	f.dedupe_seq = seq;
-	id = dbfile_store_file_info(db, &f);
-	if (id <= 0)
-		abort();
 	digest_of(digest, dg);
 	if (dbfile_update_scanned_file(db, id, digest, flags, nr_extents))
 		abort();
 	return id;
 }
 
-/* The group's dedupe target: the loader orders it first, and
- * dedupe_extent_list() always dedupes against list_first_entry(). */
-static struct filerec *target_of(struct dupe_extents *d)
-{
-	return list_first_entry(&d->de_extents, struct extent, e_list)->e_file;
-}
-
+/*
+ * The sole group in a results tree. abort()s rather than returning NULL when
+ * there is not exactly one: that means the fixture is broken, and a test that
+ * quietly took the first of two groups would pass while the loader split them.
+ */
 static struct dupe_extents *only_group(struct results_tree *res)
 {
-	if (RB_EMPTY_ROOT(&res->root))
-		return NULL;
+	if (res->num_dupes != 1 || RB_EMPTY_ROOT(&res->root))
+		abort();
 	return rb_entry(rb_first(&res->root), struct dupe_extents, de_node);
 }
 
 /*
- * A whole-file duplicate group loads every member of the window with its
- * target first, and every member at poff 0.
+ * The group's dedupe target: the loader orders it first, and
+ * dedupe_extent_list() always dedupes against list_first_entry().
+ *
+ * abort()s on an empty member list, because list_first_entry() on one returns
+ * a pointer derived from the list head rather than NULL - so a NULL check at
+ * the call site would pass while dereferencing nothing.
+ */
+static const char *target_of(struct dupe_extents *d)
+{
+	if (list_empty(&d->de_extents))
+		abort();
+	return list_first_entry(&d->de_extents, struct extent, e_list)
+		->e_file->filename;
+}
+
+/*
+ * A whole-file duplicate group loads every member of the window at poff 0.
  *
  * That zero is not incidental. GET_DUPLICATE_FILES has no fiemap to draw on,
  * so whole-file members carry no physical offset - which is exactly why they
@@ -4504,7 +4517,7 @@ static struct dupe_extents *only_group(struct results_tree *res)
  * while the extent path did not (#186). A loader that invented a poff here
  * would put them back on the path that failed to converge.
  */
-MU_TEST(test_whole_file_dupes_load_with_their_target_first) {
+MU_TEST(test_whole_file_dupes_load_at_poff_zero) {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
 	struct results_tree res;
 	struct dupe_extents *d;
@@ -4514,10 +4527,12 @@ MU_TEST(test_whole_file_dupes_load_with_their_target_first) {
 	free_all_filerecs();
 	init_results_tree(&res);
 
-	/* Three copies of one 8 KiB file, all scanned in this window. */
-	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);
+	/* Three copies of one 8 KiB file, all scanned in this window. The
+	 * tidiest is deliberately not the first inserted, so "target first" is
+	 * a claim about the election rather than about insertion order. */
+	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 4);
 	put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 1);
-	put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 6);
 	/* A file of the same size but a different digest is not a duplicate. */
 	put_dupe(db, "/tree/d", 4, 8, 8192, 1, 0, 1);
 	/* ...and neither is one of the same digest at a different size. */
@@ -4527,8 +4542,9 @@ MU_TEST(test_whole_file_dupes_load_with_their_target_first) {
 
 	mu_check(res.num_dupes == 1);
 	d = only_group(&res);
-	mu_check(d && d->de_num_dupes == 3);
+	mu_check(d->de_num_dupes == 3);
 	mu_check(d->de_len == 8192);
+	mu_assert_string_eq("/tree/b", target_of(d));	/* ordered first */
 
 	list_for_each_entry(e, &d->de_extents, e_list) {
 		mu_check(e->e_loff == 0);
@@ -4541,110 +4557,122 @@ MU_TEST(test_whole_file_dupes_load_with_their_target_first) {
 	free_all_filerecs();
 }
 
+/* Load one window over three same-size copies with the given per-file
+ * (flags, nr_extents), and report which one the query elected. Names are
+ * assigned in the order given, so a caller can put a low id anywhere. */
+static const char *elected_target(const char *const names[3],
+				  const unsigned int flags[3],
+				  const unsigned int nr_extents[3])
+{
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	static char winner[64];
+	struct results_tree res;
+
+	free_all_filerecs();
+	init_results_tree(&res);
+	for (unsigned int i = 0; i < 3; i++)
+		put_dupe(db, names[i], i + 1, 7, 8192, 1, flags[i],
+			 nr_extents[i]);
+	if (dbfile_load_same_files(db, &res, 0, 1))
+		abort();
+	snprintf(winner, sizeof(winner), "%s", target_of(only_group(&res)));
+	free_results_tree(&res);
+	free_all_filerecs();
+	return winner;
+}
+
 /*
- * Which member becomes the target, and the ranking is the whole point.
+ * Which member becomes the target, one ranking level per case.
  *
  * A read-only member wins outright: the kernel will not write into one, so it
- * has to be the source rather than a destination (#172). Below that, the
+ * has to be the source rather than a destination (#172). Below that the
  * least-fragmented member wins, because every copy inherits the target's
  * fragmentation. Both are read from columns fixed at scan time rather than
- * probed live, so that every generation window reaches the same answer (#197).
+ * probed live, so every generation window reaches the same answer (#197).
  */
 MU_TEST(test_the_whole_file_target_prefers_readonly_then_fewest_extents) {
-	struct results_tree res;
-	struct filerec *tgt;
+	static const char *const abc[3] = { "/tree/a", "/tree/b", "/tree/c" };
+	/* Ids ascend with position, so putting z first gives it the lowest. */
+	static const char *const zyx[3] = { "/tree/z", "/tree/y", "/tree/x" };
+	static const unsigned int none[3] = { 0, 0, 0 };
 
-	/* Fewest extents wins, even against a lower id. */
+	/* Fewest extents wins, and the winner is neither first nor lowest id. */
 	{
-		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+		static const unsigned int nr[3] = { 9, 2, 5 };
 
-		free_all_filerecs();
-		init_results_tree(&res);
-		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 9);	/* id 1, ragged */
-		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 2);	/* id 2, tidiest */
-		put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 5);
-		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
-		tgt = target_of(only_group(&res));
-		mu_check(tgt && !strcmp(tgt->filename, "/tree/b"));
-		free_results_tree(&res);
-		free_all_filerecs();
+		mu_assert_string_eq("/tree/b", elected_target(abc, none, nr));
 	}
 
 	/* A read-only member wins even when it is both later and worse. */
 	{
-		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+		static const unsigned int ro[3] = { 0, 0, FILE_RO_SUBVOL };
+		static const unsigned int nr[3] = { 1, 3, 9 };
 
-		free_all_filerecs();
-		init_results_tree(&res);
-		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);	/* id 1, tidiest */
-		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 3);
-		put_dupe(db, "/tree/c", 3, 7, 8192, 1,
-			 FILE_RO_SUBVOL, 9);			/* worst, wins */
-		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
-		tgt = target_of(only_group(&res));
-		mu_check(tgt && !strcmp(tgt->filename, "/tree/c"));
-		free_results_tree(&res);
-		free_all_filerecs();
+		mu_assert_string_eq("/tree/c", elected_target(abc, ro, nr));
 	}
 
-	/* Everything else equal, the lowest id breaks the tie. */
+	/*
+	 * Everything else equal, the lowest id breaks the tie - and the names
+	 * descend while the ids ascend, so an ordering that fell back to the
+	 * filename, or to no tie-break at all, would answer differently.
+	 */
 	{
-		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+		static const unsigned int nr[3] = { 4, 4, 4 };
 
-		free_all_filerecs();
-		init_results_tree(&res);
-		put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 4);
-		put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 4);
-		put_dupe(db, "/tree/c", 3, 7, 8192, 1, 0, 4);
-		mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
-		tgt = target_of(only_group(&res));
-		mu_check(tgt && !strcmp(tgt->filename, "/tree/a"));
-		free_results_tree(&res);
-		free_all_filerecs();
+		mu_assert_string_eq("/tree/z", elected_target(zyx, none, nr));
 	}
 }
 
 /*
  * #197 itself: two overlapping generation windows must elect the *same*
- * target.
+ * target, and the election ranges over every member of the group rather than
+ * the window's.
  *
- * The bug was a window free to choose someone else, so a group spanning passes
- * converged on one cluster per pass instead of a single extent - and each pass
- * deduplicated into a file an earlier pass was still relocating. The election
- * is over every member of the group, not just the window's, which is what makes
- * the answer window-invariant; a loader that ranked only the rows it loaded
- * would pass every single-window test and fail this one.
+ * The fixture is built so that weaker elections give different answers. The
+ * winner (`old2`) is neither the lowest id nor a member of either window, so
+ * an election reduced to min(id) - roughly the pre-#197 behaviour - answers
+ * `old1`, and a window-local one answers a member of the window. A fixture
+ * whose winner happened to be lowest-id *and* tidiest *and* oldest would pass
+ * against all three, which is what the first draft of this test did.
  */
 MU_TEST(test_every_window_elects_the_same_whole_file_target) {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
-	struct results_tree first = {0}, second = {0};
-	struct filerec *t1, *t2;
+	struct results_tree first, second;
+	const char *t1, *t2;
 
 	free_all_filerecs();
 
-	/* The tidiest copy is old; the later windows never see it as new. */
-	put_dupe(db, "/tree/old", 1, 7, 8192, 1, 0, 1);
-	put_dupe(db, "/tree/mid", 2, 7, 8192, 2, 0, 6);
-	put_dupe(db, "/tree/new", 3, 7, 8192, 3, 0, 4);
+	/* id 1 is old and ragged; id 2 is old and tidiest - the winner. */
+	put_dupe(db, "/tree/old1", 1, 7, 8192, 1, 0, 6);
+	put_dupe(db, "/tree/old2", 2, 7, 8192, 1, 0, 1);
+	put_dupe(db, "/tree/mid", 3, 7, 8192, 2, 0, 5);
+	put_dupe(db, "/tree/new", 4, 7, 8192, 3, 0, 4);
 
 	init_results_tree(&first);
 	mu_check(dbfile_load_same_files(db, &first, 1, 2) == 0);
 	t1 = target_of(only_group(&first));
-	mu_check(t1 != NULL);
 
 	init_results_tree(&second);
 	mu_check(dbfile_load_same_files(db, &second, 2, 3) == 0);
 	t2 = target_of(only_group(&second));
-	mu_check(t2 != NULL);
 
-	/* Same file, in both - and it is the one outside either window. */
-	mu_check(t1 == t2);
-	mu_check(t1 && !strcmp(t1->filename, "/tree/old"));
+	mu_assert_string_eq("/tree/old2", t1);
+	mu_assert_string_eq("/tree/old2", t2);
 
 	/* Each window loads its own new member plus that target, and nothing
-	 * else: two members, not three. */
+	 * else: two members, not four. */
 	mu_check(only_group(&first)->de_num_dupes == 2);
 	mu_check(only_group(&second)->de_num_dupes == 2);
+
+	/*
+	 * The loader marks the group anchored, from the query's is_target
+	 * column. Nothing reads the flag today (#237), which is precisely why
+	 * it is asserted here: without this the one C statement in
+	 * dbfile_load_same_files() that exists for #197 can be deleted with
+	 * every other test still green.
+	 */
+	mu_check(only_group(&first)->de_anchored);
+	mu_check(only_group(&second)->de_anchored);
 
 	free_results_tree(&first);
 	free_results_tree(&second);
@@ -4652,8 +4680,8 @@ MU_TEST(test_every_window_elects_the_same_whole_file_target) {
 }
 
 /*
- * An inlined file is not a group member, not a target, and cannot make a group
- * exist at all. oans stores no extents for one and the kernel will not
+ * An inlined file is not a group member, not a target, and never becomes a
+ * filerec at all. oans stores no extents for one and the kernel will not
  * deduplicate it, so a group formed around one is work that can only fail.
  */
 MU_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate) {
@@ -4661,40 +4689,29 @@ MU_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate) {
 	struct results_tree res;
 	struct dupe_extents *d;
 	struct extent *e;
+	int64_t inlined;
 
 	free_all_filerecs();
 	init_results_tree(&res);
 
-	/* Two real copies and one inlined: the inlined one must not appear. */
+	/* Two real copies and one inlined, all the same digest and size. */
 	put_dupe(db, "/tree/a", 1, 7, 8192, 1, 0, 1);
 	put_dupe(db, "/tree/b", 2, 7, 8192, 1, 0, 1);
-	put_dupe(db, "/tree/inline", 3, 7, 8192, 1, FILE_INLINED, 0);
+	inlined = put_dupe(db, "/tree/inline", 3, 7, 8192, 1, FILE_INLINED, 0);
+
 	mu_check(dbfile_load_same_files(db, &res, 0, 1) == 0);
 
 	d = only_group(&res);
-	mu_check(d && d->de_num_dupes == 2);
+	mu_check(d->de_num_dupes == 2);
 	list_for_each_entry(e, &d->de_extents, e_list)
 		mu_check(strcmp(e->e_file->filename, "/tree/inline") != 0);
+
+	/* Not merely absent from the group - never constructed. The loader
+	 * creates a filerec per row it accepts, so this is an assertion about
+	 * code that ran rather than about rows the query withheld. */
+	mu_check(filerec_find(inlined) == NULL);
+
 	free_results_tree(&res);
-
-	/*
-	 * And a pair that is only a pair *because* of the inlined file is no
-	 * group at all: the one real copy has nothing left to be deduplicated
-	 * against, so the group must not exist rather than exist with one
-	 * member.
-	 */
-	{
-		_cleanup_(sqlite3_close_cleanup) struct dbhandle *db2 = memdb();
-
-		free_all_filerecs();
-		init_results_tree(&res);
-		put_dupe(db2, "/t/real", 1, 9, 4096, 1, 0, 1);
-		put_dupe(db2, "/t/inl", 2, 9, 4096, 1, FILE_INLINED, 0);
-		mu_check(dbfile_load_same_files(db2, &res, 0, 1) == 0);
-		mu_check(res.num_dupes == 0);
-		free_results_tree(&res);
-	}
-
 	free_all_filerecs();
 }
 
@@ -4715,9 +4732,9 @@ MU_TEST(test_loading_one_filerec_treats_a_missing_id_as_success) {
 
 	mu_check(dbfile_load_one_filerec(db, id, &f) == 0);
 	mu_check(f != NULL);
-	mu_check(f && !strcmp(f->filename, "/tree/only"));
-	mu_check(f && f->fileid == id);
-	mu_check(f && f->size == 12288);	/* the row's size, not a default */
+	mu_assert_string_eq("/tree/only", f->filename);
+	mu_check(f->fileid == id);
+	mu_check(f->size == 12288);		/* the row's size, not a default */
 
 	/* Absent: success, and the caller's pointer cleared rather than left
 	 * holding whatever it had. */
@@ -4732,11 +4749,10 @@ MU_TEST(test_loading_one_filerec_treats_a_missing_id_as_success) {
  * Block hashes load into a hash tree, and come out of it sorted.
  *
  * The loader ends with sort_file_hash_heads() because find_dupes walks each
- * file's blocks under a hash expecting increasing offsets. Rows arrive in
- * whatever order the query yields, so this is the one place that ordering is
- * established for the dedupe phase - and a fixture whose rows happen to be
- * stored in ascending order cannot tell the sort from its absence, which is
- * why these go in deliberately jumbled.
+ * file's blocks under a hash expecting increasing offsets. GET_DUPLICATE_BLOCKS
+ * orders only by (dedupe_seq > ?1), fileid, and add_file_hash_head() appends in
+ * arrival order - so rows genuinely arrive jumbled and this is the one place
+ * that ordering is established for the dedupe phase.
  */
 MU_TEST(test_block_hashes_load_into_the_tree_in_offset_order) {
 	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
@@ -4745,6 +4761,7 @@ MU_TEST(test_block_hashes_load_into_the_tree_in_offset_order) {
 	struct block_csum blocks[3];
 	struct dupe_blocks_list *dl;
 	struct rb_node *n;
+	unsigned int heads = 0;
 	int64_t a, b;
 
 	free_all_filerecs();
@@ -4769,29 +4786,23 @@ MU_TEST(test_block_hashes_load_into_the_tree_in_offset_order) {
 	mu_check(tree.num_hashes == 1);
 	dl = find_block_list(&tree, dg);
 	mu_check(dl != NULL);
-	mu_check(dl && dl->dl_num_elem == 6);
+	mu_check(dl->dl_num_elem == 6);
 
-	/* Both files present, each with its blocks in increasing offset. */
-	{
-		unsigned int heads = 0;
+	/* Both files present, each holding exactly 0, 4096, 8192 in order. */
+	for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
+		struct file_hash_head *h =
+			rb_entry(n, struct file_hash_head, h_node);
+		struct file_block *blk;
+		unsigned int i = 0;
 
-		for (n = rb_first(&dl->dl_files_root); n; n = rb_next(n)) {
-			struct file_hash_head *h =
-				rb_entry(n, struct file_hash_head, h_node);
-			struct file_block *blk;
-			uint64_t prev = 0;
-			bool first = true;
-
-			heads++;
-			list_for_each_entry(blk, &h->h_blocks, b_head_list) {
-				mu_check(first || blk->b_loff > prev);
-				prev = blk->b_loff;
-				first = false;
-			}
-			mu_check(prev == 8192);	/* reached the last one */
+		heads++;
+		list_for_each_entry(blk, &h->h_blocks, b_head_list) {
+			mu_check(blk->b_loff == i * 4096);
+			i++;
 		}
-		mu_check(heads == 2);
+		mu_check(i == 3);
 	}
+	mu_check(heads == 2);
 
 	free_hash_tree(&tree);
 	free_all_filerecs();
@@ -4844,11 +4855,18 @@ MU_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets) {
 	mu_check(dbfile_load_extent_hashes(db, &res, 0, 1) == 0);
 
 	/* Only the shared digest makes a group. */
-	mu_check(res.num_dupes == 1);
 	mu_check(res.num_extents == 2);
 	d = only_group(&res);
-	mu_check(d && d->de_len == 4096);
-	mu_check(d && !memcmp(d->de_hash, shared, DIGEST_LEN));
+	mu_check(d->de_len == 4096);
+	mu_check(!memcmp(d->de_hash, shared, DIGEST_LEN));
+
+	/*
+	 * Never anchored: only the whole-file loader elects a target, because
+	 * only there do the members have differing layouts to rank. The pair
+	 * with the assertion in the #197 test above is what pins that
+	 * asymmetry rather than each half separately looking arbitrary.
+	 */
+	mu_check(!d->de_anchored);
 
 	/* Each member keeps the physical offset its row recorded - the extent
 	 * path reads it to decide what is already shared. */
@@ -4858,7 +4876,7 @@ MU_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets) {
 		else if (e->e_loff == 16384)
 			mu_check(e->e_poff == 65536);
 		else
-			mu_check(false);	/* an offset nobody stored */
+			mu_fail("an extent at an offset nobody stored");
 		seen++;
 	}
 	mu_check(seen == 2);
@@ -4974,7 +4992,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_filerec_holds_one_descriptor_however_often_it_is_opened);
 	MU_RUN_TEST(test_filerec_open_once_opens_each_file_exactly_once);
 	MU_RUN_TEST(test_prop_a_filerec_token_is_found_by_its_filerec);
-	MU_RUN_TEST(test_whole_file_dupes_load_with_their_target_first);
+	MU_RUN_TEST(test_whole_file_dupes_load_at_poff_zero);
 	MU_RUN_TEST(test_the_whole_file_target_prefers_readonly_then_fewest_extents);
 	MU_RUN_TEST(test_every_window_elects_the_same_whole_file_target);
 	MU_RUN_TEST(test_an_inlined_file_is_never_loaded_as_a_duplicate);


### PR DESCRIPTION
Third in the series, after #234 (the hashfile) and #235 (the in-memory model). These five functions sit where those two meet — turning rows into filerecs, hash trees and results trees — so they need both fixtures at once, which is why they came last.

| loader | recon | after pass 1 | final |
|---|---|---|---|
| `dbfile_load_same_files` | 35 / 35 | 11 | **10** |
| `dbfile_load_extent_hashes` | 31 / 31 | 8 | **8** |
| `dbfile_load_block_hashes` | 26 / 26 | 5 | **5** |
| `dbfile_load_one_filerec` | 23 / 23 | 7 | **7** |
| `dbfile_load_nondupe_file_extents` | 40 / 40 | 40 | **11** |
| | **155 / 155 (0% killed)** | 71 | **41 (73%)** |

`src/dbfile.c` overall: **785 → 662**.

## `GET_DUPLICATE_FILES` is the richest thing in the file

Its invariants are the ones carrying issue numbers, and none of them were pinned:

- **The target election, one test per ranking level.** A read-only member wins outright — the kernel will not write into one, so it has to be the source (#172). Below that the least-fragmented member wins, since every copy inherits the target's fragmentation. Lowest id breaks ties. All from columns fixed at scan time rather than probed live.
- **Every window elects the same target** (#197). The election ranges over every member of the group, not the window's — which is what makes the answer window-invariant.
- **Members load at `poff = 0`**, the documented asymmetry behind #186: whole-file groups have no fiemap to draw on, skip `clean_deduped()`, and that is why `only_whole_files` converged when the extent path did not.
- **An inlined file** is not a member, not a target, and never becomes a filerec.

## What the review and the sweeps changed

**My #197 fixture proved almost nothing.** `/tree/old` won on *every* column at once — lowest id, fewest extents, oldest generation — so a pre-#197 `min(id)` election elected it too, as did one with `nr_extents` dropped from the ranking. Only a strictly window-local election failed, while the comment claimed considerably more. The review verified this by replaying the real SQL against degraded rankings rather than reasoning about it. The fixture now has four rows with the winner neither lowest-id nor a member of either window. The tie-break case had the same defect from a different angle: names, inos and ids all ascended together, so a comparator with *no* tie-break still answered correctly.

**`is_anchor` was observed by nothing** — the one C statement in `dbfile_load_same_files()` that exists for #197. Deleting it left all seven tests green. It is now asserted as a pair, `de_anchored` on the whole-file group and `!de_anchored` on an extent group, which pins the asymmetry rather than each half looking arbitrary alone.

**A helper that cannot fail hides the test it serves.** `target_of()` wrapped `list_first_entry()`, which on an empty list returns a pointer derived from the list head rather than NULL — so every `mu_check(t != NULL)` around it held whatever the loader did, and `only_group()` never checked there was exactly *one* group. Both `abort()` on a broken fixture now, the convention `gs_hit()` and `exec()` already use.

**`dbfile_load_nondupe_file_extents` was 40 → 40 after the first pass** — untouched, because I never called it. That is the second iteration running where reading residue *by function* found a whole block the tests had never reached while the total looked respectable. Closed with three tests: the uniqueness filter is over the whole extents table rather than the file; all three columns paired, since a loader reading `len` where `poff` is returns the right number of extents describing the wrong bytes; and forty extents so the geometric growth from sixteen actually runs.

I also had `mu_check`'s semantics backwards while briefing the review — it returns on failure exactly like `prop_check` (`minunit.h:149`), so the `x &&` guards after a null check were dead. `mu_assert_string_eq` replaces them where the value matters: for an election test, printing which file was actually elected is most of the diagnostic.

## Bug files

Seven new blocks in `bugs/dbfile.txt` (17 → 24), all caught. One survived the first replay and the reason is worth recording: **the tool does not mutate string literals**, so the `GET_DUPLICATE_*` SQL cannot be swept and these blocks are the only thing guarding it. Dropping the inlined-file filter from the `grp` CTE is invisible with two real copies, because the group qualifies on them alone — it shows only when the group exists *because* of the inlined file. That was a scenario I had deleted earlier in this branch for using a vacuous fixture; the idea was right and the setup was wrong.

`make mutation-replay`: **65 across eight files, nothing surviving.**

## Filed, not fixed here

- **#238** — `dbfile_load_nondupe_file_extents()` publishes `*ret_extents` before freeing it on its error paths. The one caller checks `ret` first, so nothing is reachable today, which is exactly why no test or sanitizer run can find it. Same shape as the `dbfile_prepare` use-after-free this repo already paid for.
- **#237** — `de_anchored` is written and read by nothing, and `run_dedupe.c:352` documents a target-election function that no longer exists.
- **#236** — `sanitizers (thread)` is red on roughly half of all runs, on master too. `tests/tsan.supp` already carries an entry for the race, it *is* loaded, and it does not match: it was tuned where `g_free*` was the top frame, and on the CI runner the top frame is plain `free`.

## Verification

`WERROR=1 make` clean · `make lint` clean · `make test` — **98 tests, 1,283,734 assertions, 0.31 s** · `make test CC=clang SANITIZE=address,undefined` clean · valgrind **0 lost, 0 errors, 0 suppressed** · `make mutation-replay` 65/65.

**Not run locally: the Python integration suite** — this container is ext4 with no reflink filesystem. Test-only change (`Makefile:46` filters `src/tests.c` out of the binary), so the btrfs and xfs legs are CI's.

## Next

The residue across all three files is now mostly `perror_sqlite` + `goto` on bind and step failures, which needs fault injection rather than a bigger fixture. The remaining reachable block worth naming is that `oans.c` and `run_dedupe.c` are not compiled into `./test` at all, so the mutation tool reports **0% killed** on them rather than refusing — a false report in the flattering direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_