### PR TITLE
find_dupes: fix a match recorded from before the fast-forward, and test the extent search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,47 @@ and `mkfilerec()`/`free_all_filerecs()` - which is why they came last.
   `mu_assert_string_eq` is better still where the value matters, since it
   prints what was actually there.
 
+### The extent search, and the bug testing it found
+
+`find_dupes.c` is what `--dedupe-options=partial` runs: two files' block trees
+walked in lockstep for runs of blocks that share a digest *and* sit
+contiguously in both. It was **237 of 247 mutants surviving**, and writing the
+first tests for it found a real bug.
+
+- **`compare_extents()` recorded a match starting before the fast-forward.**
+  When the current blocks disagree, a loop skips ahead until they match - its
+  whole purpose - but `start[]` was assigned at the `next_match:` label above
+  that loop and never re-assigned after it. So a match found by skipping was
+  recorded as beginning inside the gap, and the range covered bytes that
+  differ. `FIDEDUPERANGE` byte-verifies and is atomic, so the kernel refuses
+  the request whole and the genuinely matching tail goes down with it: partial
+  mode finds less than it should, exits 0, and says nothing.
+  - **The evidence it was a bug rather than a design is inside the function.**
+    `start_running_checksum()` was already *below* the fast-forward, so
+    `match_id` describes only the matching blocks. A deliberately wider
+    `start[]` would file the digest of n blocks under a length of n+k, and
+    `find_alloc_dext()` keys on `(len, digest)` - so the same run reached after
+    different-sized skips lands in different groups and meets nothing.
+  - `start[]` is write-only in `compare_extents()` and read only by
+    `record_match()`, which is what bounds the fix: it cannot change control
+    flow, termination, which matches are found, or the `extent_end` gate.
+- **A symmetric fixture cannot see which side of a pair was written.**
+  `record_match()` fills `recs[]`, `soff[]` and `eoff[]` one slot per file, and
+  laying both files out identically - the natural thing to write - makes the
+  two slots hold the same numbers, so writing either into both changes nothing.
+  47 of its 72 mutants survived on that alone; putting the matching run at a
+  different offset in each file killed 11 of them. Same defect as the #197
+  election fixture whose winner led on every column.
+- **Its residue is the pool and the database.** 66 of the remaining 142 are in
+  `find_additional_dedupe`/`search_file_extents`/`search_extent` and the pool
+  helpers, which need the thread pool, the progress block and a hashfile to
+  drive. `compare_extents()` and `record_match()` are reachable directly
+  because `tests.c` `#include`s the file, which is what made this iteration
+  possible without any of that.
+- `block_len()` already had `test_block_len`, covering all three branches
+  including past-EOF. A second one was written for it here before that was
+  checked, and deleted; the sweep credits the old test either way.
+
 ### `src/proptest.h` — properties, not tables
 
 An ordinary test names an input and its answer; a property names a relationship

--- a/scripts/mutate/bugs/find_dupes.txt
+++ b/scripts/mutate/bugs/find_dupes.txt
@@ -61,10 +61,12 @@
 # ---------------------------------------------------------------- ranges
 
 # the recorded range ends one byte past the match
-# record_match() closes the range at an *inclusive* offset, and insert_result()
-# reads a length back out of it as endoff - startoff + 1. Drop the -1 and every
-# group is filed one byte longer than it is - under a length no other extent is
-# filed under, where it meets nothing.
+# record_match() closes the range at an *inclusive* offset. Drop the -1 and
+# every recorded range covers one byte more than was ever compared - and where
+# a run ends on a file's last block, one byte past the end of the file, which
+# the kernel refuses outright. Note what does *not* break: the growth is
+# uniform, so these groups still find each other in find_alloc_dext(), which
+# is why nothing about the grouping looks wrong.
 <<<
 	eoff[0] = block_len(end[0]) + end[0]->b_loff - 1;
 	eoff[1] = block_len(end[1]) + end[1]->b_loff - 1;
@@ -75,8 +77,11 @@
 
 # the last block of a file is measured as a whole block
 # A file that is not a whole number of blocks long ends mid-block, and asking
-# the kernel to deduplicate past the end of a file is a request it refuses. The
-# tail case is the one a fixture of block-aligned files never reaches.
+# the kernel to deduplicate past the end of a file is a request it refuses.
+# Caught by test_block_len, which has covered all three branches since before
+# these tests existed, and again by the record_match() test that reads a
+# group's length back out - the two say different things, one about the
+# measurement and one about what is done with it.
 <<<
 	/* We are in the last "blocksize" part of the file */
 	return (block->b_file->size - block->b_loff) % blocksize;

--- a/scripts/mutate/bugs/find_dupes.txt
+++ b/scripts/mutate/bugs/find_dupes.txt
@@ -1,0 +1,97 @@
+# file: src/find_dupes.c
+#
+# Invariants of the extent search, each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/find_dupes.txt
+#
+# This is what --dedupe-options=partial runs: two files' block trees walked in
+# lockstep, looking for runs of blocks that share a digest *and* sit
+# contiguously in both files. Everything here fails silently in the usual way -
+# a run found too long is a request the kernel byte-verifies and refuses, a run
+# found too short is a duplicate nobody ever finds, and either way the run
+# exits 0 having deduplicated slightly less than it could.
+#
+# Pure memory: compare_extents() and record_match() are static in a file
+# tests.c #includes, so they are called directly rather than through the thread
+# pool and the database that drive them in production.
+
+# ---------------------------------------------------------------- the fix
+
+# the match starts before the fast-forward instead of after it
+# This is the bug these tests found. The loop's whole job is to skip blocks
+# whose digests disagree; recording the position from *before* it makes the
+# match begin inside that gap. The range then covers bytes that differ, so
+# FIDEDUPERANGE refuses the whole request - and the genuinely matching tail it
+# was folded into is never deduplicated on its own. Partial mode quietly finds
+# less than it should, and nothing anywhere says so.
+<<<
+	while (block->b_parent != orig->b_parent && block->b_loff < extent_end) {
+		/*
+		 * Check that we don't walk off either tree
+		 */
+		if (end_of_block_list(orig) || end_of_block_list(block))
+			return 0;
+
+		orig = get_next_block(orig);
+		block = get_next_block(block);
+	}
+	/*
+	 * *After* the fast-forward, not before: the match starts where the
+	 * digests start agreeing. Recording the pre-skip position instead
+	 * hands the kernel a range whose bytes differ, which it byte-verifies
+	 * and refuses whole - taking the genuinely matching tail down with it.
+	 */
+	start[0] = orig;
+	start[1] = block;
+===
+	start[0] = orig;
+	start[1] = block;
+	while (block->b_parent != orig->b_parent && block->b_loff < extent_end) {
+		/*
+		 * Check that we don't walk off either tree
+		 */
+		if (end_of_block_list(orig) || end_of_block_list(block))
+			return 0;
+
+		orig = get_next_block(orig);
+		block = get_next_block(block);
+	}
+>>>
+
+# ---------------------------------------------------------------- ranges
+
+# the recorded range ends one byte past the match
+# record_match() closes the range at an *inclusive* offset, and insert_result()
+# reads a length back out of it as endoff - startoff + 1. Drop the -1 and every
+# group is filed one byte longer than it is - under a length no other extent is
+# filed under, where it meets nothing.
+<<<
+	eoff[0] = block_len(end[0]) + end[0]->b_loff - 1;
+	eoff[1] = block_len(end[1]) + end[1]->b_loff - 1;
+===
+	eoff[0] = block_len(end[0]) + end[0]->b_loff;
+	eoff[1] = block_len(end[1]) + end[1]->b_loff;
+>>>
+
+# the last block of a file is measured as a whole block
+# A file that is not a whole number of blocks long ends mid-block, and asking
+# the kernel to deduplicate past the end of a file is a request it refuses. The
+# tail case is the one a fixture of block-aligned files never reaches.
+<<<
+	/* We are in the last "blocksize" part of the file */
+	return (block->b_file->size - block->b_loff) % blocksize;
+===
+	return blocksize;
+>>>
+
+# a run is allowed to continue over a gap in either file
+# The two files' blocks have to stay contiguous as well as matching: a run that
+# jumps a hole describes a range containing bytes that were never compared.
+<<<
+		if (orig->b_loff != (orig_blkno + blocksize) ||
+		    block->b_loff != (walk_blkno + blocksize)) {
+			matchmore = false;
+			break;
+		}
+===
+>>>

--- a/src/find_dupes.c
+++ b/src/find_dupes.c
@@ -153,8 +153,6 @@ static int compare_extents(struct filerec *orig_file,
 	extent_end = block->b_loff + search_len - 1;
 
 next_match:
-	start[0] = orig;
-	start[1] = block;
 	/*
 	 * Fast-forward to a match, if we can find one. This doesn't
 	 * run on the first match as callers start the search on
@@ -171,6 +169,14 @@ next_match:
 		orig = get_next_block(orig);
 		block = get_next_block(block);
 	}
+	/*
+	 * *After* the fast-forward, not before: the match starts where the
+	 * digests start agreeing. Recording the pre-skip position instead
+	 * hands the kernel a range whose bytes differ, which it byte-verifies
+	 * and refuses whole - taking the genuinely matching tail down with it.
+	 */
+	start[0] = orig;
+	start[1] = block;
 	/*
 	 * XXX: There's no need for this, we ought to just generate a
 	 * unique identifier for our tree.

--- a/src/tests.c
+++ b/src/tests.c
@@ -5062,12 +5062,16 @@ MU_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents) {
  * `blocksize` is a mutable global that block_len() reads, and an earlier test
  * leaves it at 100. Each of these sets it and puts it back, so they neither
  * depend on test order nor impose one.
+ *
+ * It is the only one that needs saving. The reachable code also reads `debug`,
+ * which no test in this file assigns - a future one that does should save it
+ * here too. `options.dedupe_same_file` is *not* read: only search_extent()
+ * consults it, and these call compare_extents() directly.
  */
 struct fd_fixture {
 	struct hash_tree tree;
 	struct results_tree res;
 	unsigned int saved_blocksize;
-	bool saved_same_file;
 };
 
 static void fd_begin(struct fd_fixture *f)
@@ -5076,7 +5080,6 @@ static void fd_begin(struct fd_fixture *f)
 	init_hash_tree(&f->tree);
 	init_results_tree(&f->res);
 	f->saved_blocksize = blocksize;
-	f->saved_same_file = options.dedupe_same_file;
 	blocksize = FD_BLOCK;
 }
 
@@ -5086,43 +5089,21 @@ static void fd_end(struct fd_fixture *f)
 	free_hash_tree(&f->tree);
 	free_all_filerecs();
 	blocksize = f->saved_blocksize;
-	options.dedupe_same_file = f->saved_same_file;
 }
 
-/* A file of `nblocks` blocks whose digests are named by `digests[i]`; the file
- * size is exact unless `tail` shortens the last block. */
-static struct filerec *fd_file(struct fd_fixture *f, int64_t id,
-			       const unsigned int *digests, unsigned int n,
-			       uint64_t tail)
-{
-	char name[64];
-	struct filerec *file;
-
-	snprintf(name, sizeof(name), "/tree/f%lld", (long long)id);
-	file = filerec_new(name, id, FD_BLOCK * (n - 1) + (tail ? tail : FD_BLOCK));
-	if (!file)
-		abort();
-	for (unsigned int i = 0; i < n; i++) {
-		unsigned char dg[DIGEST_LEN];
-
-		digest_of(dg, digests[i]);
-		if (insert_hashed_block(&f->tree, dg, file, FD_BLOCK * i))
-			abort();
-	}
-	return file;
-}
-
-/* Like fd_file(), but the blocks sit at the offsets given rather than
- * contiguously - so a file can have a hole where no block was hashed. */
+/* Blocks at the offsets given, so a file can have a hole where nothing was
+ * hashed. The file ends `tail` bytes into its last block, or on a block
+ * boundary when `tail` is zero. */
 static struct filerec *fd_file_at(struct fd_fixture *f, int64_t id,
 				  const unsigned int *digests,
-				  const uint64_t *offs, unsigned int n)
+				  const uint64_t *offs, unsigned int n,
+				  uint64_t tail)
 {
 	char name[64];
 	struct filerec *file;
 
 	snprintf(name, sizeof(name), "/tree/f%lld", (long long)id);
-	file = filerec_new(name, id, offs[n - 1] + FD_BLOCK);
+	file = filerec_new(name, id, offs[n - 1] + (tail ? tail : FD_BLOCK));
 	if (!file)
 		abort();
 	for (unsigned int i = 0; i < n; i++) {
@@ -5135,7 +5116,22 @@ static struct filerec *fd_file_at(struct fd_fixture *f, int64_t id,
 	return file;
 }
 
-/* The first block of a file, which is where every search below starts. */
+/* The same, with the blocks packed contiguously from zero. */
+static struct filerec *fd_file(struct fd_fixture *f, int64_t id,
+			       const unsigned int *digests, unsigned int n,
+			       uint64_t tail)
+{
+	uint64_t offs[8];
+
+	if (n > ARRAY_SIZE(offs))
+		abort();
+	for (unsigned int i = 0; i < n; i++)
+		offs[i] = FD_BLOCK * i;
+	return fd_file_at(f, id, digests, offs, n, tail);
+}
+
+/* A block of a file by offset; aborts if there is none, which would mean the
+ * fixture is broken rather than the code under test. */
 static struct file_block *fd_block(struct filerec *file, uint64_t loff)
 {
 	struct file_block *b = find_filerec_block(file, loff);
@@ -5194,7 +5190,7 @@ MU_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search) {
 	static const unsigned int right[] = { 1, 9, 3 };
 	struct filerec *a, *b;
 	struct rb_node *n;
-	unsigned int groups = 0;
+	unsigned int groups = 0, seen = 0;
 
 	fd_begin(&f);
 	a = fd_file(&f, 1, left, ARRAY_SIZE(left), 0);
@@ -5217,11 +5213,14 @@ MU_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search) {
 		mu_check(d->de_len == FD_BLOCK);
 		list_for_each_entry(e, &d->de_extents, e_list) {
 			mu_check(e->e_loff == 0 || e->e_loff == FD_BLOCK * 2);
-			mu_check(e->e_loff != FD_BLOCK);	/* the gap */
+			seen |= e->e_loff == 0 ? 1u : 2u;
 		}
 		groups++;
 	}
 	mu_check(groups == 2);
+	/* One group at each of the two matching offsets - not both at the same
+	 * one, which the per-extent check above would allow. */
+	mu_check(seen == 3);
 	mu_check(f.res.num_extents == 4);	/* two members per group */
 
 	fd_end(&f);
@@ -5243,26 +5242,30 @@ MU_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous) {
 	/* Same three digests, but the third block sits past a hole. */
 	static const uint64_t holed[]   = { 0, FD_BLOCK, FD_BLOCK * 3 };
 	struct filerec *a, *b;
-	struct rb_node *n;
-	unsigned int groups = 0;
+	struct dupe_extents *d;
+	struct extent *e;
 
 	fd_begin(&f);
-	a = fd_file_at(&f, 1, dg, gapless, ARRAY_SIZE(dg));
-	b = fd_file_at(&f, 2, dg, holed, ARRAY_SIZE(dg));
+	a = fd_file_at(&f, 1, dg, gapless, ARRAY_SIZE(dg), 0);
+	b = fd_file_at(&f, 2, dg, holed, ARRAY_SIZE(dg), 0);
 
 	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, 0),
 				 FD_BLOCK * 4, &f.res) == 0);
 
-	for (n = rb_first(&f.res.root); n; n = rb_next(n)) {
-		struct dupe_extents *d =
-			rb_entry(n, struct dupe_extents, de_node);
-
-		/* Two blocks, then it stops - never three across the hole. */
-		mu_check(d->de_len == FD_BLOCK * 2 || d->de_len == FD_BLOCK);
-		mu_check(d->de_len != FD_BLOCK * 3);
-		groups++;
-	}
-	mu_check(groups >= 1);
+	/*
+	 * Exactly one group of exactly two blocks, starting at zero. The third
+	 * pair matches on digest and is deliberately never recorded: reaching
+	 * it would mean a range spanning b's hole, i.e. bytes that were never
+	 * compared. Asserting only "not three blocks" would accept every
+	 * found-too-short answer as well, which is half of what this is about.
+	 */
+	mu_check(f.res.num_dupes == 1);
+	d = only_group(&f.res);
+	mu_check(d->de_num_dupes == 2);
+	mu_check(d->de_len == FD_BLOCK * 2);
+	mu_check(f.res.num_extents == 2);
+	list_for_each_entry(e, &d->de_extents, e_list)
+		mu_check(e->e_loff == 0);
 
 	fd_end(&f);
 }
@@ -5293,30 +5296,6 @@ MU_TEST(test_a_short_final_block_shortens_the_recorded_run) {
 	d = only_group(&f.res);
 	/* One whole block plus the 1000-byte tail, not two whole blocks. */
 	mu_check(d->de_len == FD_BLOCK + 1000);
-
-	fd_end(&f);
-}
-
-/*
- * block_len() on its own, at the three shapes it distinguishes. It is called
- * from record_match() to close the range, so its answer becomes the group's
- * length - and the middle case is the one a fixture of whole-block files
- * never reaches.
- */
-MU_TEST(test_block_len_measures_the_tail_of_a_file) {
-	struct fd_fixture f;
-	static const unsigned int dg[] = { 1, 2, 3 };
-	struct filerec *file;
-
-	fd_begin(&f);
-	file = fd_file(&f, 1, dg, ARRAY_SIZE(dg), 1000);
-	mu_check(file->size == FD_BLOCK * 2 + 1000);
-
-	/* Wholly inside the file. */
-	mu_check(block_len(fd_block(file, 0)) == FD_BLOCK);
-	mu_check(block_len(fd_block(file, FD_BLOCK)) == FD_BLOCK);
-	/* The last block, which stops where the file does. */
-	mu_check(block_len(fd_block(file, FD_BLOCK * 2)) == 1000);
 
 	fd_end(&f);
 }
@@ -5442,7 +5421,6 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search);
 	MU_RUN_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous);
 	MU_RUN_TEST(test_a_short_final_block_shortens_the_recorded_run);
-	MU_RUN_TEST(test_block_len_measures_the_tail_of_a_file);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -5227,6 +5227,60 @@ MU_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search) {
 }
 
 /*
+ * The two sides are recorded separately, and asymmetric offsets are what makes
+ * that observable.
+ *
+ * record_match() fills recs[], soff[] and eoff[] as pairs, one slot per file.
+ * With both files laid out identically - which every other test here does,
+ * because it is the natural fixture - slot 0 and slot 1 hold the same numbers,
+ * so writing either into both, or reading the wrong one, changes nothing any
+ * assertion can see. Putting the matching run at a different offset in each
+ * file makes the two slots hold different values, and the pair of recorded
+ * offsets then pins which is which.
+ */
+MU_TEST(test_each_side_of_a_match_records_its_own_offsets) {
+	struct fd_fixture f;
+	static const unsigned int dg[] = { 1, 2, 3 };
+	static const uint64_t early[] = { 0, FD_BLOCK, FD_BLOCK * 2 };
+	static const uint64_t late[]  = { FD_BLOCK * 2, FD_BLOCK * 3, FD_BLOCK * 4 };
+	struct filerec *a, *b;
+	struct dupe_extents *d;
+	struct extent *e;
+	unsigned int seen = 0;
+
+	fd_begin(&f);
+	a = fd_file_at(&f, 1, dg, early, ARRAY_SIZE(dg), 0);
+	b = fd_file_at(&f, 2, dg, late, ARRAY_SIZE(dg), 0);
+
+	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, FD_BLOCK * 2),
+				 FD_BLOCK * 8, &f.res) == 0);
+
+	mu_check(f.res.num_dupes == 1);
+	d = only_group(&f.res);
+	mu_check(d->de_num_dupes == 2);
+	mu_check(d->de_len == FD_BLOCK * 3);
+
+	/*
+	 * a's copy starts at 0 and b's at two blocks in - each from its own
+	 * slot. A slot written from the wrong side puts both at one offset.
+	 */
+	list_for_each_entry(e, &d->de_extents, e_list) {
+		if (e->e_file == a) {
+			mu_check(e->e_loff == 0);
+			seen |= 1u;
+		} else if (e->e_file == b) {
+			mu_check(e->e_loff == FD_BLOCK * 2);
+			seen |= 2u;
+		} else {
+			mu_fail("an extent belonging to neither file");
+		}
+	}
+	mu_check(seen == 3);	/* one member from each file, not two of one */
+
+	fd_end(&f);
+}
+
+/*
  * A run stops where the blocks stop being contiguous, even though they still
  * match.
  *
@@ -5419,6 +5473,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents);
 	MU_RUN_TEST(test_a_whole_matching_run_is_recorded_as_one_group);
 	MU_RUN_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search);
+	MU_RUN_TEST(test_each_side_of_a_match_records_its_own_offsets);
 	MU_RUN_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous);
 	MU_RUN_TEST(test_a_short_final_block_shortens_the_recorded_run);
 	MU_RUN_TEST(test_dedupe_classify_probe);

--- a/src/tests.c
+++ b/src/tests.c
@@ -5038,6 +5038,289 @@ MU_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents) {
 	free_all_filerecs();
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * The extent search (find_dupes.c)
+ *
+ * What `--dedupe-options=partial` runs: for a file extent nothing else shares,
+ * walk two files' block trees in lockstep looking for runs of blocks that
+ * carry the same digest *and* sit contiguously in both files. It was 237 of
+ * 247 mutants surviving - 4% killed - and the whole of it is reachable from
+ * here, because compare_extents() and record_match() are static in a file
+ * tests.c #includes, so they can be called directly rather than through the
+ * thread pool and the database that normally drive them.
+ *
+ * A run found too long is a dedupe request the kernel byte-verify rejects;
+ * one found too short is a duplicate nobody ever finds. Neither says anything
+ * at the time.
+ * ---------------------------------------------------------------------------
+ */
+
+#define FD_BLOCK	4096
+
+/*
+ * `blocksize` is a mutable global that block_len() reads, and an earlier test
+ * leaves it at 100. Each of these sets it and puts it back, so they neither
+ * depend on test order nor impose one.
+ */
+struct fd_fixture {
+	struct hash_tree tree;
+	struct results_tree res;
+	unsigned int saved_blocksize;
+	bool saved_same_file;
+};
+
+static void fd_begin(struct fd_fixture *f)
+{
+	free_all_filerecs();
+	init_hash_tree(&f->tree);
+	init_results_tree(&f->res);
+	f->saved_blocksize = blocksize;
+	f->saved_same_file = options.dedupe_same_file;
+	blocksize = FD_BLOCK;
+}
+
+static void fd_end(struct fd_fixture *f)
+{
+	free_results_tree(&f->res);
+	free_hash_tree(&f->tree);
+	free_all_filerecs();
+	blocksize = f->saved_blocksize;
+	options.dedupe_same_file = f->saved_same_file;
+}
+
+/* A file of `nblocks` blocks whose digests are named by `digests[i]`; the file
+ * size is exact unless `tail` shortens the last block. */
+static struct filerec *fd_file(struct fd_fixture *f, int64_t id,
+			       const unsigned int *digests, unsigned int n,
+			       uint64_t tail)
+{
+	char name[64];
+	struct filerec *file;
+
+	snprintf(name, sizeof(name), "/tree/f%lld", (long long)id);
+	file = filerec_new(name, id, FD_BLOCK * (n - 1) + (tail ? tail : FD_BLOCK));
+	if (!file)
+		abort();
+	for (unsigned int i = 0; i < n; i++) {
+		unsigned char dg[DIGEST_LEN];
+
+		digest_of(dg, digests[i]);
+		if (insert_hashed_block(&f->tree, dg, file, FD_BLOCK * i))
+			abort();
+	}
+	return file;
+}
+
+/* Like fd_file(), but the blocks sit at the offsets given rather than
+ * contiguously - so a file can have a hole where no block was hashed. */
+static struct filerec *fd_file_at(struct fd_fixture *f, int64_t id,
+				  const unsigned int *digests,
+				  const uint64_t *offs, unsigned int n)
+{
+	char name[64];
+	struct filerec *file;
+
+	snprintf(name, sizeof(name), "/tree/f%lld", (long long)id);
+	file = filerec_new(name, id, offs[n - 1] + FD_BLOCK);
+	if (!file)
+		abort();
+	for (unsigned int i = 0; i < n; i++) {
+		unsigned char dg[DIGEST_LEN];
+
+		digest_of(dg, digests[i]);
+		if (insert_hashed_block(&f->tree, dg, file, offs[i]))
+			abort();
+	}
+	return file;
+}
+
+/* The first block of a file, which is where every search below starts. */
+static struct file_block *fd_block(struct filerec *file, uint64_t loff)
+{
+	struct file_block *b = find_filerec_block(file, loff);
+
+	if (!b)
+		abort();
+	return b;
+}
+
+/*
+ * Two files whose blocks all match produce one group covering the whole run.
+ *
+ * The length is the part worth stating: record_match() ends the range at
+ * `block_len(end) + end->b_loff - 1`, an *inclusive* offset, and
+ * insert_result() reads a length back out of it as `endoff - startoff + 1`.
+ * Those two have to agree, and an off-by-one either way files the group under
+ * a length no other extent is filed under - where it silently meets nothing.
+ */
+MU_TEST(test_a_whole_matching_run_is_recorded_as_one_group) {
+	struct fd_fixture f;
+	static const unsigned int dg[] = { 1, 2, 3 };
+	struct filerec *a, *b;
+	struct dupe_extents *d;
+
+	fd_begin(&f);
+	a = fd_file(&f, 1, dg, ARRAY_SIZE(dg), 0);
+	b = fd_file(&f, 2, dg, ARRAY_SIZE(dg), 0);
+
+	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, 0),
+				 FD_BLOCK * ARRAY_SIZE(dg), &f.res) == 0);
+
+	mu_check(f.res.num_dupes == 1);
+	d = only_group(&f.res);
+	mu_check(d->de_num_dupes == 2);
+	mu_check(d->de_len == FD_BLOCK * ARRAY_SIZE(dg));
+
+	/* Both members start at zero, which is where the run started. */
+	{
+		struct extent *e;
+
+		list_for_each_entry(e, &d->de_extents, e_list)
+			mu_check(e->e_loff == 0);
+	}
+	fd_end(&f);
+}
+
+/*
+ * A digest that differs in the middle ends the run there, and the search
+ * resumes past it rather than stopping - so two separate runs become two
+ * groups, not one long one and not one short one.
+ */
+MU_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search) {
+	struct fd_fixture f;
+	/* Same, different, same-again: two runs of one block each. */
+	static const unsigned int left[]  = { 1, 2, 3 };
+	static const unsigned int right[] = { 1, 9, 3 };
+	struct filerec *a, *b;
+	struct rb_node *n;
+	unsigned int groups = 0;
+
+	fd_begin(&f);
+	a = fd_file(&f, 1, left, ARRAY_SIZE(left), 0);
+	b = fd_file(&f, 2, right, ARRAY_SIZE(right), 0);
+
+	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, 0),
+				 FD_BLOCK * ARRAY_SIZE(left), &f.res) == 0);
+
+	/*
+	 * Each matching block is its own group of exactly one block, and
+	 * crucially neither *starts* at the mismatched block: a group running
+	 * 4096..12287 would cover bytes that differ, which is what this found
+	 * when it was first written.
+	 */
+	for (n = rb_first(&f.res.root); n; n = rb_next(n)) {
+		struct dupe_extents *d =
+			rb_entry(n, struct dupe_extents, de_node);
+		struct extent *e;
+
+		mu_check(d->de_len == FD_BLOCK);
+		list_for_each_entry(e, &d->de_extents, e_list) {
+			mu_check(e->e_loff == 0 || e->e_loff == FD_BLOCK * 2);
+			mu_check(e->e_loff != FD_BLOCK);	/* the gap */
+		}
+		groups++;
+	}
+	mu_check(groups == 2);
+	mu_check(f.res.num_extents == 4);	/* two members per group */
+
+	fd_end(&f);
+}
+
+/*
+ * A run stops where the blocks stop being contiguous, even though they still
+ * match.
+ *
+ * Matching digests are not enough: the recorded range is a span of bytes in
+ * both files, so a run that jumps a hole in either one describes bytes that
+ * were never compared. The kernel byte-verifies and refuses the request, and
+ * the parts that really did match go down with it.
+ */
+MU_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous) {
+	struct fd_fixture f;
+	static const unsigned int dg[] = { 1, 2, 3 };
+	static const uint64_t gapless[] = { 0, FD_BLOCK, FD_BLOCK * 2 };
+	/* Same three digests, but the third block sits past a hole. */
+	static const uint64_t holed[]   = { 0, FD_BLOCK, FD_BLOCK * 3 };
+	struct filerec *a, *b;
+	struct rb_node *n;
+	unsigned int groups = 0;
+
+	fd_begin(&f);
+	a = fd_file_at(&f, 1, dg, gapless, ARRAY_SIZE(dg));
+	b = fd_file_at(&f, 2, dg, holed, ARRAY_SIZE(dg));
+
+	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, 0),
+				 FD_BLOCK * 4, &f.res) == 0);
+
+	for (n = rb_first(&f.res.root); n; n = rb_next(n)) {
+		struct dupe_extents *d =
+			rb_entry(n, struct dupe_extents, de_node);
+
+		/* Two blocks, then it stops - never three across the hole. */
+		mu_check(d->de_len == FD_BLOCK * 2 || d->de_len == FD_BLOCK);
+		mu_check(d->de_len != FD_BLOCK * 3);
+		groups++;
+	}
+	mu_check(groups >= 1);
+
+	fd_end(&f);
+}
+
+/*
+ * The last block of a file that is not a whole number of blocks long is
+ * shorter, and the recorded length has to say so. Asking the kernel to
+ * deduplicate past the end of a file is a request it refuses, so a run
+ * measured in whole blocks here is work that fails later with nothing
+ * connecting the failure to this decision.
+ */
+MU_TEST(test_a_short_final_block_shortens_the_recorded_run) {
+	struct fd_fixture f;
+	static const unsigned int dg[] = { 1, 2 };
+	struct filerec *a, *b;
+	struct dupe_extents *d;
+
+	fd_begin(&f);
+	/* Both files end 1000 bytes into their second block. */
+	a = fd_file(&f, 1, dg, ARRAY_SIZE(dg), 1000);
+	b = fd_file(&f, 2, dg, ARRAY_SIZE(dg), 1000);
+	mu_check(a->size == FD_BLOCK + 1000);
+
+	mu_check(compare_extents(a, fd_block(a, 0), b, fd_block(b, 0),
+				 FD_BLOCK * 2, &f.res) == 0);
+
+	mu_check(f.res.num_dupes == 1);
+	d = only_group(&f.res);
+	/* One whole block plus the 1000-byte tail, not two whole blocks. */
+	mu_check(d->de_len == FD_BLOCK + 1000);
+
+	fd_end(&f);
+}
+
+/*
+ * block_len() on its own, at the three shapes it distinguishes. It is called
+ * from record_match() to close the range, so its answer becomes the group's
+ * length - and the middle case is the one a fixture of whole-block files
+ * never reaches.
+ */
+MU_TEST(test_block_len_measures_the_tail_of_a_file) {
+	struct fd_fixture f;
+	static const unsigned int dg[] = { 1, 2, 3 };
+	struct filerec *file;
+
+	fd_begin(&f);
+	file = fd_file(&f, 1, dg, ARRAY_SIZE(dg), 1000);
+	mu_check(file->size == FD_BLOCK * 2 + 1000);
+
+	/* Wholly inside the file. */
+	mu_check(block_len(fd_block(file, 0)) == FD_BLOCK);
+	mu_check(block_len(fd_block(file, FD_BLOCK)) == FD_BLOCK);
+	/* The last block, which stops where the file does. */
+	mu_check(block_len(fd_block(file, FD_BLOCK * 2)) == 1000);
+
+	fd_end(&f);
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -5155,6 +5438,11 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_nondupe_extents_are_the_ones_nothing_else_shares);
 	MU_RUN_TEST(test_nondupe_extents_grow_past_the_initial_capacity);
 	MU_RUN_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents);
+	MU_RUN_TEST(test_a_whole_matching_run_is_recorded_as_one_group);
+	MU_RUN_TEST(test_a_mismatch_splits_the_run_rather_than_ending_the_search);
+	MU_RUN_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous);
+	MU_RUN_TEST(test_a_short_final_block_shortens_the_recorded_run);
+	MU_RUN_TEST(test_block_len_measures_the_tail_of_a_file);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run


### PR DESCRIPTION
Fourth in the series. **Writing the first unit tests for the extent search found a bug in it**, so this PR is a one-line behaviour fix plus the tests that found it and pin it.

`src/find_dupes.c`: **237 of 247 mutants surviving (4% killed) → 142 (42%)**.

## The bug

`compare_extents()` walks two files' block trees in lockstep looking for runs of blocks that share a digest. When the blocks it is on do *not* match, a loop fast-forwards both trees until they do — that loop's entire purpose. But `start[]` was assigned at the `next_match:` label, **above** that loop, and never re-assigned after it. A match found by fast-forwarding was therefore recorded as beginning at the pre-skip position, inside the gap.

Measured, three blocks per file differing only in the middle one:

```
group len=4096 members: /tree/f1@0     /tree/f2@0
group len=8192 members: /tree/f1@4096  /tree/f2@4096   <- covers bytes that differ
```

After moving the two assignments below the loop:

```
group len=4096 members: /tree/f1@0     /tree/f2@0
group len=4096 members: /tree/f1@8192  /tree/f2@8192
```

**The consequence is quiet, which is why it lasted.** `FIDEDUPERANGE` byte-verifies and is atomic, so a range containing differing bytes is refused *whole* — and the genuinely matching tail, folded into that request, never gets deduplicated on its own. `--dedupe-options=partial` finds less than it should and nothing anywhere says so. Nothing is corrupted; the kernel refusing is what makes this a lost opportunity rather than a wrong dedupe.

## Why it is a bug and not a design

The argument is internal to the function, and it is what convinced me rather than the diff looking odd:

**`start_running_checksum()` was already below the fast-forward**, so `match_id` describes only the matching blocks. A deliberately wider `start[]` would file the digest of *n* blocks under a length of *n+k* — and `find_alloc_dext()` keys on `(len, digest)`, so the same run reached after different-sized skips would land in different groups and meet nothing. The two statements disagreed with each other; one had been left on the wrong side of a loop added around it.

The fix is bounded by a structural fact: **`start[]` is write-only inside `compare_extents()`**, read only by `record_match()`. Moving the assignment cannot change control flow, termination, which matches are found, or the `match_end <= extent_end` gate — only the two recorded start offsets. Every path from the label to `record_match()` passes through the new assignment; where the fast-forward exits without a match, `end[0]` stays NULL and the function returns before `start[]` is read. No `-Wmaybe-uninitialized` warning at `-O2`.

Reachability is narrow, which is the other half of why it survived: only under `--dedupe-options=partial` (off by default), and only on the second and later matches within one call.

## A symmetric fixture cannot see which side of a pair was written

Worth recording because my own tests walked into it. After the first pass, 47 of `record_match()`'s 72 mutants were still alive, and reading them line by line rather than counting them showed they were index mutants on the `[0]`/`[1]` pairs — `recs[0]` written from `start[1]`, `soff[1]` read from slot 0.

They survived because every fixture laid the two files out *identically*, which is the natural thing to write. With identical layouts both slots hold the same numbers, so writing either into both is invisible. One test with the matching run at a **different offset in each file** killed 11 of them, taking `record_match` from 34% to 50%.

That is the same defect as #239's target-election fixture whose winner led on every column, one iteration later in different clothes.

## What the tests cover

`compare_extents()` and `record_match()` are `static` in a file `tests.c` `#include`s, so they are called directly — no thread pool, no database. Five tests: a whole matching run recorded as one group; a mismatch splitting the run rather than ending the search; a run stopping where the blocks stop being contiguous; each side recording its own offsets; and a short final block shortening the recorded run (`record_match` closes an *inclusive* range that `insert_result` reads a length back out of).

`scripts/mutate/bugs/find_dupes.txt` puts the bug back along with three neighbouring invariants — **4/4 caught**, so the test provably fails without the fix.

## What the `/simplify` pass changed

Two reviews, one on the fix and one on the tests. The fix came back clean, with the better argument above. The tests review found:

- **I added a `block_len` test without checking whether one existed.** `test_block_len` has covered all three branches including past-EOF since before this change; mine omitted past-EOF and used a far heavier fixture. Deleted, and its comment claiming the tail case was out of reach was simply false.
- **Two assertions looser than the behaviour they describe.** The contiguity test accepted anything that was not three blocks — which passes for every *found-too-short* outcome too, half of what it is about. Traced through `compare_extents()`, the exact result is one group of two blocks with both members at zero; that is what it says now. The mismatch test allowed both groups to sit at the same offset.
- **A consequence I stated wrongly in a bug block.** The off-by-one range grows *uniformly*, so those groups still find each other; what actually breaks is that the range covers a byte never compared and runs past EOF at a file's end. Corrected.
- Dead fixture state (`options.dedupe_same_file` is read only by `search_extent()`, which these never call) and a duplicated helper.

## The residue

**66 of the remaining 142 are the pool-and-database layer** — `find_additional_dedupe`, `search_file_extents`, `search_extent` and the pool helpers, all at 0%, all needing the thread pool, the progress block and a hashfile to drive. That is a stated gap and the natural next iteration, not an oversight. `record_match`'s remainder is mostly deleted `abort_on()`s, which fire only on a fixture that is already broken, and array-size mutants needing a sanitizer rather than a test.

## Verification

`WERROR=1 make` clean · `make lint` clean · `make test` — **103 tests, 1,283,768 assertions, 0.38 s** · `make test CC=clang SANITIZE=address,undefined` clean · valgrind **0 lost, 0 errors, 0 suppressed** · `bugs/find_dupes.txt` 4/4.

**Not run locally: the Python integration suite** — this container is ext4 with no reflink filesystem. Note this PR *does* change production behaviour, unlike the previous three, so the btrfs and xfs legs matter more here than usual.

## Also measured, not included

Recon sweeps of three other never-swept files, for whoever picks them up: `longpath.c` 65/124 (47% killed, `open_ancestor` 34), `threads.c` 75/75 (0%), `interrupt.c` 46/46 (0%). Kept out of this PR because they are separate subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_