### PR TITLE
test: the extent search driven by its own thread pool

### DIFF
--- a/scripts/mutate/bugs/find_dupes.txt
+++ b/scripts/mutate/bugs/find_dupes.txt
@@ -100,3 +100,33 @@
 		}
 ===
 >>>
+
+# ---------------------------------------------------------------- the pool
+
+# the search returns without waiting for its workers
+# #123. Each worker holds a filerec from the global list, and the caller - the
+# streaming dedupe producer - goes straight back to reaping batches, which
+# frees them. Returning with work in flight lets a worker read a filerec that
+# has already been freed; it reproduced in about one memcheck run in twenty.
+# The test holds the workers back for 300ms to make this deterministic, which
+# has to exceed psearch_join()'s own latency rather than just the workers':
+# with the wait gone, find_additional_dedupe() still blocks in printer_stop()
+# for the rest of the progress thread's 100ms sleep, and any shorter delay is
+# hidden behind that.
+<<<
+	threads_pool_wait_idle(&search_pool);
+===
+>>>
+
+# an empty file is skipped without being counted as processed
+# The progress total is the whole filerec list, so a skip that forgets to
+# count leaves the search reading as permanently unfinished. Note that
+# deleting the *whole* branch rather than just this line is equivalent and is
+# deliberately not listed: the file then goes to the pool, whose worker counts
+# it instead, and nothing downstream can tell the two apart.
+<<<
+			psearch_update_processed_count(1);
+			continue;
+===
+			continue;
+>>>

--- a/src/tests.c
+++ b/src/tests.c
@@ -5354,6 +5354,183 @@ MU_TEST(test_a_short_final_block_shortens_the_recorded_run) {
 	fd_end(&f);
 }
 
+/*
+ * The search driven the way the dedupe phase drives it.
+ *
+ * This is `--dedupe-options=partial`: a thread pool over the global filerec
+ * list, each worker asking the hashfile which of its file's extents nothing
+ * else shares, then searching those block by block for matches the extent pass
+ * could not see.
+ *
+ * **One test, several scenarios, and that is not laziness.** The pool must be
+ * created once per process, because search_file_extents() caches its database
+ * handle in a `static __thread` and GLib caches idle pool threads: a second
+ * extents_search_init() hands work to the same OS threads, whose thread-local
+ * still points at the handle the first free_pool() released, and whose
+ * `if (!db)` is therefore false. ASAN calls that a heap-use-after-free, and it
+ * is - but only for a caller that builds the pool twice. Production builds it
+ * once around the whole dedupe phase (oans.c) and calls the search once per
+ * generation window inside, so the handle lives exactly as long as the pool
+ * that owns it. Splitting these into four MU_TESTs would test a lifetime oans
+ * does not have.
+ */
+struct search_fixture {
+	struct fd_fixture fd;
+	unsigned int saved_cpu_threads;
+	int saved_quiet;
+	bool saved_same_file;
+};
+
+/*
+ * Teardown by scope exit, not at the end of the body: mu_check() *returns* on
+ * failure, so a failed assertion would otherwise leave the pool alive with its
+ * per-thread handles open - and those handles are the only thing keeping the
+ * shared in-memory database alive, so its rows would survive into every later
+ * test. One failing assertion cost eight unrelated dbfile tests before this
+ * was a cleanup attribute.
+ */
+static void search_end(struct search_fixture *s)
+{
+	extents_search_free();
+	options.cpu_threads = s->saved_cpu_threads;
+	options.dedupe_same_file = s->saved_same_file;
+	quiet = s->saved_quiet;
+	fd_end(&s->fd);
+}
+
+static void search_begin(struct search_fixture *s, struct dbhandle *db)
+{
+	struct dbfile_config cfg = {0};
+
+	fd_begin(&s->fd);			/* sets the global blocksize */
+	s->saved_cpu_threads = options.cpu_threads;
+	s->saved_quiet = quiet;
+	s->saved_same_file = options.dedupe_same_file;
+	options.cpu_threads = 2;
+	options.dedupe_same_file = false;
+	/* Silences find_additional_dedupe()'s banner. The progress bar it also
+	 * starts cannot be: psearch_progress_thread() printf()s unguarded. */
+	quiet = 1;
+
+	/*
+	 * The stored config has to agree with the blocksize just set. Every
+	 * dbfile_open_handle() runs dbfile_check(), which treats the hashfile's
+	 * blocksize as authoritative and writes it back over the global - so a
+	 * worker opening its own handle would otherwise undo fd_begin()
+	 * mid-test, and the runs come back measured in the wrong unit.
+	 */
+	cfg.blocksize = blocksize;
+	memcpy(cfg.hash_type, HASH_TYPE, 8);
+	cfg.major = DB_FILE_MAJOR;
+	cfg.minor = DB_FILE_MINOR;
+	if (dbfile_sync_config(db, &cfg))
+		abort();
+
+	extents_search_init();
+}
+
+/* Between scenarios: the trees and the filerec registry go, and so do the rows,
+ * since every memdb() handle is the same shared in-memory database. */
+static void search_reset(struct search_fixture *s, struct dbhandle *db)
+{
+	free_results_tree(&s->fd.res);
+	free_hash_tree(&s->fd.tree);
+	free_all_filerecs();
+	exec(db, "delete from files");		/* hashes cascade */
+	init_hash_tree(&s->fd.tree);
+	init_results_tree(&s->fd.res);
+}
+
+/* A file with `n` blocks, plus one extent row whose digest nothing else shares
+ * - which is what makes the search consider the file at all. */
+static struct filerec *search_file(struct search_fixture *s,
+				   struct dbhandle *db, const char *name,
+				   uint64_t ino, unsigned int extent_dg,
+				   const unsigned int *blocks, unsigned int n)
+{
+	struct extent_csum ext[1];
+	int64_t id = put_dupe(db, name, ino, extent_dg, FD_BLOCK * n, 1, 0, 1);
+	struct filerec *file;
+
+	ext[0].loff = 0;
+	ext[0].poff = FD_BLOCK * ino;
+	ext[0].len = FD_BLOCK * n;
+	digest_of(ext[0].digest, extent_dg);
+	if (dbfile_store_extent_hashes(db, id, 1, ext))
+		abort();
+
+	file = fd_file(&s->fd, id, blocks, n, 0);
+	if (!file)
+		abort();
+	return file;
+}
+
+MU_TEST(test_the_extent_search_driven_by_its_pool) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	_cleanup_(search_end) struct search_fixture s = {0};
+	static const unsigned int blocks[] = { 11, 12, 13 };
+	struct dupe_extents *d;
+
+	search_begin(&s, db);
+
+	/*
+	 * A match the extent pass could not see: two extents that hash
+	 * differently, holding blocks that agree. If this ever finds nothing,
+	 * partial mode has quietly become a no-op - which would otherwise show
+	 * up only as "we seem to reclaim less than we used to".
+	 */
+	search_file(&s, db, "/tree/a", 1, 41, blocks, ARRAY_SIZE(blocks));
+	search_file(&s, db, "/tree/b", 2, 42, blocks, ARRAY_SIZE(blocks));
+
+	mu_check(find_additional_dedupe(&s.fd.res) == 0);
+	mu_assert(s.fd.res.num_dupes == 1, "a block-level match was not found");
+	d = only_group(&s.fd.res);
+	mu_check(d->de_num_dupes == 2);
+	mu_check(d->de_len == FD_BLOCK * ARRAY_SIZE(blocks));
+
+	/*
+	 * The search is idle by the time it returns, which is #123 rather than
+	 * tidiness: each worker holds a filerec from the global list, and the
+	 * caller goes straight back to reaping batches - which frees them.
+	 * Returning with work in flight lets a worker read a freed filerec.
+	 * That reproduced in about one memcheck run in twenty.
+	 */
+	mu_assert(extents_search_idle(), "the search returned with work still running");
+
+	/* A file of no bytes is skipped rather than handed to the pool, and the
+	 * two real files still find each other. */
+	search_reset(&s, db);
+	search_file(&s, db, "/tree/c", 3, 43, blocks, ARRAY_SIZE(blocks));
+	search_file(&s, db, "/tree/d", 4, 44, blocks, ARRAY_SIZE(blocks));
+	if (!filerec_new("/tree/empty", 99, 0))
+		abort();
+
+	mu_check(find_additional_dedupe(&s.fd.res) == 0);
+	mu_assert(s.fd.res.num_dupes == 1, "an empty file disturbed the search");
+	mu_check(extents_search_idle());
+
+	/*
+	 * Two halves of one file are not matched against each other unless
+	 * asked for. oans will deduplicate a file against itself on request and
+	 * must not by default - the win is usually nil and the surprise is not.
+	 */
+	search_reset(&s, db);
+	{
+		static const unsigned int twice[] = { 61, 62, 61, 62 };
+
+		search_file(&s, db, "/tree/self", 5, 45, twice, ARRAY_SIZE(twice));
+		mu_check(find_additional_dedupe(&s.fd.res) == 0);
+		mu_assert(s.fd.res.num_dupes == 0,
+			  "a file was matched against itself by default");
+
+		/* ...and does when it is asked. */
+		options.dedupe_same_file = true;
+		mu_check(find_additional_dedupe(&s.fd.res) == 0);
+		mu_assert(s.fd.res.num_dupes == 1,
+			  "dedupe_same_file did not enable a self match");
+	}
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -5476,6 +5653,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_each_side_of_a_match_records_its_own_offsets);
 	MU_RUN_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous);
 	MU_RUN_TEST(test_a_short_final_block_shortens_the_recorded_run);
+	MU_RUN_TEST(test_the_extent_search_driven_by_its_pool);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -5392,6 +5392,7 @@ struct search_fixture {
 static void search_end(struct search_fixture *s)
 {
 	extents_search_free();
+	search_delay_us = 0;
 	options.cpu_threads = s->saved_cpu_threads;
 	options.dedupe_same_file = s->saved_same_file;
 	quiet = s->saved_quiet;
@@ -5441,28 +5442,31 @@ static void search_reset(struct search_fixture *s, struct dbhandle *db)
 	init_results_tree(&s->fd.res);
 }
 
-/* A file with `n` blocks, plus one extent row whose digest nothing else shares
- * - which is what makes the search consider the file at all. */
-static struct filerec *search_file(struct search_fixture *s,
-				   struct dbhandle *db, const char *name,
-				   uint64_t ino, unsigned int extent_dg,
-				   const unsigned int *blocks, unsigned int n)
+/*
+ * A file with `n` blocks, plus one extent row whose digest nothing else shares
+ * - which is what makes the search consider the file at all.
+ *
+ * The row's name and the filerec's differ, deliberately and harmlessly: only
+ * the row is looked up by name, and fd_file() names the in-memory file after
+ * its id. poff is zero because nothing under test reads it - search_extent()
+ * takes only loff and len, and the rest reaches a dprintf.
+ */
+static void search_file(struct search_fixture *s, struct dbhandle *db,
+			const char *name, uint64_t ino, unsigned int extent_dg,
+			const unsigned int *blocks, unsigned int n)
 {
 	struct extent_csum ext[1];
 	int64_t id = put_dupe(db, name, ino, extent_dg, FD_BLOCK * n, 1, 0, 1);
-	struct filerec *file;
 
 	ext[0].loff = 0;
-	ext[0].poff = FD_BLOCK * ino;
+	ext[0].poff = 0;
 	ext[0].len = FD_BLOCK * n;
 	digest_of(ext[0].digest, extent_dg);
 	if (dbfile_store_extent_hashes(db, id, 1, ext))
 		abort();
 
-	file = fd_file(&s->fd, id, blocks, n, 0);
-	if (!file)
+	if (!fd_file(&s->fd, id, blocks, n, 0))
 		abort();
-	return file;
 }
 
 MU_TEST(test_the_extent_search_driven_by_its_pool) {
@@ -5482,7 +5486,24 @@ MU_TEST(test_the_extent_search_driven_by_its_pool) {
 	search_file(&s, db, "/tree/a", 1, 41, blocks, ARRAY_SIZE(blocks));
 	search_file(&s, db, "/tree/b", 2, 42, blocks, ARRAY_SIZE(blocks));
 
+	/*
+	 * Hold the workers back for this one call, so the idleness assertion
+	 * below is a claim rather than a race the fixture wins by default.
+	 * It has to exceed psearch_join()'s latency, not just the workers':
+	 * with the wait deleted, find_additional_dedupe() still blocks in
+	 * psearch_join() -> printer_stop() for the remainder of the progress
+	 * thread's 100ms sleep, which masks any shorter delay. Measured: at
+	 * 2ms the deletion survives, at 300ms it is caught.
+	 *
+	 * Set directly rather than via DUPEREMOVE_SEARCH_DELAY_MS because
+	 * tests.c #includes find_dupes.c and extents_search_init() reads the
+	 * environment. Scoped to this call alone - paying it on all four costs
+	 * a second of suite time, and suite runtime feeds the mutation tool's
+	 * hang timeout.
+	 */
+	search_delay_us = 300000;
 	mu_check(find_additional_dedupe(&s.fd.res) == 0);
+	search_delay_us = 0;
 	mu_assert(s.fd.res.num_dupes == 1, "a block-level match was not found");
 	d = only_group(&s.fd.res);
 	mu_check(d->de_num_dupes == 2);
@@ -5508,6 +5529,17 @@ MU_TEST(test_the_extent_search_driven_by_its_pool) {
 	mu_check(find_additional_dedupe(&s.fd.res) == 0);
 	mu_assert(s.fd.res.num_dupes == 1, "an empty file disturbed the search");
 	mu_check(extents_search_idle());
+	/*
+	 * The results tree cannot see the skip at all: a worker handed the
+	 * empty file would find no extent rows for it and return without
+	 * touching the tree, so `num_dupes == 1` holds either way. What the
+	 * branch uniquely does is count the file as processed itself, so that
+	 * is what is asserted - three files, all accounted for. Deleting the
+	 * count gives two; deleting the `continue` gives four, because the
+	 * worker counts it as well.
+	 */
+	mu_assert(search_processed == 3,
+		  "an empty file was not counted as processed exactly once");
 
 	/*
 	 * Two halves of one file are not matched against each other unless
@@ -5528,6 +5560,13 @@ MU_TEST(test_the_extent_search_driven_by_its_pool) {
 		mu_check(find_additional_dedupe(&s.fd.res) == 0);
 		mu_assert(s.fd.res.num_dupes == 1,
 			  "dedupe_same_file did not enable a self match");
+		/* And it is the right group: blocks 0-1 matched against 2-3.
+		 * Checking only that *a* group exists would survive a mutant
+		 * that recorded the wrong range - which is the bug this file
+		 * was written around. */
+		d = only_group(&s.fd.res);
+		mu_check(d->de_num_dupes == 2);
+		mu_check(d->de_len == FD_BLOCK * 2);
 	}
 }
 


### PR DESCRIPTION
Fifth in the series, closing the layer #241 deliberately left at 0%: `find_additional_dedupe()`, `search_file_extents()`, `search_extent()` and the pool helpers, which need the thread pool, the progress block and a hashfile together.

`src/find_dupes.c`: **142 → 115 survivors, 42% → 53%.**

| | #241 | this | live | killed |
|---|---|---|---|---|
| `search_extent` | 15 | **6** | 15 | 60% |
| `find_additional_dedupe` | 20 | **15** | 20 | 25% |
| `search_file_extents` | 18 | **13** | 18 | 27% |
| `extents_search_init` | 7 | 5 | 7 | 28% |
| `find_dupes_thread` | 6 | 4 | 6 | 33% |
| `extents_search_idle` / `_free` | 2 | **0** | 2 | 100% |

That layer goes 66 → 43.

## One test, several scenarios — and that is the finding

`search_file_extents()` caches its database handle in a `static __thread`, and GLib caches idle pool threads. So a **second** `extents_search_init()` hands work to the same OS threads, whose thread-local still points at the handle the first `free_pool()` released and whose `if (!db)` is therefore false. ASAN:

```
ERROR: AddressSanitizer: heap-use-after-free
  READ  dbfile_load_nondupe_file_extents  ← search_file_extents ← find_dupes_thread
  FREED free_pool ← extents_search_free ← (previous test's teardown)
```

**This is not a bug in oans.** `extents_search_init()`/`_free()` bracket the whole dedupe phase (`oans.c:1447`/`1489`) with `find_additional_dedupe()` running once per generation window inside, so the handle lives exactly as long as the pool that owns it. Only a caller that builds the pool twice can see it. Four separate `MU_TEST`s would have been testing a lifetime oans does not have; one test that initialises once and searches several times is the shape production actually has.

## Two other things this cost, both now encoded in the fixture

- **`mu_check()` returns on failure**, so teardown at the end of a test body is skipped. For a test holding the pool that leaves its per-thread handles open — and those handles are the only thing keeping the shared in-memory database alive, so its rows survive into every later test. **One failing assertion broke eight unrelated `dbfile` tests** before `search_end` became a `_cleanup_` attribute.
- **`dbfile_check()` treats the hashfile's stored blocksize as authoritative and writes it over the global.** A worker opening its own handle therefore undid `fd_begin()` mid-test, and runs came back measured in the wrong unit — 100 bytes instead of 12288. The fixture now syncs a config that agrees with the blocksize it set.

## What the `/simplify` pass changed

It confirmed one doubt I raised and refuted the other, which is why I checked both instead of "fixing" both:

- **Confirmed — the empty-file scenario was vacuous.** With the `continue` deleted the worker runs anyway, finds no extent rows and returns without touching the tree, so `num_dupes == 1` held either way. What the branch uniquely does is count the file as processed itself, so that is what is asserted now.
- **Refuted — the self-match pair is attributable.** I suspected the second call's group might be residue from the first, since they share a results tree. The first call asserts the tree is *empty*, so it cannot be. That phrasing stays.

Two I had not seen:

- **The idleness assertion was a race the fixture wins by default.** Two files and two threads finish a SELECT so fast that a deleted `threads_pool_wait_idle()` still looks idle. Measured: at a 2 ms worker delay the deletion **survives**; at 300 ms it is **caught**. The threshold is that high because `psearch_join()` blocks in `printer_stop()` for the remainder of the progress thread's 100 ms sleep — so the delay must exceed the *join's* latency, not the workers'.
- **The positive half of the self-match pair asserted only that *a* group existed**, so a mutant recording the wrong range — the bug #241 fixed — would have survived it. It now checks the members and the length.

## A cost I am stating rather than burying

That 300 ms delay is scoped to the one call that needs it. The suite goes **0.73 s → 1.02 s** wall (0.32 s of it CPU). Paying it on all four calls cost 1.73 s, past the 1.2 s where CLAUDE.md measured mutants being reclassified as `hang`.

So: roughly **+18% on every future sweep**, bought for a deterministic unit guard on a use-after-free (#123) that otherwise reproduces in about one memcheck run in twenty and is pinned only by an integration test needing btrfs. I think that is worth it, but it is a real cost on shared tooling and easy to revert if you disagree — delete the two `search_delay_us` lines.

## Bug file

`bugs/find_dupes.txt` gains the two blocks that are real (**6/6 caught**). Deleting the whole `size == 0` branch is *equivalent* — the pool's worker then counts the file instead — so it is recorded as prose rather than as a block that would always survive.

`make mutation-replay`: **9 files, nothing surviving.**

## Verification

`WERROR=1 make` clean · `make lint` clean · `make test` — 104 tests, 1,283,783 assertions · `make test CC=clang SANITIZE=address,undefined` clean with leak detection · valgrind **0 lost, 0 errors**.

Worth noting: valgrind now reports `suppressed: 2 from 2` where every earlier PR in this series reported `0` — the GLib cached-idle-thread residue those entries were written for, finally exercised by a test that actually starts a pool.

**Not run locally: the Python integration suite** — ext4, no reflink filesystem. Test-only change.

## Residue

43 left in that layer, and I expect it to be `perror`/`eprintf` + `goto` error paths and thread-pool failure handling a unit test cannot provoke — the same shape as `dbfile_describe_file`'s residue. I have not triaged it line by line, so that is an expectation rather than a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_