### PR TITLE
test: the interrupt flag and its test hooks (interrupt.c 0% → 73%)

### DIFF
--- a/scripts/mutate/bugs/interrupt.txt
+++ b/scripts/mutate/bugs/interrupt.txt
@@ -1,0 +1,80 @@
+# file: src/interrupt.c
+#
+# Invariants of the graceful shutdown (#201), each broken on purpose.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/interrupt.txt
+#
+# The whole feature fails silently. A flag that is never raised makes Ctrl-C
+# look ignored for minutes and then print "Nothing to deduplicate"; a second
+# signal that kills before the flush throws away exactly the work this exists
+# to keep. Nothing in the output distinguishes any of it from a slow run.
+
+# the handler does not restore the default action on delivery
+# SA_RESETHAND is what makes the *second* Ctrl-C kill at once. Without it a
+# user hammering it during a long flush gets no response at all, which is the
+# behaviour that made people reach for SIGKILL - and SIGKILL is the one signal
+# that still discards the open batch.
+<<<
+	sa.sa_flags = SA_RESTART | SA_RESETHAND;
+===
+	sa.sa_flags = SA_RESTART;
+>>>
+
+# a walker blocked in read() fails with EINTR instead of resuming
+# SA_RESTART is why no error path in the scan has to know signals exist. Drop
+# it and a directory walk interrupted mid-syscall returns an error the caller
+# reads as a broken filesystem rather than as a shutdown.
+<<<
+	sa.sa_flags = SA_RESTART | SA_RESETHAND;
+===
+	sa.sa_flags = SA_RESETHAND;
+>>>
+
+# only SIGTERM is handled, not SIGINT
+# Ctrl-C then kills outright with the batch still open, which is exactly the
+# pre-#201 behaviour this replaced.
+<<<
+	static const int signals[] = { SIGINT, SIGTERM };
+===
+	static const int signals[] = { SIGTERM };
+>>>
+
+# the file hook raises one tick early
+# The counter is files that have *finished hashing*, so the durability
+# assertion in the integration suite is exact: when the signal lands, N files
+# are already in the open batch. Off by one and the test asserts against a
+# batch holding something else.
+<<<
+	if (atomic_fetch_add(&tick_files, 1) + 1 == limit_files)
+===
+	if (atomic_fetch_add(&tick_files, 1) == limit_files)
+>>>
+
+# the hook keeps counting after the run is interrupted
+# On the file side the counter is shared by the csum workers, so a tick past
+# the raise is a second raise waiting to happen - against a disposition
+# SA_RESETHAND has already put back to the default, which kills the process
+# with the batch still open.
+<<<
+	if (!limit_files || interrupted())
+===
+	if (!limit_files && interrupted())
+>>>
+
+# the wind-down notice is repeated by every loop that notices
+# Several loops call it. The latch is what keeps the reassurance to one line
+# instead of one per worker, which would read as something going wrong.
+<<<
+	if (!interrupted() || atomic_exchange(&reported, true))
+===
+	if (!interrupted())
+>>>
+
+# TERM is not recognised, so the scheduled-stop case raises SIGINT
+# `systemctl stop oans@...` is the case #201 was written for; a hook that
+# cannot select TERM cannot test it.
+<<<
+	if (sig && (!strcmp(sig, "TERM") || !strcmp(sig, "SIGTERM")))
+===
+	if (sig && !strcmp(sig, "INT"))
+>>>

--- a/scripts/mutate/bugs/interrupt.txt
+++ b/scripts/mutate/bugs/interrupt.txt
@@ -39,26 +39,41 @@
 	static const int signals[] = { SIGTERM };
 >>>
 
-# the file hook raises one tick early
-# The counter is files that have *finished hashing*, so the durability
-# assertion in the integration suite is exact: when the signal lands, N files
-# are already in the open batch. Off by one and the test asserts against a
-# batch holding something else.
+# the file hook raises one tick late
+# atomic_fetch_add() returns the *old* value, so `+ 1 ==` fires on the Nth
+# tick and dropping it fires on the N+1th. The counter is files that have
+# finished hashing, so the durability assertion in the integration suite is
+# exact: when the signal lands, N files are already in the open batch. Off by
+# one and that test asserts against a batch holding something else.
 <<<
 	if (atomic_fetch_add(&tick_files, 1) + 1 == limit_files)
 ===
 	if (atomic_fetch_add(&tick_files, 1) == limit_files)
 >>>
 
-# the hook keeps counting after the run is interrupted
-# On the file side the counter is shared by the csum workers, so a tick past
-# the raise is a second raise waiting to happen - against a disposition
-# SA_RESETHAND has already put back to the default, which kills the process
-# with the batch still open.
+# the file hook keeps counting after the run is interrupted
+# Not a second raise: the comparison is `==` against a counter that only
+# grows, so once past the limit no later tick can fire. What it costs is an
+# atomic increment per file after shutdown has begun, on the counter the csum
+# workers share - work in the shutdown path, which is the one place the
+# feature exists to keep short.
 <<<
 	if (!limit_files || interrupted())
 ===
 	if (!limit_files && interrupted())
+>>>
+
+# the batch hook loses its guard entirely
+# This is the one where the second raise really happens. The batch hook
+# compares with `>=`, so with no limit set every call satisfies 1 >= 0: the
+# first raise is handled and SA_RESETHAND restores the default, and the second
+# terminates the process. That is also why the test's no-limit loop stops at
+# the first raise - otherwise this mutant would kill the suite instead of
+# being scored.
+<<<
+	if (!limit_batches || interrupted())
+		return;
+===
 >>>
 
 # the wind-down notice is repeated by every loop that notices

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -77,10 +77,12 @@ int interrupt_signo(void)
 	return atomic_load_explicit(&caught_signal, memory_order_relaxed);
 }
 
+/* File scope rather than function scope so a test can put it back; the
+ * storage duration and initialisation are the same either way. */
+static _Atomic bool reported;
+
 void interrupt_report(void)
 {
-	static _Atomic bool reported;
-
 	if (!interrupted() || atomic_exchange(&reported, true))
 		return;
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -5604,6 +5604,7 @@ static struct sigaction intr_disposition(int signo)
 static void intr_reset(void)
 {
 	atomic_store(&caught_signal, 0);
+	atomic_store(&reported, false);
 	atomic_store(&tick_files, 0);
 	tick_batches = 0;
 	limit_files = 0;
@@ -5612,6 +5613,13 @@ static void intr_reset(void)
 	unsetenv("DUPEREMOVE_INTERRUPT_AFTER");
 	unsetenv("DUPEREMOVE_INTERRUPT_AFTER_BATCHES");
 	unsetenv("DUPEREMOVE_INTERRUPT_SIGNAL");
+	/*
+	 * And the dispositions, which nothing else here would restore: leaving
+	 * the handler installed means a SIGTERM aimed at a hung ./test is
+	 * swallowed once and appears to do nothing.
+	 */
+	signal(SIGINT, SIG_DFL);
+	signal(SIGTERM, SIG_DFL);
 }
 
 MU_TEST(test_the_interrupt_flag_and_its_test_hooks) {
@@ -5664,11 +5672,11 @@ MU_TEST(test_the_interrupt_flag_and_its_test_hooks) {
 
 	/*
 	 * Once the flag is up the hook stops counting entirely, which is the
-	 * other half of `!limit_files || interrupted()`. Without that guard a
-	 * tick after interruption would keep incrementing - and on the file
-	 * side, where the counter is atomic because the csum workers share it,
-	 * that is a second raise waiting to happen against a disposition
-	 * SA_RESETHAND has already put back to the default.
+	 * other half of `!limit_files || interrupted()`. On the file side that
+	 * cannot raise a second time - the comparison is `==` against a counter
+	 * that only grows - so what the guard saves is an atomic increment per
+	 * file after shutdown has begun. It is the *batch* hook, comparing with
+	 * `>=`, where losing this guard raises again and kills.
 	 */
 	{
 		unsigned long at_raise = atomic_load(&tick_files);
@@ -5717,7 +5725,16 @@ MU_TEST(test_the_interrupt_flag_and_its_test_hooks) {
 	 * the first file of every ordinary run. */
 	intr_reset();
 	interrupt_install();
-	for (int i = 0; i < 8; i++) {
+	/*
+	 * Bounded by !interrupted(), which is not caution about the test but
+	 * about the suite: the batch hook compares with >=, so deleting its
+	 * `!limit_batches || interrupted()` guard makes 1 >= 0 true on every
+	 * call. The first raise is handled and SA_RESETHAND puts the default
+	 * back; a second would terminate the process, and every test after
+	 * this one would simply never run. Stopping at the first raise turns
+	 * that mutant into a clean failure below.
+	 */
+	for (int i = 0; i < 8 && !interrupted(); i++) {
 		interrupt_test_file_tick();
 		interrupt_test_batch_tick();
 	}
@@ -5741,6 +5758,7 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
 	int saved = dup(STDERR_FILENO);
 	char buf[4096] = {0};
 	unsigned int seen = 0;
+	off_t quiet_before;
 	ssize_t n;
 
 	if (fd < 0 || saved < 0)
@@ -5749,8 +5767,12 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
 	intr_reset();
 	dup2(fd, STDERR_FILENO);
 
-	/* Nothing has happened yet, so there is nothing to announce. */
+	/* Nothing has happened yet, so there is nothing to announce. The
+	 * offset is read here and judged after stderr is back, so no assertion
+	 * fires while the capture is up. */
 	interrupt_report();
+	fflush(stderr);
+	quiet_before = lseek(fd, 0, SEEK_END);
 
 	/* Now there is - and saying it twice would be the bug. */
 	atomic_store(&caught_signal, SIGINT);
@@ -5760,6 +5782,9 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
 
 	dup2(saved, STDERR_FILENO);
 	close(saved);
+
+	mu_assert(quiet_before == 0,
+		  "the notice was printed before any signal arrived");
 
 	n = pread(fd, buf, sizeof(buf) - 1, 0);
 	close(fd);

--- a/src/tests.c
+++ b/src/tests.c
@@ -5570,6 +5570,213 @@ MU_TEST(test_the_extent_search_driven_by_its_pool) {
 	}
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * The interrupt flag (#201)
+ *
+ * SIGINT and SIGTERM set a flag; every loop that owns state notices it and
+ * unwinds through its ordinary exit, so the batched writer commits on the way
+ * out. What fails silently here is the whole of it: a flag that is never set
+ * makes a Ctrl-C look ignored for minutes, and a second one that kills before
+ * the flush throws away exactly the work the feature exists to keep.
+ *
+ * One test with ordered scenarios, because the state is global *and* one-shot:
+ * SA_RESETHAND puts the default action back on delivery, so a raise with no
+ * handler installed would kill the suite rather than fail it. Every scenario
+ * below re-installs before it raises, and puts the flag back afterwards.
+ * tests.c #includes interrupt.c, so the statics are reachable to do that -
+ * without it none of this would be testable at all.
+ * ---------------------------------------------------------------------------
+ */
+
+/* What the kernel currently has installed for a signal. */
+static struct sigaction intr_disposition(int signo)
+{
+	struct sigaction sa;
+
+	memset(&sa, 0, sizeof(sa));
+	if (sigaction(signo, NULL, &sa))
+		abort();
+	return sa;
+}
+
+/* Back to a clean slate between scenarios. */
+static void intr_reset(void)
+{
+	atomic_store(&caught_signal, 0);
+	atomic_store(&tick_files, 0);
+	tick_batches = 0;
+	limit_files = 0;
+	limit_batches = 0;
+	test_signal = SIGINT;
+	unsetenv("DUPEREMOVE_INTERRUPT_AFTER");
+	unsetenv("DUPEREMOVE_INTERRUPT_AFTER_BATCHES");
+	unsetenv("DUPEREMOVE_INTERRUPT_SIGNAL");
+}
+
+MU_TEST(test_the_interrupt_flag_and_its_test_hooks) {
+	struct sigaction sa;
+
+	intr_reset();
+	mu_check(!interrupted());
+	mu_assert(interrupt_signo() == 0, "a signal was recorded before any arrived");
+
+	/*
+	 * Both flags matter and neither is decoration. SA_RESTART keeps a
+	 * walker blocked in read() from failing with EINTR, so no error path
+	 * has to learn about signals; SA_RESETHAND is what makes the second
+	 * Ctrl-C kill at once, which is what a user hammering it expects.
+	 * Both signals get the same treatment - `systemctl stop` sends TERM.
+	 */
+	interrupt_install();
+	for (int signo = 0; signo < 2; signo++) {
+		int s = signo ? SIGTERM : SIGINT;
+
+		sa = intr_disposition(s);
+		mu_check(sa.sa_handler == interrupt_handler);
+		mu_check((sa.sa_flags & SA_RESTART) != 0);
+		mu_check((sa.sa_flags & SA_RESETHAND) != 0);
+	}
+
+	/*
+	 * The file hook raises at exactly the Nth tick. Counting files that
+	 * have *finished hashing* rather than queued ones is what makes the
+	 * durability assertion in the integration suite exact, so the count
+	 * being off by one is not cosmetic.
+	 */
+	intr_reset();
+	setenv("DUPEREMOVE_INTERRUPT_AFTER", "3", 1);
+	interrupt_install();			/* re-reads the hooks */
+	mu_assert(limit_files == 3, "the file limit was not read from the environment");
+
+	interrupt_test_file_tick();
+	interrupt_test_file_tick();
+	mu_assert(!interrupted(), "the hook raised before its limit");
+	interrupt_test_file_tick();
+	mu_assert(interrupted(), "the hook did not raise at its limit");
+	mu_check(interrupt_signo() == SIGINT);
+
+	/* SA_RESETHAND really did put the default back, which is why the
+	 * second signal kills rather than running the handler again. */
+	sa = intr_disposition(SIGINT);
+	mu_assert(sa.sa_handler == SIG_DFL,
+		  "the handler was not reset on delivery");
+
+	/*
+	 * Once the flag is up the hook stops counting entirely, which is the
+	 * other half of `!limit_files || interrupted()`. Without that guard a
+	 * tick after interruption would keep incrementing - and on the file
+	 * side, where the counter is atomic because the csum workers share it,
+	 * that is a second raise waiting to happen against a disposition
+	 * SA_RESETHAND has already put back to the default.
+	 */
+	{
+		unsigned long at_raise = atomic_load(&tick_files);
+
+		mu_check(interrupted());	/* still set, deliberately */
+		interrupt_test_file_tick();
+		interrupt_test_file_tick();
+		mu_assert(atomic_load(&tick_files) == at_raise,
+			  "the hook kept counting after the run was interrupted");
+	}
+
+	/*
+	 * And now the reason the comparison is `==` rather than `>=`: with the
+	 * counter already past the limit, further ticks must not raise. Under
+	 * `>=` every later tick would, and with the disposition back to the
+	 * default the second one kills the process - the very thing this hook
+	 * exists to test against. The `interrupted()` early return is not what
+	 * saves it here, because the flag is cleared first.
+	 */
+	atomic_store(&caught_signal, 0);
+	interrupt_install();			/* re-arm, so a raise would not kill */
+	for (int i = 0; i < 4; i++)
+		interrupt_test_file_tick();
+	mu_assert(!interrupted(), "a tick past the limit raised again");
+
+	/*
+	 * The batch hook counts generation batches instead, and TERM selects
+	 * the other signal - `systemctl stop oans@...` is the scheduled case
+	 * this whole feature was written for.
+	 */
+	intr_reset();
+	setenv("DUPEREMOVE_INTERRUPT_AFTER_BATCHES", "2", 1);
+	setenv("DUPEREMOVE_INTERRUPT_SIGNAL", "TERM", 1);
+	interrupt_install();
+	mu_assert(limit_batches == 2, "the batch limit was not read");
+	mu_assert(test_signal == SIGTERM, "TERM did not select SIGTERM");
+
+	interrupt_test_batch_tick();
+	mu_assert(!interrupted(), "the batch hook raised before its limit");
+	interrupt_test_batch_tick();
+	mu_assert(interrupted(), "the batch hook did not raise at its limit");
+	mu_assert(interrupt_signo() == SIGTERM,
+		  "the run was stopped by the wrong signal");
+
+	/* Unset means off: a hook that ticked without a limit would raise on
+	 * the first file of every ordinary run. */
+	intr_reset();
+	interrupt_install();
+	for (int i = 0; i < 8; i++) {
+		interrupt_test_file_tick();
+		interrupt_test_batch_tick();
+	}
+	mu_assert(!interrupted(), "a hook fired with no limit set");
+
+	intr_reset();
+}
+
+/*
+ * The wind-down notice is said once, and only once there is something to say.
+ *
+ * Every loop that notices the flag may call this, and several do - the point
+ * of it is that the pause between the signal and the exit does not look like a
+ * hang, and a line repeated once per worker would look like something worse.
+ * The `reported` latch is function-local, so what is observable is the output
+ * itself; eprintf() reaches stderr, which is capturable.
+ */
+MU_TEST(test_the_wind_down_notice_is_said_once) {
+	char path[] = "/tmp/oans-intr-XXXXXX";
+	int fd = mkstemp(path);
+	int saved = dup(STDERR_FILENO);
+	char buf[4096] = {0};
+	unsigned int seen = 0;
+	ssize_t n;
+
+	if (fd < 0 || saved < 0)
+		abort();
+
+	intr_reset();
+	dup2(fd, STDERR_FILENO);
+
+	/* Nothing has happened yet, so there is nothing to announce. */
+	interrupt_report();
+
+	/* Now there is - and saying it twice would be the bug. */
+	atomic_store(&caught_signal, SIGINT);
+	interrupt_report();
+	interrupt_report();
+	fflush(stderr);
+
+	dup2(saved, STDERR_FILENO);
+	close(saved);
+
+	n = pread(fd, buf, sizeof(buf) - 1, 0);
+	close(fd);
+	unlink(path);
+	if (n < 0)
+		abort();
+	buf[n] = '\0';
+
+	for (const char *p = buf; (p = strstr(p, "Interrupted by")); p++)
+		seen++;
+	mu_assert(seen == 1, "the wind-down notice was not said exactly once");
+	/* And it names the signal, since SIGTERM is the scheduled-stop case. */
+	mu_check(strstr(buf, "SIGINT") != NULL);
+
+	intr_reset();
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -5693,6 +5900,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_a_run_stops_where_the_blocks_stop_being_contiguous);
 	MU_RUN_TEST(test_a_short_final_block_shortens_the_recorded_run);
 	MU_RUN_TEST(test_the_extent_search_driven_by_its_pool);
+	MU_RUN_TEST(test_the_interrupt_flag_and_its_test_hooks);
+	MU_RUN_TEST(test_the_wind_down_notice_is_said_once);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run


### PR DESCRIPTION
Sixth in the series. `src/interrupt.c` — the SIGINT/SIGTERM graceful shutdown from #201 — goes from **46 of 46 mutants surviving to 12**, five of its eight functions fully killed.

## Re-measuring first changed the plan

`threads.c` was 75/75 at 0% when #241's recon measured it. #243's search-pool test has since covered two thirds of it **with no test written for it at all** — it now stands at 25/75, 66% killed. Had I trusted the stale figure, most of this iteration would have aimed at code already covered. `interrupt.c` was unchanged at 46/46, so that is the subject and `threads.c`'s remaining 25 are noted for later.

## One test, ordered scenarios — because a mistake here kills rather than fails

`SA_RESETHAND` restores the default disposition on delivery, so a `raise()` with no handler installed **terminates the test binary**. Every scenario re-installs before it raises and resets the flag afterwards. `tests.c` `#include`s `interrupt.c`, so the file statics are reachable to do that — without it none of this is testable.

Covered: both signals getting `SA_RESTART` and `SA_RESETHAND`, read back **from the kernel** rather than from the struct that was passed in; the handler recording which signal arrived; the default genuinely being restored on delivery, which is what makes the second Ctrl-C kill; the file hook raising at exactly the Nth tick and the batch hook at the Nth batch; `TERM` selecting SIGTERM, the `systemctl stop` case the feature exists for; and unset limits meaning the hooks do nothing, since one that fired without a limit would stop every ordinary run on its first file.

Two needed a fixture that isn't obvious. The `==` rather than `>=` in the file tick is only observable with the flag cleared and the counter already past the limit. And the `interrupted()` half of the early return is only observable by ticking **without** clearing the flag and asserting the counter didn't move.

## The review found a test that could kill the suite

`interrupt_test_batch_tick()` compares with `>=`, not `==` like the file hook. Delete its `!limit_batches || interrupted()` guard — a whole-statement deletion, the shape most of these bug blocks take — and with no limit set every call satisfies `1 >= 0`. The first raise is handled and `SA_RESETHAND` puts the default back; **the second terminates the process**, and every test after it never runs. The failure would have presented as a Ctrl-C rather than an assertion.

Bounding the loop with `!interrupted()` turns that mutant into a clean failure. It is now a block in the bug file, **scored rather than fatal** — which is the proof the fix works.

## Two consequences I had stated backwards

- **`atomic_fetch_add()` returns the *old* value**, so `+ 1 ==` fires on the Nth tick and dropping it fires on the N+1th. My block was titled "one tick early". It is one tick **late**.
- I wrote that losing the file hook's `interrupted()` guard leaves "a second raise waiting to happen". **It does not** — that comparison is `==` against a counter that only grows, so no later tick can fire. Its real cost is an atomic increment per file after shutdown has begun. The claim is true of the *batch* hook, which had no block at all. Now it has one.

## Other review findings

- **The "nothing to announce yet" step had no assertion.** Dropping `!interrupted() ||` from `interrupt_report()` left `seen == 1` holding; what caught it was the SIGINT string check, which exists for a different reason and would stop catching it the moment the ternary's default arm changed. The offset is now recorded inside the capture window and judged after stderr is restored, so no assertion fires while stderr is redirected.
- **`reported` was function-local and therefore unresettable**, making the second test silently order-dependent: `file_scan.c` is in the same translation unit and calls `interrupt_report()`, so the first unit test to drive that loop with the flag up would latch it and this test would then fail for an unrelated reason. Hoisted to file scope — same storage duration, same initialisation, only the name's scope changes. **That is the only production change in this PR.**
- **`intr_reset()` now restores `SIG_DFL`.** Leaving the handler installed for the rest of the binary meant a SIGTERM aimed at a hung `./test` was swallowed once and appeared to do nothing.

## `interrupt_report` was another block I never called

It came back 4/4 after the first pass. I'd assumed its idempotency wasn't observable because the latch is function-local — but its *output* is, via stderr capture. 4 → 0. That is the **fifth iteration running** where reading residue by function found a block the tests had never reached.

## The residue is 12, triaged rather than reported

`memset` and `sigemptyset` are each redundant given the other; `SA_RESTART | SA_RESETHAND` are disjoint bits so `^` computes the same value (the standing example from unordered_dense's notes); `sizeof(signals[0])` equals `sizeof(signals[1])`; the `strtoul` base can't be distinguished by the digits these limits use; and `>=` can't differ from `==` on the batch tick because the `interrupted()` guard catches the second crossing.

## Verification

`WERROR=1 make` clean · `make lint` clean · `make test` — 106 tests, 1,283,808 assertions · `make test CC=clang SANITIZE=address,undefined` clean · valgrind **0 lost, 0 errors** · `bugs/interrupt.txt` **8/8** · `make mutation-replay` 10 files, nothing surviving.

**Not run locally: the Python integration suite** — ext4, no reflink filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_