### PR TITLE
tests: stop dropping TSAN_OPTIONS in the interrupted-scan pty test (fixes #236)

### DIFF
--- a/tests/integration/test_progress_tty.py
+++ b/tests/integration/test_progress_tty.py
@@ -204,9 +204,15 @@ class ProgressTtyTest(DuperemoveTest):
             self.mkdup(f"tree/a{i}.bin", f"tree/b{i}.bin", 256 * 1024)
         tree = os.path.join(self.work, "tree")
 
+        # dict(os.environ, ...) rather than a bare dict: _run_in_pty() passes
+        # this straight to execvpe(), which *replaces* the environment rather
+        # than adding to it. A bare dict therefore drops TSAN_OPTIONS, so this
+        # one process ran with no suppressions file while the other 248 had
+        # one - and reported the GLib queue-node race the file exists to
+        # filter, as a stranded worker row. See #236.
         screen = _render(_run_in_pty(
             [DUPEREMOVE, "-dr", "--hashfile", self.hf, tree],
-            env={"DUPEREMOVE_INTERRUPT_AFTER": "4"}))
+            env=dict(os.environ, DUPEREMOVE_INTERRUPT_AFTER="4")))
         shown = "\n  ".join(screen)
 
         stranded = [ln for ln in screen if WORKER_ROW.match(ln)]


### PR DESCRIPTION
**Master is red on this**, and has been on roughly half of all runs — three of the last six merge runs (`2067e8fa`, `17825bc4`, `631d8aa9`).

Always the same failure, in `test_an_interrupted_scan_leaves_nothing_behind_either`: a ThreadSanitizer report about a GLib queue node interleaved into the live progress block, leaving the worker rows stranded.

## One line, and it is here rather than in oans

`_run_in_pty()` passes its `env` straight to `execvpe()`, which **replaces** the environment rather than adding to it. This call site passed a bare dict:

```python
env={"DUPEREMOVE_INTERRUPT_AFTER": "4"}
```

So that one `oans` process ran with nothing but that variable — **no `TSAN_OPTIONS`, therefore no suppressions file** — while the other 248 processes in the same run had both. `tests/tsan.supp` already carries `race:g_queue_pop_tail` for exactly this GLib handoff. It was never reaching the process that needed it.

Measured, reproducing `execvpe` with each spelling:

```
bare dict (as before)   -> TSAN_OPTIONS=[]                            HOOK=[4]
dict(os.environ, ...)   -> TSAN_OPTIONS=[suppressions=.../tsan.supp]  HOOK=[4]
```

That accounts for every part of the symptom:

- **why only this one test ever reported the race** — it is the only bare-dict `env=` in the file; line 303 already spells it `dict(os.environ, **env)`
- **why the suppression file looked loaded** — it was, for every other process; the job log shows `TSAN_OPTIONS` on the `make integration` command line and the harness printing `sanitize: thread (suppressions active)`
- **why it was intermittent rather than constant** — the race is timing-dependent, so an unsuppressed run reports it only when it actually happens

## This retires the hypothesis in #236

I filed #236 arguing the suppression was tuned where `g_free*` was the top frame and failed to match on the CI runner's GLib, since the top frame there is plain `free` and `g_queue_pop_tail` is frame #1. **That was wrong.** The entries match fine when they are loaded; they were simply absent from this one process. I have left the wrong reasoning visible in the issue rather than quietly editing it, since the wrong diagnosis is the more useful half of the record.

## What I could and could not verify

**Verified locally:** the mechanism, by reproducing `pty.fork()` + `execvpe()` with both spellings (above). That is the whole causal chain except the race itself.

**Not verified locally:** the test passing, because this container is ext4 with no reflink filesystem, so the integration suite cannot run here at all.

**Worth stating about the proof:** the failure is ~50%, so a single green `sanitizers (thread)` run is not evidence. What makes this the right fix is the mechanism, not the next run's colour. If it goes red again with the same signature, the diagnosis is wrong and I would want to know rather than re-run it.

Fixes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_