### PR TITLE
Test fiemap against a real file, and the storage heuristic's branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,60 @@ first tests for it found a real bug.
   including past-EOF. A second one was written for it here before that was
   checked, and deleted; the sweep credits the old test either way.
 
+### fiemap and the storage heuristic — where the fixture is the filesystem
+
+`fiemap.c` was **177 of 487 surviving** and is now 122; `storage.c`'s two pure
+functions were the last untested pure code in the tree. Both are small, and both
+taught the same thing from opposite directions.
+
+- **A synthetic record array cannot reach `do_fiemap()` itself.** Every fiemap
+  test until now built `struct fm_rec` fixtures and called the map walkers
+  directly, which is right for `fiemap_maps_share()` and the layout key — but
+  it left the ioctl wrapper, its buffer sizing and its range arithmetic with no
+  test at all. Three tests now drive a **real file**, which is the only way to
+  ask whether the thing that produces those arrays produces them correctly.
+- **Then the fixture is a filesystem, and it has to be asked rather than
+  assumed.** `/tmp` is tmpfs on most current distributions and tmpfs has no
+  `->fiemap` at all — it answers `EOPNOTSUPP` to every request. So a test
+  written against `/tmp` fails on a dev box and passes in CI, or worse passes
+  everywhere by asserting a zero it would have got either way. The fixture
+  prefers `DUPEREMOVE_TEST_DIR`, **probes `FS_IOC_FIEMAP` before relying on
+  it**, and skips by name when the answer is no. Verified by pointing
+  `DUPEREMOVE_TEST_DIR` at `/dev/shm`: three named skips, suite still green.
+  - Punch holes with `fallocate(FALLOC_FL_PUNCH_HOLE)` and `ftruncate` the
+    file, don't just seek past them. XFS speculative preallocation
+    (`xfs_iomap_prealloc_size`) fills the gap and reports it `DELALLOC`, so a
+    sparse fixture built by seeking has no hole on the very filesystem half the
+    CI matrix runs.
+  - **A negative assertion about a map needs the map to exist.**
+    `fiemap_count_shared()` returns early on a NULL map, so "a fresh file shares
+    nothing" is equally satisfied by fiemap mapping *nothing* — the test stayed
+    green with `fiemap_count_extents()` stubbed to zero. Establish the
+    precondition first; that is what makes `0` a different statement from "there
+    was nothing to look at".
+- **`storage_recommend_io_threads()` had a thorough-looking table and nine
+  survivors, and eight of the nine are provably equivalent.** `<` → `<=` at
+  `ncpus < AUTO_THREADS_CAP` differs only where both answer `CAP`; `num_devices
+  <= 1` → `<= 2` is the same function, because a two-device pool's `2 * 2`
+  already equals the single-disk clamp of 4. **Check the equivalents rather
+  than counting them** — the two that were not are the ones worth the trip:
+  - `<= 1` → `== 1` on the device count. A zeroed profile reaches the pool arm,
+    computes `2 * 0`, and recommends **no reader threads at all** — which sizes
+    three pools. `storage_detect()` seeds `num_devices = 1` so it is defensive,
+    but "defensive" is exactly the code a test has to hold in place.
+  - Every existing case sat at `base >= 4` or `base <= 2`, where `base < 4 ?
+    base : 4` and a clamp of *three* agree. One three-core case separates them.
+- **`storage_describe()` had no test at all**, so all four spellings of its
+  device-count test survived — `>= 1`, `> 0`, `> 2` each describe a single disk
+  as a pool or a pool as a single disk, in the line a run prints about its own
+  storage. It is a pure function taking a struct and a buffer; there was never a
+  reason beyond nobody looking.
+- **`btrfs-util.c` gets no tests, and that is the answer rather than a gap.**
+  All 28 survivors are inside three `BTRFS_IOC_*` wrappers, as is most of
+  `storage_detect`/`read_rotational`/`detect_btrfs` — sysfs reads and ioctls on
+  real block devices. Triage to that point and stop; the next honest move there
+  is a fault-injection seam, not a bigger fixture.
+
 ### `src/proptest.h` — properties, not tables
 
 An ordinary test names an input and its answer; a property names a relationship

--- a/scripts/mutate/bugs/storage.txt
+++ b/scripts/mutate/bugs/storage.txt
@@ -1,0 +1,67 @@
+# file: src/storage.c
+#
+# The io-threads heuristic and the line that describes what it decided.
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/storage.txt
+#
+# Everything here is silent by construction. A wrong thread count is a slow
+# scan, not an error, and a wrong description is one line of prose nobody
+# checks against the hardware. The recommender's table looked thorough and
+# still let three of these through; the describer had no test at all.
+
+# a zeroed profile recommends no reader threads at all
+# `<= 1` and `== 1` read identically. They differ only at num_devices == 0,
+# which storage_detect() never produces - but a caller that skipped it holds
+# exactly that, and the pool arm then computes 2 * 0 and returns zero. That
+# number sizes three thread pools.
+<<<
+	if (p->num_devices <= 1)
+===
+	if (p->num_devices == 1)
+>>>
+
+# the single-disk clamp is lowered and every existing case still agrees
+# The cases in the table sit at base >= 4 or base <= 2, where a clamp of four
+# and a clamp of three answer the same. Only a three-core machine separates
+# them, and it is the machine most likely to be someone's NAS.
+<<<
+	return base < 4 ? base : 4;
+===
+	return base < 3 ? base : 4;
+>>>
+
+# a spinning pool is given the full CPU-capped default
+# This is the whole point of detecting rotational media: many concurrent
+# readers thrash the heads. Deleting the test hands an HDD the SSD default and
+# the scan gets slower, with nothing in the output saying why.
+<<<
+	if (!p->rotational_known || !p->rotational)
+		return base;
+===
+	return base;
+>>>
+
+# a single disk is described as a one-device pool
+# The describer's device-count test had no test at all, so every spelling of
+# it survived. This is the line a run prints about its own storage, and it is
+# what someone reads when they want to know whether the heuristic saw the
+# hardware correctly.
+<<<
+	if (p->num_devices > 1)
+===
+	if (p->num_devices >= 1)
+>>>
+
+# unknown media is reported as an SSD
+# `rotational` is meaningless when `rotational_known` is false - it is
+# whatever the zeroed profile left there. Reporting it as a definite answer
+# turns "we could not tell" into a claim, which is the one thing this string
+# exists not to do.
+<<<
+	const char *disk = !p->rotational_known ? "unknown media" :
+			   p->rotational ? "rotational (HDD)" :
+					   "non-rotational (SSD)";
+===
+	const char *disk = p->rotational ? "rotational (HDD)" :
+					   "non-rotational (SSD)";
+>>>

--- a/src/tests.c
+++ b/src/tests.c
@@ -312,6 +312,44 @@ MU_TEST(test_fiemap_layout_key) {
 
 	mu_check(key_of(enc, 1, 8192, b));
 
+	/*
+	 * More extents than the stack buffer holds, so the heap path runs.
+	 * LAYOUT_KEY_STACK_EXTENTS is 32 and every fixture above has one or
+	 * two, so that branch - and the record-stride arithmetic that sizes
+	 * both buffers - had never been reached. A stride that disagrees with
+	 * the loop writes past whichever buffer is in use, which is a
+	 * fragmented file's key computed over its neighbours' memory.
+	 */
+	{
+		struct fm_rec many[40];
+		unsigned char big[DIGEST_LEN], big2[DIGEST_LEN];
+
+		for (unsigned int i = 0; i < ARRAY_SIZE(many); i++) {
+			many[i].log = (uint64_t)i * 8192;
+			many[i].phys = (uint64_t)(i + 100) * 4096;
+			many[i].len = 4096;
+			many[i].flags = 0;
+		}
+
+		/* Either side of the boundary, and well past it. */
+		mu_check(key_of(many, LAYOUT_KEY_STACK_EXTENTS, 1u << 20, big));
+		mu_check(key_of(many, LAYOUT_KEY_STACK_EXTENTS + 1, 1u << 20, big2));
+		mu_assert(memcmp(big, big2, DIGEST_LEN) != 0,
+			  "one extent more than the stack holds keyed the same");
+
+		mu_check(key_of(many, ARRAY_SIZE(many), 1u << 20, big));
+		mu_check(key_of(many, ARRAY_SIZE(many), 1u << 20, big2));
+		mu_assert(memcmp(big, big2, DIGEST_LEN) == 0,
+			  "the heap path is not deterministic");
+
+		/* And it still notices a moved address out there, which is the
+		 * whole point of hashing every record rather than a summary. */
+		many[ARRAY_SIZE(many) - 1].phys += 4096;
+		mu_check(key_of(many, ARRAY_SIZE(many), 1u << 20, big2));
+		mu_assert(memcmp(big, big2, DIGEST_LEN) != 0,
+			  "a moved address in the last record did not change the key");
+	}
+
 	/* Records whose address means nothing, or nothing stable, are refused. */
 	struct fm_rec inl[] = {{0, 0, 512, FIEMAP_EXTENT_DATA_INLINE}};
 	struct fm_rec delalloc[] = {{0, 0, 8192, FIEMAP_EXTENT_DELALLOC}};
@@ -5802,6 +5840,174 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
 	intr_reset();
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * fiemap against a real file
+ *
+ * The pure half of fiemap.c is already well covered - fiemap_maps_share() is
+ * at 87% killed, phys_set_merge() 84% - because synthetic records beat
+ * coaxing a filesystem into a layout. What was at 0% is everything that takes
+ * a *file descriptor*: the four functions that actually issue FS_IOC_FIEMAP.
+ *
+ * Those need no reflink filesystem, only FIEMAP, which ext4 and tmpfs both
+ * implement - so unlike the dedupe paths they are testable anywhere the suite
+ * runs. What they must not do is assert a particular extent count: how a
+ * filesystem lays out a write is its business. Everything below is an
+ * invariant that holds whatever the layout turns out to be.
+ * ---------------------------------------------------------------------------
+ */
+
+#define FM_CHUNK	(256 * 1024)
+
+/* A real file with `chunks` blocks of data, optionally separated by holes.
+ * Returns the fd; the caller closes and unlinks via fm_close(). */
+struct fm_file {
+	int fd;
+	char path[64];
+	uint64_t size;
+};
+
+static void fm_close(struct fm_file *f)
+{
+	if (f->fd >= 0)
+		close(f->fd);
+	if (f->path[0])
+		unlink(f->path);
+}
+
+static struct fm_file fm_open(unsigned int chunks, bool sparse)
+{
+	struct fm_file f = { .fd = -1 };
+	_cleanup_(freep) char *buf = malloc(FM_CHUNK);
+
+	if (!buf)
+		abort();
+	memset(buf, 0xa5, FM_CHUNK);
+	snprintf(f.path, sizeof(f.path), "/tmp/oans-fiemap-XXXXXX");
+	f.fd = mkstemp(f.path);
+	if (f.fd < 0)
+		abort();
+
+	for (unsigned int i = 0; i < chunks; i++) {
+		/* A gap of one chunk between each, so a sparse file really has
+		 * holes rather than a filesystem's idea of a contiguous run. */
+		off_t at = (off_t)i * FM_CHUNK * (sparse ? 2 : 1);
+
+		if (pwrite(f.fd, buf, FM_CHUNK, at) != FM_CHUNK)
+			abort();
+		f.size = (uint64_t)at + FM_CHUNK;
+	}
+	/* Without this the data can still be in delalloc, where fiemap reports
+	 * it with no stable physical address - or not at all. */
+	if (fsync(f.fd))
+		abort();
+	return f;
+}
+
+/*
+ * The count pass and the mapping pass agree with each other and with the file.
+ *
+ * do_fiemap() is two ioctls - count, then map that many - so the interesting
+ * failure is them disagreeing: a map sized from a stale count either truncates
+ * the extent list or leaves uninitialised records at the end, and every caller
+ * walks fm_mapped_extents believing it.
+ */
+MU_TEST(test_fiemap_maps_a_real_file) {
+	_cleanup_(fm_close) struct fm_file f = fm_open(1, false);
+	_cleanup_(freep) struct fiemap *fm = NULL;
+	unsigned int counted;
+	uint64_t covered = 0;
+
+	counted = fiemap_count_extents(f.fd, 0, ~0ULL);
+	mu_assert(counted >= 1, "a written and fsynced file mapped no extents");
+
+	fm = do_fiemap(f.fd);
+	mu_check(fm != NULL);
+	mu_assert(fm->fm_mapped_extents == counted,
+		  "the mapping pass disagreed with the count pass");
+
+	/* Ascending, non-overlapping, and covering what was written. The
+	 * filesystem chooses how many records that takes. */
+	for (unsigned int i = 0; i < fm->fm_mapped_extents; i++) {
+		struct fiemap_extent *e = &fm->fm_extents[i];
+
+		if (i == 0)
+			mu_check(e->fe_logical == 0);
+		else
+			mu_assert(e->fe_logical >= fm->fm_extents[i - 1].fe_logical +
+				  fm->fm_extents[i - 1].fe_length,
+				  "extents came back out of order or overlapping");
+		covered += e->fe_length;
+	}
+	mu_assert(covered >= f.size, "the extents do not cover the file");
+
+	/*
+	 * And the single-ioctl shortcut agrees with the full map. It exists so
+	 * the dedupe rescan need not enumerate a huge file, so the one thing
+	 * that must hold is that it answers the same as the long way round.
+	 */
+	{
+		uint64_t poff = 0;
+
+		mu_check(fiemap_first_extent_poff(f.fd, 0, f.size, &poff) == 0);
+		mu_assert(poff == fm->fm_extents[0].fe_physical,
+			  "the shortcut disagreed with the full map");
+	}
+}
+
+/*
+ * A range query maps the range asked for, and answers "hole" rather than
+ * "error" where there is nothing.
+ *
+ * do_fiemap_range() returning NULL for both is deliberate and is why
+ * fiemap_count_shared() can treat NULL as zero shared bytes rather than as a
+ * failure - a distinction that would otherwise turn every hole into an error.
+ */
+MU_TEST(test_fiemap_range_answers_for_the_range_asked_for) {
+	_cleanup_(fm_close) struct fm_file f = fm_open(2, true);
+	_cleanup_(freep) struct fiemap *first = NULL;
+	uint64_t poff = 0;
+
+	/* The hole between the two written chunks. */
+	mu_assert(do_fiemap_range(f.fd, FM_CHUNK, FM_CHUNK) == NULL,
+		  "a hole was reported as an extent");
+	mu_assert(fiemap_first_extent_poff(f.fd, FM_CHUNK, FM_CHUNK, &poff) == -1,
+		  "the shortcut found an extent in a hole");
+
+	/* Past the end of the file. */
+	mu_assert(do_fiemap_range(f.fd, f.size + FM_CHUNK, FM_CHUNK) == NULL,
+		  "a range past EOF was reported as an extent");
+
+	/* The first chunk, which is there. */
+	first = do_fiemap_range(f.fd, 0, FM_CHUNK);
+	mu_check(first != NULL);
+	mu_assert(first->fm_mapped_extents >= 1, "the first chunk mapped nothing");
+	mu_check(first->fm_extents[0].fe_logical == 0);
+}
+
+/*
+ * Nothing is shared in a file nobody has deduplicated, and saying otherwise
+ * would credit the run with space it never freed.
+ *
+ * This is the counter behind the "net change in shared extents" line. It
+ * cannot be tested positively here - making an extent SHARED needs reflink,
+ * which this filesystem may not have - but the negative is the direction that
+ * matters: a false positive inflates a figure users read as disk saved.
+ */
+MU_TEST(test_fiemap_counts_nothing_shared_in_a_fresh_file) {
+	_cleanup_(fm_close) struct fm_file f = fm_open(2, true);
+	uint64_t shared = 99;
+
+	mu_check(fiemap_count_shared(f.fd, 0, f.size, &shared) == 0);
+	mu_assert(shared == 0, "a freshly written file was reported as sharing");
+
+	/* A range that is entirely hole answers zero rather than failing - the
+	 * NULL-is-not-an-error path. */
+	shared = 99;
+	mu_check(fiemap_count_shared(f.fd, FM_CHUNK, FM_CHUNK * 2, &shared) == 0);
+	mu_check(shared == 0);
+}
+
 MU_TEST(test_dedupe_classify_probe)
 {
 	/* Dispatched, and the destination was processed: SAME or DIFFERS. */
@@ -5927,6 +6133,9 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_the_extent_search_driven_by_its_pool);
 	MU_RUN_TEST(test_the_interrupt_flag_and_its_test_hooks);
 	MU_RUN_TEST(test_the_wind_down_notice_is_said_once);
+	MU_RUN_TEST(test_fiemap_maps_a_real_file);
+	MU_RUN_TEST(test_fiemap_range_answers_for_the_range_asked_for);
+	MU_RUN_TEST(test_fiemap_counts_nothing_shared_in_a_fresh_file);
 	MU_RUN_TEST(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run

--- a/src/tests.c
+++ b/src/tests.c
@@ -316,9 +316,15 @@ MU_TEST(test_fiemap_layout_key) {
 	 * More extents than the stack buffer holds, so the heap path runs.
 	 * LAYOUT_KEY_STACK_EXTENTS is 32 and every fixture above has one or
 	 * two, so that branch - and the record-stride arithmetic that sizes
-	 * both buffers - had never been reached. A stride that disagrees with
-	 * the loop writes past whichever buffer is in use, which is a
-	 * fragmented file's key computed over its neighbours' memory.
+	 * both buffers - had never been reached.
+	 *
+	 * Only half of a stride mismatch is visible from here, and it is worth
+	 * being exact about which. A stride *wider* than the loop's leaves the
+	 * moved word past `bytes` and unhashed, so the last assertion below
+	 * catches it. A stride *narrower* feeds the unwritten tail of the
+	 * buffer to checksum_block(), which a plain run cannot see - that one
+	 * belongs to the valgrind and ASAN legs, the same shape as the missing
+	 * memset in start_running_checksum().
 	 */
 	{
 		struct fm_rec many[40];
@@ -334,6 +340,9 @@ MU_TEST(test_fiemap_layout_key) {
 		/* Either side of the boundary, and well past it. */
 		mu_check(key_of(many, LAYOUT_KEY_STACK_EXTENTS, 1u << 20, big));
 		mu_check(key_of(many, LAYOUT_KEY_STACK_EXTENTS + 1, 1u << 20, big2));
+		/* Different counts key differently - which rec[1] alone
+		 * guarantees, so this is a sanity check on the fixture rather
+		 * than a claim about the boundary. */
 		mu_assert(memcmp(big, big2, DIGEST_LEN) != 0,
 			  "one extent more than the stack holds keyed the same");
 
@@ -5847,11 +5856,17 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
  * The pure half of fiemap.c is already well covered - fiemap_maps_share() is
  * at 87% killed, phys_set_merge() 84% - because synthetic records beat
  * coaxing a filesystem into a layout. What was at 0% is everything that takes
- * a *file descriptor*: the four functions that actually issue FS_IOC_FIEMAP.
+ * a *file descriptor*: every function here that issues FS_IOC_FIEMAP.
  *
- * Those need no reflink filesystem, only FIEMAP, which ext4 and tmpfs both
- * implement - so unlike the dedupe paths they are testable anywhere the suite
- * runs. What they must not do is assert a particular extent count: how a
+ * Those need no reflink filesystem, only FIEMAP - but not every filesystem
+ * has it. tmpfs installs no ->fiemap at all, so the ioctl fails with
+ * EOPNOTSUPP before the filesystem is consulted, and CLAUDE.md notes that /tmp
+ * is tmpfs on the usual dev box. So fm_open() asks first and says so when the
+ * answer is no, rather than failing an assertion that has nothing to do with
+ * the code under test. DUPEREMOVE_TEST_DIR is preferred when set, since CI
+ * guarantees btrfs or XFS there.
+ *
+ * What these must not do is assert a particular extent count: how a
  * filesystem lays out a write is its business. Everything below is an
  * invariant that holds whatever the layout turns out to be.
  * ---------------------------------------------------------------------------
@@ -5859,11 +5874,11 @@ MU_TEST(test_the_wind_down_notice_is_said_once) {
 
 #define FM_CHUNK	(256 * 1024)
 
-/* A real file with `chunks` blocks of data, optionally separated by holes.
- * Returns the fd; the caller closes and unlinks via fm_close(). */
+/* A real file to map. fd is -1 when this filesystem has no FIEMAP, which the
+ * callers treat as a skip rather than as a failure. */
 struct fm_file {
 	int fd;
-	char path[64];
+	char path[128];
 	uint64_t size;
 };
 
@@ -5875,32 +5890,69 @@ static void fm_close(struct fm_file *f)
 		unlink(f->path);
 }
 
-static struct fm_file fm_open(unsigned int chunks, bool sparse)
+static struct fm_file fm_open(const char *name, unsigned int chunks, bool sparse)
 {
 	struct fm_file f = { .fd = -1 };
 	_cleanup_(freep) char *buf = malloc(FM_CHUNK);
+	const char *dir = getenv("DUPEREMOVE_TEST_DIR");
+	struct fiemap probe = { .fm_length = ~0ULL };
+	int fd;
 
 	if (!buf)
 		abort();
 	memset(buf, 0xa5, FM_CHUNK);
-	snprintf(f.path, sizeof(f.path), "/tmp/oans-fiemap-XXXXXX");
-	f.fd = mkstemp(f.path);
-	if (f.fd < 0)
+	snprintf(f.path, sizeof(f.path), "%s/oans-fiemap-XXXXXX",
+		 dir && *dir ? dir : "/tmp");
+	fd = mkstemp(f.path);
+	if (fd < 0)
 		abort();
+
+	/* Ask before relying on it. tmpfs answers EOPNOTSUPP here, and a bare
+	 * assertion failure would say nothing about why. */
+	if (ioctl(fd, FS_IOC_FIEMAP, &probe) < 0 &&
+	    (errno == EOPNOTSUPP || errno == ENOTTY)) {
+		printf("\n[fiemap] skipping %s: %s has no FIEMAP\n", name, f.path);
+		close(fd);
+		unlink(f.path);
+		f.path[0] = '\0';
+		return f;			/* fd stays -1 */
+	}
 
 	for (unsigned int i = 0; i < chunks; i++) {
 		/* A gap of one chunk between each, so a sparse file really has
 		 * holes rather than a filesystem's idea of a contiguous run. */
 		off_t at = (off_t)i * FM_CHUNK * (sparse ? 2 : 1);
 
-		if (pwrite(f.fd, buf, FM_CHUNK, at) != FM_CHUNK)
+		if (pwrite(fd, buf, FM_CHUNK, at) != FM_CHUNK) {
+			unlink(f.path);
 			abort();
+		}
 		f.size = (uint64_t)at + FM_CHUNK;
+	}
+	/*
+	 * Punch the gaps rather than assuming a skipped write leaves one. XFS
+	 * reserves post-EOF blocks on a buffered extending write - for a file
+	 * this size, about the size of the gap - and reports the reservation as
+	 * a DELALLOC record, so the "hole" would come back mapped. Truncating
+	 * to the written size drops anything left past the end.
+	 */
+	if (sparse) {
+		for (unsigned int i = 1; i < chunks; i++)
+			(void)fallocate(fd, FALLOC_FL_PUNCH_HOLE |
+					FALLOC_FL_KEEP_SIZE,
+					(off_t)(2 * i - 1) * FM_CHUNK, FM_CHUNK);
+	}
+	if (ftruncate(fd, (off_t)f.size)) {
+		unlink(f.path);
+		abort();
 	}
 	/* Without this the data can still be in delalloc, where fiemap reports
 	 * it with no stable physical address - or not at all. */
-	if (fsync(f.fd))
+	if (fsync(fd)) {
+		unlink(f.path);
 		abort();
+	}
+	f.fd = fd;
 	return f;
 }
 
@@ -5913,10 +5965,13 @@ static struct fm_file fm_open(unsigned int chunks, bool sparse)
  * walks fm_mapped_extents believing it.
  */
 MU_TEST(test_fiemap_maps_a_real_file) {
-	_cleanup_(fm_close) struct fm_file f = fm_open(1, false);
+	_cleanup_(fm_close) struct fm_file f = fm_open(__func__, 1, false);
 	_cleanup_(freep) struct fiemap *fm = NULL;
 	unsigned int counted;
 	uint64_t covered = 0;
+
+	if (f.fd < 0)
+		return;
 
 	counted = fiemap_count_extents(f.fd, 0, ~0ULL);
 	mu_assert(counted >= 1, "a written and fsynced file mapped no extents");
@@ -5964,19 +6019,27 @@ MU_TEST(test_fiemap_maps_a_real_file) {
  * failure - a distinction that would otherwise turn every hole into an error.
  */
 MU_TEST(test_fiemap_range_answers_for_the_range_asked_for) {
-	_cleanup_(fm_close) struct fm_file f = fm_open(2, true);
+	_cleanup_(fm_close) struct fm_file f = fm_open(__func__, 2, true);
 	_cleanup_(freep) struct fiemap *first = NULL;
+	/* Kept rather than discarded: on the branch where these assertions
+	 * fail the map would otherwise leak, and the valgrind unit leg turns
+	 * one clear failure into a failure plus an unrelated leak report. */
+	_cleanup_(freep) struct fiemap *hole = NULL;
+	_cleanup_(freep) struct fiemap *past = NULL;
 	uint64_t poff = 0;
 
+	if (f.fd < 0)
+		return;
+
 	/* The hole between the two written chunks. */
-	mu_assert(do_fiemap_range(f.fd, FM_CHUNK, FM_CHUNK) == NULL,
-		  "a hole was reported as an extent");
+	hole = do_fiemap_range(f.fd, FM_CHUNK, FM_CHUNK);
+	mu_assert(hole == NULL, "a hole was reported as an extent");
 	mu_assert(fiemap_first_extent_poff(f.fd, FM_CHUNK, FM_CHUNK, &poff) == -1,
 		  "the shortcut found an extent in a hole");
 
 	/* Past the end of the file. */
-	mu_assert(do_fiemap_range(f.fd, f.size + FM_CHUNK, FM_CHUNK) == NULL,
-		  "a range past EOF was reported as an extent");
+	past = do_fiemap_range(f.fd, f.size + FM_CHUNK, FM_CHUNK);
+	mu_assert(past == NULL, "a range past EOF was reported as an extent");
 
 	/* The first chunk, which is there. */
 	first = do_fiemap_range(f.fd, 0, FM_CHUNK);
@@ -5995,8 +6058,23 @@ MU_TEST(test_fiemap_range_answers_for_the_range_asked_for) {
  * matters: a false positive inflates a figure users read as disk saved.
  */
 MU_TEST(test_fiemap_counts_nothing_shared_in_a_fresh_file) {
-	_cleanup_(fm_close) struct fm_file f = fm_open(2, true);
+	_cleanup_(fm_close) struct fm_file f = fm_open(__func__, 2, true);
+	_cleanup_(freep) struct fiemap *fm = NULL;
 	uint64_t shared = 99;
+
+	if (f.fd < 0)
+		return;
+
+	/*
+	 * Establish that there was something to look at first. Without this,
+	 * `shared == 0` is equally satisfied by fiemap mapping nothing at all -
+	 * fiemap_count_shared() takes an early return on a NULL map - so the
+	 * test would stay green with fiemap_count_extents() stubbed to zero,
+	 * and would say nothing about the SHARED test inside the loop.
+	 */
+	fm = do_fiemap_range(f.fd, 0, f.size);
+	mu_assert(fm != NULL && fm->fm_mapped_extents >= 1,
+		  "the fixture mapped no extents, so nothing below is tested");
 
 	mu_check(fiemap_count_shared(f.fd, 0, f.size, &shared) == 0);
 	mu_assert(shared == 0, "a freshly written file was reported as sharing");

--- a/src/tests.c
+++ b/src/tests.c
@@ -804,6 +804,115 @@ MU_TEST(test_storage_recommend_io_threads) {
 	p = (struct storage_profile){ .rotational = true,
 		.rotational_known = true, .num_devices = 1 };
 	mu_check(storage_recommend_io_threads(&p, 0) == 1);
+
+	/*
+	 * A device count of zero takes the single-disk branch too, and this
+	 * is the one assertion here that is about a hazard rather than a
+	 * preference. storage_detect() seeds num_devices = 1, but a zeroed
+	 * profile is what a caller that skipped it holds - and the pool arm
+	 * would compute 2 * 0 and recommend *no* reader threads at all, which
+	 * sizes three pools. `<= 1` is what keeps that unreachable; `== 1`
+	 * reads identically and does not.
+	 */
+	p = (struct storage_profile){ .rotational = true,
+		.rotational_known = true, .num_devices = 0 };
+	mu_check(storage_recommend_io_threads(&p, 32) == 4);
+
+	/*
+	 * Between the clamp and the cap: with three cores the single-disk arm
+	 * must yield the cores, not the constant. Every case above sits at
+	 * base >= 4 or base <= 2, where `base < 4 ? base : 4` and a clamp of
+	 * three agree - so the clamp could be lowered and nothing noticed.
+	 */
+	p = (struct storage_profile){ .rotational = true,
+		.rotational_known = true, .num_devices = 1 };
+	mu_check(storage_recommend_io_threads(&p, 3) == 3);
+}
+
+MU_TEST(test_prop_a_recommendation_is_never_zero_and_never_over_the_cap) {
+	declare_prop(p, 20000);
+
+	/*
+	 * The table above says what each branch should answer. This says what
+	 * no branch may answer, and it is deliberately phrased without
+	 * reference to the branches: at least one reader thread, and never
+	 * more than the CPU cap allows.
+	 *
+	 * That independence is the point. The floor is the same claim the
+	 * `num_devices <= 1` test carries - a zeroed profile reaching the pool
+	 * arm computes 2 * 0 - but a table case asserts it at one profile,
+	 * where this asserts it at every combination of the three inputs,
+	 * including the ones nobody thought to write down. The result sizes
+	 * three thread pools, so zero is not a wrong number, it is a hang.
+	 */
+	while (prop_next(&p)) {
+		struct storage_profile sp;
+		unsigned int ncpus = (unsigned int)prop_below(&p, 260);
+		unsigned int got, ceiling;
+
+		sp.rotational_known = prop_bool(&p);
+		sp.rotational = prop_bool(&p);
+		/*
+		 * Log-uniform over a bounded range, so a pool of 3 and a pool
+		 * of a million both come up. The bound is deliberate and is
+		 * the one caveat on the claim below: `2 * p->num_devices` is
+		 * unsigned int arithmetic, so a count at or above 2^31 wraps
+		 * and the pool arm can answer zero by a second route the
+		 * `<= 1` guard knows nothing about. num_devices is a btrfs
+		 * pool member count read from BTRFS_IOC_FS_INFO, so no such
+		 * filesystem exists; widening this generator would report an
+		 * unreachable input as a counterexample and say nothing about
+		 * the guard the property is here to hold.
+		 */
+		sp.num_devices = (unsigned int)
+			((prop_u64(&p) >> prop_below(&p, 64)) & 0xfffff);
+
+		got = storage_recommend_io_threads(&sp, ncpus);
+		ceiling = ncpus < AUTO_THREADS_CAP ? ncpus : AUTO_THREADS_CAP;
+		if (ceiling < 1)
+			ceiling = 1;
+
+		prop_check(&p, got >= 1);
+		prop_check(&p, got <= ceiling);
+	}
+}
+
+MU_TEST(test_storage_describe) {
+	struct storage_profile p;
+	char buf[64];
+
+	/*
+	 * The line a run prints for its own storage, and the only place the
+	 * profile is rendered rather than acted on. Its device-count test had
+	 * no test at all, so every spelling of it - `>= 1`, `> 0`, `> 2` -
+	 * described a single disk as a pool or a pool as a single disk with
+	 * nothing going red.
+	 */
+	p = (struct storage_profile){ .rotational = false,
+		.rotational_known = true, .num_devices = 1 };
+	storage_describe(&p, buf, sizeof(buf));
+	mu_assert_string_eq("single device, non-rotational (SSD)", buf);
+
+	/* Two is the boundary: the first count that is a pool. */
+	p.num_devices = 2;
+	p.rotational = true;
+	storage_describe(&p, buf, sizeof(buf));
+	mu_assert_string_eq("btrfs pool of 2 devices, rotational (HDD)", buf);
+
+	/* Unknown media outranks the rotational flag, which is then stale. */
+	p = (struct storage_profile){ .rotational = true,
+		.rotational_known = false, .num_devices = 1 };
+	storage_describe(&p, buf, sizeof(buf));
+	mu_assert_string_eq("single device, unknown media", buf);
+
+	/* Truncation is snprintf's job, but the result must stay a C string:
+	 * this is what the caller passes to a %s. */
+	p = (struct storage_profile){ .rotational = true,
+		.rotational_known = true, .num_devices = 12 };
+	memset(buf, 'x', sizeof(buf));
+	storage_describe(&p, buf, 12);
+	mu_assert_string_eq("btrfs pool ", buf);	/* 11 chars + NUL */
+	mu_check(buf[12] == 'x');	/* nothing written past the length */
 }
 
 MU_TEST(test_scan_bucket) {
@@ -6155,6 +6264,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_progress_copy_path);
 	MU_RUN_TEST(test_progress_path_two_stage_render);
 	MU_RUN_TEST(test_storage_recommend_io_threads);
+	MU_RUN_TEST(test_storage_describe);
+	MU_RUN_TEST(test_prop_a_recommendation_is_never_zero_and_never_over_the_cap);
 	MU_RUN_TEST(test_scan_bucket);
 	MU_RUN_TEST(test_scan_workq_priority);
 	MU_RUN_TEST(test_starved_worker_line_reads_idle);


### PR DESCRIPTION
Last of the unit-testing iterations, and the two files left were the ones where
the fixture is not a struct you can write down: `fiemap.c`, whose input comes
from the kernel, and `storage.c`, whose input is the hardware.

## fiemap: three tests against a real file

Every fiemap test until now built synthetic `struct fm_rec` arrays and called
the map walkers directly. That is right for `fiemap_maps_share()` and the
layout key, and it is why those were already well covered — but it left
`do_fiemap()` itself, its buffer sizing and its range arithmetic with no test
at all, since nothing exercised the code that *produces* those arrays.

Three tests now open a real file and ask the kernel. That immediately raises the
question of which kernel, and the answer turned out to matter more than the
tests:

- **`/tmp` is tmpfs, and tmpfs has no `->fiemap` at all.** The first draft wrote
  its fixture there and asserted the ioctl worked. On a dev box two of the three
  tests fail with a `perror` and the third passes vacuously. The fixture now
  prefers `DUPEREMOVE_TEST_DIR`, probes `FS_IOC_FIEMAP` before relying on it,
  and skips **by name** when the answer is no. Verified rather than assumed —
  pointing `DUPEREMOVE_TEST_DIR` at `/dev/shm` gives three named skips and a
  green suite.
- **Holes are punched, not seeked.** XFS speculative preallocation fills a gap
  left by seeking and reports it `DELALLOC`, so a sparse fixture built the
  obvious way has no hole on half the CI matrix.
- **A negative assertion about a map needs the map to exist.**
  `fiemap_count_shared()` returns early on a NULL map, so "a fresh file shares
  nothing" was equally satisfied by fiemap mapping *nothing* — the test stayed
  green with `fiemap_count_extents()` stubbed to zero. It now establishes at
  least one mapped extent first, which is what makes `0` a different statement
  from "there was nothing to look at".

Also covered: the layout key's **heap path**. `LAYOUT_KEY_STACK_EXTENTS` is 32
and every fixture in the tree had one or two, so that branch and the
record-stride arithmetic that sizes both buffers had never run.

## storage: a thorough-looking table with nine survivors, eight of them equivalent

`storage_recommend_io_threads()` is pure, takes a struct, and already had what
reads like a complete table. Nine mutants survived it. **Eight are provably
equivalent** and checking that rather than counting it is the whole exercise:
`<` → `<=` at `ncpus < AUTO_THREADS_CAP` differs only where both answer `CAP`,
and `num_devices <= 1` → `<= 2` is the same function, because a two-device
pool's `2 * 2` already equals the single-disk clamp of 4.

The two that were not:

- **`<= 1` → `== 1` on the device count.** A zeroed profile reaches the pool
  arm, computes `2 * 0`, and recommends **no reader threads at all** — a number
  that sizes three pools. `storage_detect()` seeds `num_devices = 1`, so this is
  defensive code; defensive code is exactly what a test has to hold in place.
- **The single-disk clamp could be lowered and nothing noticed.** Every existing
  case sits at `base >= 4` or `base <= 2`, where `base < 4 ? base : 4` and a
  clamp of three agree. One three-core case separates them.

**`storage_describe()` had no test at all**, so all four spellings of its
device-count test survived — `>= 1`, `> 0`, `> 2` each describe a single disk as
a pool or a pool as a single disk, in the line a run prints about its own
storage.

## Where the fiemap residue is

Read by function rather than as a total, the three real-file tests moved
exactly the code that needed a kernel to answer:

| function | before | after |
|---|---|---|
| `fiemap_first_extent_poff` | 24 / 26 | 8 |
| `fiemap_map` | 18 / 21 | 8 |
| `fiemap_count_extents` | 11 / 12 | 5 |
| `do_fiemap_range` | 4 / 6 | 0 |
| `fiemap_count_shared` | 39 / 48 | 29 |
| `fiemap_layout_key` | 32 / 76 | 24 |

`fiemap_count_shared`'s remaining 29 are all one thing: the clipping arithmetic
*inside* `if (... fe_flags & FIEMAP_EXTENT_SHARED)`. A fresh file enters that
branch never, so reaching it needs an extent that genuinely shares — which needs
a reflink filesystem, i.e. `tests/integration/`, not the unit suite. That is a
boundary rather than a hole.

## What is deliberately not here

`btrfs-util.c` (28 survivors of 37) gets no tests. All of them are inside three
`BTRFS_IOC_*` wrappers, as is most of `storage_detect`/`read_rotational`/
`detect_btrfs` — sysfs reads and ioctls against real block devices. Triaged to
that point and stopped; the next honest move there is a fault-injection seam,
not a bigger fixture.

## Numbers

| file | survivors before | after |
|---|---|---|
| `src/fiemap.c` | 177 / 487 | 122 |
| `src/storage.c` | 101 / 147 | 95 |

The storage number is small and that is the whole of it: the six that went are
**exactly** the six argued above to be real, and the seven left in the two pure
functions are **exactly** the seven argued to be equivalent. Everything else in
that file is `storage_detect`/`read_rotational`/`detect_btrfs`.

A property states the recommender's floor a second way, without reference to any
branch — at least one thread, never more than the CPU cap, over every
combination of the three inputs. It added **no sweep kills at all** while
catching its own bug block, which is the lower-bound lesson a fourth time. Its
generator is bounded on purpose and says why: `2 * num_devices` is unsigned int
arithmetic, so a count at or above 2^31 wraps and reaches zero by a route the
`<= 1` guard knows nothing about. That count is a btrfs pool member count from
`BTRFS_IOC_FS_INFO`, so no such filesystem exists — generating it would report
an unreachable input as a counterexample.

`scripts/mutate/bugs/storage.txt` puts five of the invariants back.

## Gate

`make lint`, `WERROR=1` build, `SANITIZE=address,undefined CC=clang make test`,
valgrind with `--error-exitcode=42` (0 definitely-lost, 0 errors),
`make mutation-replay` across all eleven bug files with nothing surviving, and
three `OANS_PROPTEST_SEED=random` runs.

The integration suite is not part of that list, and deliberately: this sandbox
has no btrfs or XFS, so the #224 probe refuses and ~106 cases fail there for the
environment rather than for the diff. Nothing in this branch can reach them —
the only changed C file is `src/tests.c`, which `Makefile:46` filters out of
`CFILES`, so the shipped binary is unchanged. CI runs that suite on both
filesystems.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_