### PR TITLE
A by-function mutation report, and a lint that refuses a two-source bug file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,49 @@ in `tests/`; no shell tests.
 Two additions to `src/tests.c`'s side of the house. Neither touches the
 integration suite, and the distinction matters for reading either of them.
 
+### What eight iterations of this actually taught
+
+The per-file sections below are the findings. This is the method they converged
+on, and it is worth reading before starting a ninth.
+
+- **The loop is: write the tests, review them, sweep, then open the PR — in
+  that order.** A review that lands after the sweep invalidates every number in
+  it, because a review of tests always edits tests. Sweeping first and
+  reviewing second means re-running a sweep that costs minutes to an hour.
+- **In seven of seven iterations, the review found a test that could not
+  fail.** Not a weak test — a test whose assertion held no matter what the code
+  did. The list, because the shapes repeat: a fixture whose winner led on every
+  column (so a `min(id)` election passed the #197 test); an `is_anchor`
+  assertion that passed against its own mutation; two symmetric file layouts,
+  which made "which side of the pair was written" unobservable and cost 47 of
+  72 mutants; a helper wrapping `list_first_entry()` on a possibly-empty list,
+  which never returns NULL, so every `mu_check(t != NULL)` around it held
+  whatever the loader did; an idleness check a deleted wait still satisfied; a
+  vacuous empty-file scenario; and "a fresh file shares nothing", equally
+  satisfied by fiemap mapping nothing at all.
+  That rate did not fall as the work got better, which is the argument for the
+  review step being mandatory rather than a finishing touch. **Suspect the
+  fixture before you suspect the code**, and ask of every new assertion: what
+  would have to be true for this to fail?
+- **Read every survivor count by function** (`report.py`, below). The number the
+  tool prints answers a question nobody asked. `src/util.c` at 213 of 413 was
+  5-9% survival wherever a test existed and 85-94% in four untested pure
+  functions; the total says one thing and the grouping says two.
+- **Check the equivalents rather than counting them.** `storage.c` ended at
+  nine survivors in a pure function of which eight are provably equivalent, and
+  the discipline is what found the two that were not. Three that *looked*
+  equivalent in `src/util.c` were not, and one of those wrote a byte past a
+  buffer — so prove it, one at a time, rather than waving at the group.
+- **Then stop.** Residue that is an ioctl, a `perror_sqlite` + `goto out` pair,
+  or an `exit()` path is triaged, not fixed: the next honest move there is a
+  fault-injection seam, and saying so is a better answer than a bigger fixture.
+- **A `caught` count is a lower bound on what a test guards, never the
+  measure.** Measured four times now: the `src/glob.c` properties gained
+  nothing on a sweep, the three hashfile ones moved exactly one mutant (and it
+  was worth all three), and the storage property moved *zero* while catching
+  its own bug block. No operator generates a design change, so anything a
+  bug file guards against is invisible to a sweep by construction.
+
 ### `scripts/mutate/mutate.py` — does anything notice when this breaks
 
 Breaks a source file in a throwaway copy of the tree, rebuilds, runs `./test`,
@@ -134,6 +177,16 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
     exactly one file. `make mutation-replay` now runs the lot with nothing to
     know, and `make lint` refuses a bug file whose `# file:` line is missing or
     names something that is not there.
+  - **One source per bug file, and the lint now enforces that too.** A *second*
+    `# file:` line is worse than a missing one, because it does not abort: the
+    adapter takes the first match and ignores the rest, so the blocks under the
+    later heading are applied to the earlier heading's source. Measured — a
+    block written for `src/util.c` (`if (base < 1)`) applied cleanly to
+    `src/storage.c`, where the same text exists and the mutant is equivalent,
+    and came back **`survived`**, under the report's "nothing noticed these —
+    whatever covers them is decoration". A test called decoration when it was
+    never run, which is the direction every bug in this tool has erred. This is
+    how nine blocks in one file once became three that ran.
 - **A `survived` is a narrower claim than it reads.** The suite is `src/tests.c`
   alone: the end-to-end Python suite drives the *binary* and is not in the loop,
   so for the dedupe phase, the scan pipeline and the progress block a survivor
@@ -233,6 +286,50 @@ scripts/mutate/mutate.py --file src/util.c --dry-run    # how many, and how long
   from `<=` because `v >= 1024.0` fails first, UINT64_MAX being 16 EiB. Check
   the equivalents rather than assuming them: three that looked equivalent were
   not, and one of those wrote a byte past a buffer.
+
+### `scripts/mutate/report.py` — the grouping, and the diff
+
+`mutate.py --json` writes a report; this reads it. Two modes, and both exist
+because they were hand-rolled in throwaway python four times over eight
+iterations before earning a file.
+
+```sh
+scripts/mutate/report.py sweep.json                 # survivors by function
+scripts/mutate/report.py before.json after.json     # what a change moved
+```
+
+- **The grouping is the rule above, made cheap.** Kill rate per function is
+  computed over the *scored* mutants (total minus `compiler`), since a function
+  whose mutants the build all rejected says nothing about the tests.
+- **The diff is the claim worth making.** "Survivors went down by four" is the
+  same number for a change that killed four and one that killed six and lost
+  two, so it names the mutants that went and calls out any that **arrived** —
+  a test that stopped covering something is the finding a total cannot show.
+  Used to confirm that `storage.c`'s six kills were exactly the six argued to
+  be real, and that nothing regressed.
+- **It refuses a per-mutant diff across a changed source, and this is the whole
+  reason it is careful.** Line numbers move, so mapping one run's lines through
+  the other's function map attributes survivors to whatever now sits at that
+  number — done by hand once here, it produced a confident report of a
+  regression in `extents_search_init`, a function the change had not touched.
+  The guard is the mutant population: identical `(line, name)` multisets mean
+  the same source, and anything else falls back to per-function counts and says
+  so.
+- **`scripts/mutate/test_report.py` is hermetic and runs in `make lint`** — no
+  compiler, no build, no lanes. It is there because this tool is only ever read
+  as the explanation of a number, so a wrong grouping does not fail, it
+  persuades: the first parser walked back over a signature into the doc comment
+  above it and filed all 36 of `read_rotational`'s mutants under `parent`, a
+  word from prose about partitions. A plausible name with a plausible count.
+  - The makefile runs the script directly rather than piping it to `tail`.
+    `sh` reports a pipeline's *last* command, so a `| tail -1` would return 0
+    however the tests went — the check could never fail, which is the exact
+    shape of thing this directory exists to catch.
+- **Not in `mutate_core.py`, deliberately.** The core is vendored byte-identical
+  into unordered_dense and nanobench and tested over there, so a change to it is
+  a three-repo errand; this reads only the JSON those runs already emit, and
+  nothing about it is oans-specific except the C function parser. Promote it if
+  the other two want it, rather than paying that cost up front.
 
 ### The dedupe model is unit-testable too, and needs no fixture at all
 

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ lint:
 	@python3 scripts/lint-longpath.py
 	@python3 scripts/lint-escape.py
 	@python3 scripts/lint-mutate-core.py
+	@python3 scripts/mutate/test_report.py
 
 # Replay the known bugs in scripts/mutate/bugs/ and fail if any survives - the
 # check that says the tests would still notice #147, #159, #186, #187, #191 and

--- a/scripts/lint-mutate-core.py
+++ b/scripts/lint-mutate-core.py
@@ -49,15 +49,33 @@ def adapter_module():
 
 
 def bug_file_problems(project):
-    """Every bugs/*.txt names a source that exists.
+    """Every bugs/*.txt names exactly one source, and that source exists.
 
     A bug file whose `# file:` line is missing or stale mutates whatever
     `--file` defaults to, where its blocks do not appear - so every one of them
     fails to apply, the run aborts, and the reason is two steps from the
     message. One stat each, at the only moment anyone is looking.
+
+    A *second* `# file:` line is worse than either, because it does not abort.
+    The adapter takes the first match and ignores the rest, so the blocks under
+    the second heading are applied to the first heading's source - and a short
+    block often exists in both files. Measured: `if (base < 1)` written for
+    src/util.c applied cleanly to src/storage.c, where it is an equivalent
+    mutant, and came back `survived` under "nothing noticed these - whatever
+    covers them is decoration". That is a test being called decoration when it
+    was never run, and it is the direction every bug in this tool has erred.
+    One file per source; split the blocks.
     """
     found = []
     for path in sorted((CORE.parent / "bugs").glob("*.txt")):
+        headings = adapter_module().BUG_FILE_TARGET.findall(path.read_text())
+        if len(headings) > 1:
+            found.append("%s names %d sources (%s): a bug file mutates one, "
+                         "and the blocks under the later ones would be applied "
+                         "to the first - split it"
+                         % (path.relative_to(REPO), len(headings),
+                            ", ".join(headings)))
+            continue
         target = adapter_module().bug_file_target(str(path))
         if target is None:
             found.append("%s names no source: give it a `# file: src/....c` line"

--- a/scripts/mutate/report.py
+++ b/scripts/mutate/report.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Read a mutation run's --json report by function, and diff two of them.
+
+CLAUDE.md says to read a survivor count by function and never as a total, and
+every sweep in this tree has proved it: src/util.c came back 213 survivors of
+413, which says nothing at all - grouped, it was 5-9% survival everywhere a
+test existed and 85-94% in four pure functions that had no test, and only the
+grouping tells an absent test from a weak one. The tool prints the total. This
+prints what the total hides.
+
+    scripts/mutate/report.py sweep.json                 # survivors by function
+    scripts/mutate/report.py before.json after.json     # what a change moved
+
+The diff exists because "the survivor count went down" is not the claim worth
+making. What is worth making is which mutants went, and whether any arrived:
+a run that kills six and loses two reports the same -4 as one that kills four.
+
+Two traps this encodes, both of which were hit by hand before it existed:
+
+  - A before/after pair whose source differs cannot be diffed per mutant. Line
+    numbers move, so mapping one run's lines through the other's function map
+    silently attributes survivors to whatever now sits at that line - which
+    once produced a confident report of a regression in a function that had
+    not been touched. When the mutant populations differ, this falls back to
+    per-function counts and says so rather than guessing.
+  - A function with no mutants at all is not a function with no survivors. It
+    is usually a function the sweep never reached, and it is listed separately.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def function_map(path):
+    """Line number (1-based) -> enclosing function name, for kernel-style C.
+
+    Keyed off `{` alone in column 0 rather than a regex over the declaration:
+    a signature wrapped across lines (`storage_recommend_io_threads` is one)
+    leaves its continuation looking nothing like a definition, and a regex that
+    matches it anyway also matches half the `if` statements in the file.
+    """
+    lines = path.read_text().split("\n")
+    names = ["<file scope>"] * (len(lines) + 1)
+    i = 0
+    while i < len(lines):
+        if lines[i] != "{":
+            i += 1
+            continue
+        # Walk back over the signature to the line that starts it.
+        start = i - 1
+        while start > 0:
+            prev = lines[start - 1].strip()
+            # `*/` and `*` stop it as surely as `;` does: without them the walk
+            # runs up into the doc comment, and a comment mentioning a word
+            # before a `(` becomes the function's name. read_rotational's
+            # comment says "via the parent (\"..\"", and that is what the
+            # first version of this reported for every one of its 36 mutants.
+            if (prev == "" or prev.startswith(("#", "*", "/*"))
+                    or prev.endswith((";", "}", "{", "*/"))):
+                break
+            start -= 1
+        decl = " ".join(lines[start:i])
+        name = None
+        if "(" in decl:
+            head = decl[: decl.index("(")].replace("*", " ").strip()
+            if head:
+                name = head.split()[-1]
+        # Body runs to the next `}` in column 0.
+        end = i + 1
+        while end < len(lines) and lines[end] != "}":
+            end += 1
+        if name:
+            for ln in range(start + 1, min(end, len(lines)) + 2):
+                names[ln] = name
+        i = end + 1
+    return names
+
+
+def load(p):
+    d = json.loads(Path(p).read_text())
+    src = d.get("environment", {}).get("file")
+    if not src:
+        sys.exit(f"{p}: no environment.file - not a mutation report?")
+    return d, src
+
+
+def grouped(results, names):
+    """{function: [survived, total]}, in file order."""
+    out = {}
+    for m in results:
+        ln = m.get("line", 0)
+        fn = names[ln] if 0 < ln < len(names) else "<unknown line>"
+        slot = out.setdefault(fn, [0, 0])
+        slot[1] += 1
+        if m["verdict"] == "survived":
+            slot[0] += 1
+    return out
+
+
+def population(results):
+    """The (line, name) multiset a run generated. Equal populations mean the
+    two runs saw the same source, which is what makes a per-mutant diff sound."""
+    return sorted((m.get("line", 0), m["name"]) for m in results)
+
+
+def report_one(path):
+    d, src = load(path)
+    names = function_map(Path(src))
+    g = grouped(d["results"], names)
+    counts = d["counts"]
+    total = sum(counts.values())
+    print(f"{src}: {counts['survived']} survivors of {total}"
+          f"  (caught {counts['caught']}, compiler {counts['compiler']},"
+          f" hang {counts['hang']}, oom {counts['oom']})\n")
+    print(f"  {'function':38s} {'survived':>9s} {'of':>5s}  {'kill rate':>9s}")
+    for fn, (s, t) in sorted(g.items(), key=lambda kv: -kv[1][0]):
+        # A function whose mutants are all `compiler` says nothing about tests.
+        scored = t - sum(1 for m in d["results"]
+                         if names[m.get("line", 0)] == fn
+                         and m["verdict"] == "compiler")
+        rate = f"{100 * (scored - s) // scored:d}%" if scored else "-"
+        print(f"  {fn:38s} {s:9d} {t:5d}  {rate:>9s}")
+
+
+def report_diff(before, after):
+    db, sb = load(before)
+    da, sa = load(after)
+    if sb != sa:
+        sys.exit(f"different files swept ({sb} vs {sa}) - nothing to compare")
+    names = function_map(Path(sa))
+    gb, ga = grouped(db["results"], names), grouped(da["results"], names)
+
+    print(f"{sa}: {db['counts']['survived']} -> {da['counts']['survived']}"
+          f" survivors\n")
+    print(f"  {'function':38s} {'before':>7s} {'after':>7s} {'':>6s}")
+    for fn in sorted(set(gb) | set(ga),
+                     key=lambda f: -(gb.get(f, [0])[0] - ga.get(f, [0])[0])):
+        b, a = gb.get(fn, [0, 0])[0], ga.get(fn, [0, 0])[0]
+        if b == a == 0:
+            continue
+        mark = "" if b == a else ("  <-- worse" if a > b else "")
+        print(f"  {fn:38s} {b:7d} {a:7d} {mark}")
+
+    if population(db["results"]) != population(da["results"]):
+        print("\nThe two runs generated different mutants, so the source"
+              "\nchanged between them and per-mutant lines would be"
+              "\nmisattributed. Per-function counts above are the whole answer.")
+        return
+
+    sb_ = {(m["line"], m["name"]) for m in db["results"] if m["verdict"] == "survived"}
+    sa_ = {(m["line"], m["name"]) for m in da["results"] if m["verdict"] == "survived"}
+    src_lines = Path(sa).read_text().split("\n")
+
+    def show(title, keys):
+        if not keys:
+            return
+        print(f"\n{title}:")
+        for ln, nm in sorted(keys):
+            text = src_lines[ln - 1].strip() if 0 < ln <= len(src_lines) else ""
+            print(f"  {names[ln]:32s} {ln:5d}  {nm:16s} | {text[:44]}")
+
+    show("killed by the change", sb_ - sa_)
+    show("NEWLY SURVIVING - a test stopped covering these", sa_ - sb_)
+
+
+def main(argv):
+    if len(argv) == 2:
+        report_one(argv[1])
+    elif len(argv) == 3:
+        report_diff(argv[1], argv[2])
+    else:
+        sys.exit(__doc__.strip().split("\n\n")[0] + "\n\n"
+                 "usage: report.py <run.json> [<after.json>]")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/mutate/test_report.py
+++ b/scripts/mutate/test_report.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Hermetic tests for report.py. No compiler, no build, no mutation run.
+
+report.py exists to stop a survivor count being misread, and its first version
+misread one itself: the walk back over a signature ran up into the doc comment
+above it, so every one of read_rotational's 36 mutants was filed under the word
+`parent`, taken from prose describing a partition's parent directory. Nothing
+about the output looked wrong - a plausible name with a plausible count.
+
+That is the whole hazard of this tool. It is only ever read as an explanation
+of a number, so a wrong grouping does not fail, it persuades. These tests are
+the parser's, and every case below is a shape that appears in src/.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import report  # noqa: E402
+
+SRC = '''\
+#include <stdio.h>
+
+static int plain(int a)
+{
+	return a;
+}
+
+/*
+ * A doc comment whose prose mentions a call (like this one) - which is what
+ * broke the first parser, since `(` in a comment reads as a signature.
+ */
+static int commented(int a)
+{
+	return a + 1;
+}
+
+unsigned int wrapped_signature(const struct thing *p,
+			       unsigned int n)
+{
+	return n;
+}
+
+static void *returns_a_pointer(void)
+{
+	return NULL;
+}
+'''
+
+
+class TestFunctionMap(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.src = Path(self.dir.name) / "s.c"
+        self.src.write_text(SRC)
+        self.names = report.function_map(self.src)
+
+    def tearDown(self):
+        self.dir.cleanup()
+
+    def at(self, needle):
+        """The name reported for the line containing `needle`."""
+        for i, line in enumerate(SRC.split("\n"), 1):
+            if needle in line:
+                return self.names[i]
+        self.fail(f"{needle!r} is not in the fixture")
+
+    def test_a_body_line_is_attributed_to_its_function(self):
+        self.assertEqual("plain", self.at("return a;"))
+
+    def test_a_doc_comment_does_not_become_the_name(self):
+        # The regression this file is named for. `parent` came from prose.
+        self.assertEqual("commented", self.at("return a + 1;"))
+
+    def test_a_signature_wrapped_across_lines_keeps_its_name(self):
+        # The continuation line looks nothing like a definition, which is why
+        # the parser keys off `{` in column 0 rather than matching the decl.
+        self.assertEqual("wrapped_signature", self.at("return n;"))
+
+    def test_a_pointer_return_type_is_not_part_of_the_name(self):
+        self.assertEqual("returns_a_pointer", self.at("return NULL;"))
+
+    def test_code_outside_any_function_is_file_scope(self):
+        self.assertEqual("<file scope>", self.at("#include"))
+
+
+class TestPopulation(unittest.TestCase):
+    """The guard on the per-mutant diff.
+
+    Two runs of a *changed* source generate different mutants, and diffing them
+    per line attributes survivors to whatever now sits at that number. Doing
+    exactly that by hand once produced a confident report of a regression in a
+    function the change had not touched.
+    """
+
+    def test_the_same_mutants_compare_equal_in_any_order(self):
+        a = [{"line": 2, "name": "x"}, {"line": 1, "name": "y"}]
+        b = [{"line": 1, "name": "y"}, {"line": 2, "name": "x"}]
+        self.assertEqual(report.population(a), report.population(b))
+
+    def test_a_moved_line_is_a_different_population(self):
+        a = [{"line": 10, "name": "< -> <="}]
+        b = [{"line": 11, "name": "< -> <="}]
+        self.assertNotEqual(report.population(a), report.population(b))
+
+    def test_a_different_mutation_on_the_same_line_differs(self):
+        a = [{"line": 10, "name": "< -> <="}]
+        b = [{"line": 10, "name": "< -> >"}]
+        self.assertNotEqual(report.population(a), report.population(b))
+
+
+class TestGrouped(unittest.TestCase):
+    def test_totals_and_survivors_are_counted_per_function(self):
+        names = ["<file scope>", "f", "f", "g"]
+        res = [{"line": 1, "verdict": "survived"},
+               {"line": 2, "verdict": "caught"},
+               {"line": 3, "verdict": "survived"}]
+        self.assertEqual({"f": [1, 2], "g": [1, 1]}, report.grouped(res, names))
+
+    def test_a_line_outside_the_map_is_not_silently_dropped(self):
+        # Better a visible bucket than a total that quietly stops adding up.
+        g = report.grouped([{"line": 999, "verdict": "survived"}], ["a", "b"])
+        self.assertEqual({"<unknown line>": [1, 1]}, g)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Drive the script the way a person does, since the reports are its API."""
+
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        d = Path(self.dir.name)
+        self.src = d / "s.c"
+        self.src.write_text(SRC)
+        line = next(i for i, l in enumerate(SRC.split("\n"), 1)
+                    if "return a + 1;" in l)
+        self.before = self.write(d / "b.json", [
+            {"line": line, "name": "+ -> -", "verdict": "survived"},
+            {"line": line, "name": "1 -> 2", "verdict": "survived"}])
+        self.after = self.write(d / "a.json", [
+            {"line": line, "name": "+ -> -", "verdict": "caught"},
+            {"line": line, "name": "1 -> 2", "verdict": "survived"}])
+
+    def tearDown(self):
+        self.dir.cleanup()
+
+    def write(self, path, results):
+        counts = {v: sum(1 for r in results if r["verdict"] == v)
+                  for v in ("caught", "compiler", "hang", "oom", "survived")}
+        path.write_text(json.dumps({
+            "environment": {"file": str(self.src)},
+            "counts": counts, "results": results}))
+        return path
+
+    def run_it(self, *args):
+        p = subprocess.run([sys.executable, str(HERE / "report.py"), *args],
+                           capture_output=True, text=True)
+        self.assertEqual(0, p.returncode, p.stderr)
+        return p.stdout
+
+    def test_a_single_run_names_the_function_not_the_line(self):
+        out = self.run_it(str(self.before))
+        self.assertIn("commented", out)
+        self.assertIn("2 survivors of 2", out)
+
+    def test_a_diff_names_what_was_killed(self):
+        out = self.run_it(str(self.before), str(self.after))
+        self.assertIn("killed by the change", out)
+        self.assertIn("+ -> -", out)
+        # And says nothing about the one that did not move.
+        self.assertNotIn("NEWLY SURVIVING", out)
+
+    def test_a_survivor_that_appears_is_called_out(self):
+        out = self.run_it(str(self.after), str(self.before))
+        self.assertIn("NEWLY SURVIVING", out)
+
+    def test_a_changed_source_refuses_the_per_mutant_diff(self):
+        moved = self.write(Path(self.dir.name) / "m.json", [
+            {"line": 99, "name": "+ -> -", "verdict": "survived"}])
+        out = self.run_it(str(self.before), str(moved))
+        self.assertIn("different mutants", out)
+        self.assertNotIn("killed by the change", out)
+
+    def test_two_different_files_are_refused_outright(self):
+        other = Path(self.dir.name) / "o.json"
+        other.write_text(json.dumps({
+            "environment": {"file": "src/elsewhere.c"},
+            "counts": {"survived": 0, "caught": 0, "compiler": 0,
+                       "hang": 0, "oom": 0},
+            "results": []}))
+        p = subprocess.run(
+            [sys.executable, str(HERE / "report.py"), str(self.before), str(other)],
+            capture_output=True, text=True)
+        self.assertNotEqual(0, p.returncode)
+        self.assertIn("different files swept", p.stderr)
+
+
+if __name__ == "__main__":
+    # One line on success, like the lint-*.py scripts beside it, and a real
+    # exit status. Deliberately not `unittest.main() | tail -1` from the
+    # makefile: sh reports a pipeline's *last* command, so the tail would
+    # return 0 however the tests went and the check could never fail - which
+    # is the exact shape of thing the rest of this directory exists to catch.
+    import io
+
+    buf = io.StringIO()
+    loader = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+    result = unittest.TextTestRunner(verbosity=2, stream=buf).run(loader)
+    if not result.wasSuccessful():
+        sys.stderr.write(buf.getvalue())
+        sys.exit(1)
+    print(f"report-selftest: {result.testsRun} tests, parser and diff guards")


### PR DESCRIPTION
Two tooling gaps that eight iterations of unit-test work made obvious, plus what
those iterations taught, written down. **No C changes** — the shipped binary and
the test binary are untouched.

## `scripts/mutate/report.py`

`CLAUDE.md` has said since the first sweep to read a survivor count **by
function and never as a total**, and every sweep since has proved it: `src/util.c`
came back 213 survivors of 413, which grouped was 5-9% survival everywhere a
test existed and 85-94% in four pure functions that had no test at all. The tool
prints the total. This prints what the total hides.

It was hand-rolled in throwaway python four times before earning a file.

```
$ scripts/mutate/report.py sweep.json
src/storage.c: 95 survivors of 147  (caught 25, compiler 27, hang 0, oom 0)

  function                                survived    of  kill rate
  storage_detect                                30    35         0%
  read_rotational                               29    36         0%
  detect_btrfs                                  24    27         0%
  storage_recommend_io_threads                   7    32        75%
  fold_rotational                                5     8         0%
  storage_describe                               0     9       100%
```

Kill rate is over the *scored* mutants (total minus `compiler`), since a
function whose mutants the build all rejected says nothing about the tests.

## The diff, and the trap it encodes

"Survivors went down by four" is the same number for a change that killed four
and one that killed six and lost two. So the second mode names what went, and
calls out anything that **arrived**:

```
$ scripts/mutate/report.py before.json after.json
src/storage.c: 101 -> 95 survivors
...
killed by the change:
  storage_recommend_io_threads       170  <= -> ==   | if (p->num_devices <= 1)
  storage_recommend_io_threads       171  4 -> 3     | return base < 4 ? base : 4;
  storage_describe                   184  > -> >=    | if (p->num_devices > 1)
  ...
```

**It refuses a per-mutant diff across a changed source.** Line numbers move, so
mapping one run's lines through the other's function map attributes survivors to
whatever now sits at that number — done by hand once here, it produced a
confident report of a regression in `extents_search_init`, a function the change
had not touched. The guard is the mutant population: identical `(line, name)`
multisets mean the same source; anything else falls back to per-function counts
and says so.

## The self-test, and why this tool of all tools needs one

`scripts/mutate/test_report.py` is hermetic — no compiler, no build, no lanes —
and runs in `make lint`.

The first parser walked back over a signature into the doc comment above it, so
all 36 of `read_rotational`'s mutants were filed under **`parent`**, a word taken
from prose describing a partition's parent directory. A plausible name with a
plausible count. This tool is only ever read as the explanation of a number, so
a wrong grouping does not fail — it persuades.

Verified the tests are not decoration: reverting the parser fix turns
`test_a_doc_comment_does_not_become_the_name` red (`'commented' != 'call'`) and
takes an end-to-end case with it; restoring it turns them green.

One detail worth flagging, since it is the same class of bug: the makefile runs
the script directly rather than piping it to `tail -1`. `sh` reports a
pipeline's *last* command, so the tail would return 0 however the tests went and
the check could never fail.

## A live bug: a bug file naming two sources

Found while checking whether an old failure was still reachable. It is, and it
is worse than I remembered — a second `# file:` line does **not** abort. The
adapter takes the first match and ignores the rest, so blocks under the later
heading are applied to the earlier heading's source.

Measured. A block written for `src/util.c`:

```
<<<
	if (base < 1)
===
	if (base < 2)
>>>
```

applied cleanly to `src/storage.c`, where the same text exists and the mutant is
equivalent, and came back:

```
a block that belongs to util.c and cannot apply to storage.c  survived   -
1 caught by a test, 0 by the compiler only, 0 hung, 1 SURVIVED
nothing noticed these - whatever covers them is decoration:
```

That is a test being called decoration when it was never run — and it is the
direction every bug in this tool has erred. It is also how nine blocks in one
file once became three that ran. `make lint` now refuses it, naming both
sources.

## Not in `mutate_core.py`, deliberately

The core is vendored byte-identical into unordered_dense and nanobench and is
tested over there, so changing it is a three-repo errand. `report.py` reads only
the JSON those runs already emit, and nothing about it is oans-specific except
the C function parser. Worth promoting if the other two want it, rather than
paying that cost up front. The lint change is in `scripts/lint-mutate-core.py`,
which is oans's own.

## Gate

`make lint`, `make test` (111 tests, 1,323,841 assertions), `WERROR=1` build,
and `make mutation-replay` across all eleven bug files with nothing surviving.
No valgrind or sanitizer leg this time: the diff contains no C.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_