### PR TITLE
Property-test the long-path chunk boundary, behind a seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,6 +660,22 @@ counterexample. No dependencies, one header, minunit-compatible.
   the named-bug files they earn their place differently again — leaving the
   fiemap address set unsorted is caught by nothing else. Expect that
   unevenness rather than a uniform number.
+  - **`longpath.c`'s chunk boundary is the second clear win, and it needed a
+    seam first.** The split lived inside `open_ancestor()`, which opens each
+    chunk as it goes, so asking what the split *is* meant building a real
+    directory tree of the right shape - and the suite has to stay fast enough
+    that the mutation tool's hang timeout still separates a slow mutant from a
+    caught one. Pulled out as `chunk_end()`, a pure function, it is askable
+    about every path shape for nothing: **65 survivors → 61, and `chunk_end`
+    itself 4 → 0.** All four are the `LONGPATH_MAXLEN + 1` the comment there
+    calls deliberate.
+    - **The first draft left one of them alive, and the residue said which.**
+      `<=` → `<` on the limit differs only at *exactly* `LONGPATH_MAXLEN`, and
+      only matters for a path with **no separator at all** - there the mutant
+      answers `ENAMETOOLONG` for a path that fits. The generator capped
+      components at 300 characters, so it never made a slashless 4095-byte
+      path. One `prop_chance` for that shape took it to zero. Read the residue
+      by function and the generator's gap is what it names.
   - The three **hashfile** properties are the same story a third time:
     `src/dbfile.c` swept with and without them is **786 survivors → 785**,
     one mutant. That one is worth the three, though - `i > 0` → `i > 1` in

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DEPENDS := $(CFILES:.c=.d)
 # or every symbol in them is defined twice. Everything else the suite needs is
 # an ordinary object it shares with the binary.
 TEST_INLINED := file_scan.c progress.c find_dupes.c dbfile.c hash-tree.c \
-		results-tree.c fiemap.c glob.c csum.c interrupt.c
+		results-tree.c fiemap.c glob.c csum.c interrupt.c longpath.c
 TEST_SKIP    := $(addprefix src/,$(TEST_INLINED:.c=.o)) src/oans.o src/run_dedupe.o
 TEST_LINKED  := $(filter-out $(TEST_SKIP),$(OBJECTS))
 TEST_SOURCES := $(sort $(wildcard tests/unit/tu_*.c)) tests/unit/main.c

--- a/src/longpath.c
+++ b/src/longpath.c
@@ -50,6 +50,30 @@ static void close_keep_errno(int fd)
  * rather than one component per call: a ~4 KiB path costs 2-3 opens instead of
  * ~20, and the cost is O(len / PATH_MAX) instead of O(components).
  */
+/*
+ * Where the next chunk ends: the longest prefix of [start, end) that fits one
+ * syscall argument and ends on a component boundary - all of it, or up to the
+ * last '/' within the limit. NULL means a single component longer than any
+ * openat() would accept, which is ENAMETOOLONG.
+ *
+ * Split out of open_ancestor() because this is the arithmetic and the rest is
+ * the walk. Inline it stays unobservable: the caller opens each chunk as it
+ * goes, so asking what the split *is* meant building a real directory tree of
+ * the right shape. Out here it can be asked about every path shape there is
+ * without touching a filesystem, which is what the property test does - and
+ * this is where the mutants lived, 40 of longpath.c's 65 survivors being this
+ * boundary and the loop around it.
+ *
+ * Searching LONGPATH_MAXLEN + 1 bytes is deliberate: it lets a boundary
+ * sitting exactly on the limit count, and the property pins that.
+ */
+static const char *chunk_end(const char *start, const char *end)
+{
+	if ((size_t)(end - start) <= LONGPATH_MAXLEN)
+		return end;
+	return memrchr(start, '/', LONGPATH_MAXLEN + 1);
+}
+
 static int open_ancestor(const char *begin, const char *end)
 {
 	const char *p = begin;
@@ -70,20 +94,8 @@ static int open_ancestor(const char *begin, const char *end)
 		if (p >= end)
 			break;
 
-		/*
-		 * Take the longest prefix of the remainder that fits one syscall
-		 * argument and ends on a component boundary: either all of it, or
-		 * up to the last '/' within the limit. Searching LONGPATH_MAXLEN
-		 * + 1 bytes lets a boundary sitting exactly on the limit count.
-		 * No '/' in range means a single component longer than any
-		 * openat() would accept.
-		 */
 		start = p;
-		if ((size_t)(end - start) <= LONGPATH_MAXLEN)
-			fit = end;
-		else
-			fit = memrchr(start, '/', LONGPATH_MAXLEN + 1);
-
+		fit = chunk_end(start, end);
 		if (!fit) {
 			close_keep_errno(dfd);
 			errno = ENAMETOOLONG;

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -66,6 +66,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_human_duration);
 	MU_RUN(test_num_digits);
 	MU_RUN(test_longpath);
+	MU_RUN(test_prop_a_chunk_ends_on_a_boundary_and_is_the_longest_that_fits);
+	MU_RUN(test_prop_the_chunk_walk_always_advances);
 	MU_RUN(test_glob_basename);
 	MU_RUN(test_glob_anchored_vs_any_depth);
 	MU_RUN(test_glob_wildcards_respect_separators);

--- a/tests/unit/test_longpath.c
+++ b/tests/unit/test_longpath.c
@@ -226,3 +226,157 @@ MU_TEST(test_longpath) {
  * rather than returning false: laundering it into "no match" would let every
  * negative assertion below pass vacuously.
  */
+
+/*
+ * The chunk boundary, over every path shape rather than a handful.
+ *
+ * This is where longpath.c's survivors were: 40 of 65, all in chunk_end() and
+ * the loop around it. The reason a table cannot reach them is that the space
+ * has four independent dimensions - total length, component length, where the
+ * slashes fall, and runs of consecutive slashes - and the interesting cases are
+ * the ones where a boundary lands exactly on LONGPATH_MAXLEN. That is the same
+ * argument that made the sanitize_ctrl properties the one clear win in this
+ * tree: a buffer that runs out at every possible offset.
+ *
+ * No filesystem here. chunk_end() is pure, which is the whole reason it was
+ * split out of open_ancestor() - inline, asking what the split is meant
+ * building a real directory tree of the right shape, and the suite has to stay
+ * fast enough that the mutation tool's hang timeout still separates a slow
+ * mutant from a caught one.
+ */
+#define PROP_PATH_MAX_EXTRA 4096
+
+MU_TEST(test_prop_a_chunk_ends_on_a_boundary_and_is_the_longest_that_fits) {
+	declare_prop(p, 1200);
+	_cleanup_(freep) char *buf = malloc(LONGPATH_MAXLEN + PROP_PATH_MAX_EXTRA + 1);
+
+	if (!buf)
+		abort();
+
+	while (prop_next(&p)) {
+		/*
+		 * Lengths that straddle the limit: shorter than it, exactly it,
+		 * and past it by up to a page. A generator that only made long
+		 * paths would never reach the `<= LONGPATH_MAXLEN` arm.
+		 */
+		size_t len = prop_chance(&p, 4)
+			? LONGPATH_MAXLEN	/* the boundary, exactly */
+			: (size_t)prop_range(&p, LONGPATH_MAXLEN - 64,
+					     LONGPATH_MAXLEN + PROP_PATH_MAX_EXTRA);
+		const char *start, *end, *fit;
+		size_t i = 0;
+
+		/*
+		 * Sometimes no separator at all: one component the whole way.
+		 * That is the only shape where `<=` and `<` on the limit
+		 * differ - at exactly LONGPATH_MAXLEN the first takes the
+		 * whole thing and the second falls through to a search that
+		 * finds nothing and answers ENAMETOOLONG for a path that fits.
+		 * Left out of the first draft, and the `<= -> <` mutant
+		 * survived it.
+		 */
+		if (prop_chance(&p, 6)) {
+			memset(buf, 'a', len);
+			buf[len] = '\0';
+			i = len;
+		}
+
+		/* Components of varied width, with the occasional run of
+		 * slashes - the walk skips those, so they must not shift a
+		 * boundary. */
+		while (i < len) {
+			size_t comp = (size_t)prop_range(&p, 1, 300);
+
+			while (comp-- && i < len)
+				buf[i++] = 'a';
+			if (i < len)
+				buf[i++] = '/';
+			if (i < len && prop_chance(&p, 8))
+				buf[i++] = '/';
+		}
+		buf[len] = '\0';
+		start = buf;
+		end = buf + len;
+
+		fit = chunk_end(start, end);
+		if (!fit) {
+			/*
+			 * The only reason to refuse: no boundary in the first
+			 * LONGPATH_MAXLEN + 1 bytes. Asserted directly rather
+			 * than trusted, since "returns NULL" is otherwise
+			 * satisfied by a function that always refuses.
+			 */
+			prop_check(&p, (size_t)(end - start) > LONGPATH_MAXLEN);
+			prop_check(&p, memchr(start, '/',
+					      LONGPATH_MAXLEN + 1) == NULL);
+			continue;
+		}
+
+		/* Fits one syscall argument. */
+		prop_check(&p, (size_t)(fit - start) <= LONGPATH_MAXLEN);
+		/* Ends on a component boundary, or at the end of the path. */
+		prop_check(&p, fit == end || *fit == '/');
+		/* And is the *longest* such prefix: nothing better was
+		 * available inside the limit. This is the half that a
+		 * `return start` would satisfy without it. */
+		if (fit != end) {
+			const char *rest = fit + 1;
+			size_t room = LONGPATH_MAXLEN - (size_t)(fit - start);
+
+			if (rest < end)
+				prop_check(&p, memchr(rest, '/',
+						      room < (size_t)(end - rest)
+						      ? room : (size_t)(end - rest))
+					   == NULL);
+		}
+	}
+}
+
+MU_TEST(test_prop_the_chunk_walk_always_advances) {
+	declare_prop(p, 600);
+	_cleanup_(freep) char *buf = malloc(LONGPATH_MAXLEN * 3 + 1);
+
+	if (!buf)
+		abort();
+
+	/*
+	 * open_ancestor() loops on chunk_end() and would spin forever on a
+	 * split that does not move `p`. The walk is the part with the openat()
+	 * in it, so this replays its pointer arithmetic and nothing else.
+	 */
+	while (prop_next(&p)) {
+		size_t len = (size_t)prop_range(&p, 1, LONGPATH_MAXLEN * 3);
+		const char *q, *end;
+		size_t i = 0, steps = 0;
+
+		while (i < len) {
+			size_t comp = (size_t)prop_range(&p, 1, 900);
+
+			while (comp-- && i < len)
+				buf[i++] = 'a';
+			if (i < len)
+				buf[i++] = '/';
+		}
+		buf[len] = '\0';
+		q = buf;
+		end = buf + len;
+
+		while (q < end) {
+			const char *start, *fit;
+
+			while (q < end && *q == '/')
+				q++;
+			if (q >= end)
+				break;
+			start = q;
+			fit = chunk_end(start, end);
+			if (!fit)
+				break;
+			prop_check(&p, fit > start);	/* or the loop spins */
+			q = fit;
+			if (++steps > len + 2)
+				break;			/* fail below, not hang */
+		}
+		prop_check(&p, steps <= len + 1);
+	}
+}

--- a/tests/unit/tu_longpath.c
+++ b/tests/unit/tu_longpath.c
@@ -1,0 +1,12 @@
+/*
+ * Paths past PATH_MAX (#117).
+ *
+ * Its own translation unit since the chunk-boundary property reaches
+ * chunk_end(), which is static: the arithmetic is the part worth asking about
+ * over every path shape, and it is only observable from inside longpath.c.
+ */
+#include "suite.h"
+
+#include "longpath.c"
+
+#include "test_longpath.c"

--- a/tests/unit/tu_plain.c
+++ b/tests/unit/tu_plain.c
@@ -7,6 +7,5 @@
 /* filerec.c is linked, so these reach only its public API. */
 #include "test_filerec.c"
 #include "test_util.c"
-#include "test_longpath.c"
 #include "test_storage.c"
 #include "test_dedupe.c"


### PR DESCRIPTION
`longpath.c` had **65 survivors of 169**, and 40 of them were the chunk-splitting
arithmetic in `open_ancestor()` — the shape where properties have paid in this
tree and, measurably, nowhere else.

## Why this one and not more properties generally

Four A/B tests of properties in oans have moved **10, 0, 1, 0** mutants. They pay
at *tabulation-resistant boundaries* (`sanitize_ctrl`'s truncation arithmetic) and
gain nothing where a table already covers the space (`glob.c`). 28 of 111 tests
were already properties, across 8 of 14 subjects, so "add more" had a poor prior.

`longpath.c` is the exception, and I checked before writing anything — classifying
its 65 survivors:

| kind | count | property-reachable? |
|---|---|---|
| **boundary arithmetic** | **40** | **yes** |
| syscall / errno paths | 12 | no |
| other | 13 | partly |

The space is total length × component length × where the slashes fall × runs of
consecutive slashes, with the interesting cases landing exactly on
`LONGPATH_MAXLEN`. A table cannot enumerate that.

## The arithmetic wasn't observable, so it needed a seam

`open_ancestor()` opens each chunk as it goes, so asking what the split *is* meant
building a real directory tree of the right shape — and the suite has to stay fast,
because the mutation tool derives a mutant's hang timeout from a green run.

So the split is now `chunk_end()`, a pure function — the same move
`dedupe_classify_probe` exists as. The walk keeps the `openat()`.

Two properties: a chunk fits one syscall argument, ends on a component boundary,
and is the **longest** such prefix; and the walk always advances, which is what
stops `open_ancestor()` spinning.

## Measured

Same source, properties removed and restored:

```
src/longpath.c: 65 -> 61 survivors
  chunk_end        4 -> 0
killed by the change:
  chunk_end  72  <= -> <   | if ((size_t)(end - start) <= LONGPATH_MAXLEN
  chunk_end  74  + -> -    | return memrchr(start, '/', LONGPATH_MAXLEN +
  chunk_end  74  1 -> 0    | …
  chunk_end  74  1 -> 2    | …
```

All four are the `LONGPATH_MAXLEN + 1` that the comment there calls deliberate,
and nothing else in the suite held them.

**The first draft left one alive, and the residue named the gap.** `<=` → `<` on
the limit differs only at *exactly* `LONGPATH_MAXLEN`, and only for a path with
**no separator at all** — there the mutant answers `ENAMETOOLONG` for a path that
fits. My generator capped components at 300 characters, so it never built a
slashless 4095-byte path. One `prop_chance` for that shape took `chunk_end` to
zero.

## Cost

**1.23 s against a 1.20 s baseline, +2%** — measured, because CLAUDE.md is
explicit that a slow suite reclassifies slow mutants as `hang` instead of letting
a test catch them. `longpath.c` gets its own translation unit, since the property
reaches a static.

## Gate

`make lint` (five checks), `WERROR=1` build and suite, `SANITIZE=address,undefined`,
valgrind with `--error-exitcode=42` (0 definitely-lost, 0 errors),
`make mutation-replay` across all eleven bug files with nothing surviving, and
three `OANS_PROPTEST_SEED=random` runs. 113 tests / 1,328,833 assertions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_