### PR TITLE
Reach the fault-injection residue — and fix WERROR=1 silently disabling -O2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,19 @@ exactly where UB-sensitive differences hide, and this file already records that
   compiled with, grouped - which is how the mixed build was found (19 TUs at
   `-O0`, one at `-O2` from a stray plain `make`). An object-size comparison sent
   me the wrong way twice; the producer string cannot.
+- **It also surfaced a name collision that had been latent for years.**
+  `src/debug.h` defines macros called `dprintf` and `vprintf`, which are also
+  POSIX and C89 functions - and glibc turns both into macros in
+  `bits/stdio2.h` *only when `_FORTIFY_SOURCE` is on*, which needs
+  optimization. clang then reports `-Wmacro-redefined` and `-Werror` stops the
+  build; gcc does not. So the combination that fails is clang + WERROR + `-O2`,
+  which is exactly the build nobody had ever run. `#undef` first, and note that
+  shadowing two libc names is still a trap for whoever wants the real ones -
+  renaming them is a tree-wide change for its own commit.
+- **Gate a build-flag change under *both* compilers.** The sanitizer leg is the
+  only clang build in the local gate and it uses `-O1` with no hardening (the
+  makefile says why), so clang + `-O2` + FORTIFY was unbuilt locally and went
+  red in CI. `CC=clang WERROR=1 make` is one command.
 - **Fixing it immediately surfaced two `-Wformat-truncation` warnings CI had
   never seen**, because that analysis needs optimization to run at all. Both
   were deliberate truncations whose intent lived in a comment; they now spell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,59 @@ else.
 - **Adding a subject is two edits**: the `test_*.c`, and its `#include` in the
   right `tu_*.c` (plus `TEST_INLINED` if it needs a static).
 
+## WERROR=1 was silently disabling -O2, in every CI job
+
+`ifdef WERROR` does `override CFLAGS += -Werror`, and **once a variable carries
+the `override` origin GNU make ignores every later ordinary assignment to it**.
+The release block's `CFLAGS += -O2 $(HARDENING)` sat below that, so with WERROR
+set it evaporated. No warning, no error - just a different binary.
+
+`.github/workflows/ci.yml` sets `WERROR: 1` for every job, so every check this
+project runs - btrfs, xfs, the four valgrind shards, the three sanitizer legs,
+the mutation sweep - was verifying `-O0` code while what ships is `-O2`. That is
+exactly where UB-sensitive differences hide, and this file already records that
+17 of `dbfile.c`'s 1,879 mutants differ between the two builds.
+
+- **The fix is one word**: `override CFLAGS += -O2 $(HARDENING)`. Order does not
+  save you - any later plain assignment loses, wherever it sits.
+- **`scripts/lint-build-flags.py` asserts it** rather than a comment claiming
+  it, because the original comment was right and the code was wrong for however
+  long CI has been green. It asks `make -Bn` what it would run with and without
+  `WERROR` and compares the `-O` level. `-Bn` and not `-n`: with the tree built,
+  `make -n` prints nothing and a check reading an empty command list passes for
+  the wrong reason.
+- **Diagnose this from the binary, not the makefile.** `readelf
+  --debug-dump=info ./test | grep DW_AT_producer` prints the flags gcc actually
+  compiled with, grouped - which is how the mixed build was found (19 TUs at
+  `-O0`, one at `-O2` from a stray plain `make`). An object-size comparison sent
+  me the wrong way twice; the producer string cannot.
+- **Fixing it immediately surfaced two `-Wformat-truncation` warnings CI had
+  never seen**, because that analysis needs optimization to run at all. Both
+  were deliberate truncations whose intent lived in a comment; they now spell
+  the bound out in code the compiler can follow.
+- **The suite is ~2x faster optimized** - measured on the property soak, 221 s →
+  109 s for an identical 659,961,110 assertions. The fixed ~0.85 s of startup
+  does not optimize, so small runs show less.
+
+## Soaking the property tests
+
+`OANS_PROPTEST_SCALE=100 ./test` multiplies every property's case count. A
+multiplier rather than a fixed number, so the ordinary run keeps the count each
+property chose - those are tuned, and the glob ones are shaped around what
+compiling a `GRegex` costs.
+
+- **A soak extends a run rather than replacing it.** Each property draws from
+  its own stream, so the first N cases of a soak are exactly the cases an
+  unscaled run would try. A failure at case 40,000 is something the default
+  genuinely could not reach, and still names the seed and case to replay.
+- **The wide pass is the half that teaches.** Six random seeds at scale 100 say
+  the properties are not tuned to the default seed; the deep pass at scale 500
+  mostly confirms, since more cases cannot find a bug in a property that is
+  already a tautology - and this tree has had one of those.
+- Measured clean at ~1.45 billion assertions across seven runs. Read that as
+  "no rare input shape is missing from the generators", not as "the properties
+  are good".
+
 ## Mutation & property testing (the C unit suite)
 
 Two additions to the C unit suite's side of the house (`tests/unit/`). Neither touches the

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,16 @@ else
 	# Release hardening (needs optimization, hence not in the debug build).
 	# Override with HARDENING= to disable.
 	HARDENING ?= -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection
-	CFLAGS += -O2 $(HARDENING)
+	# `override`, and it is load-bearing. WERROR=1 does `override CFLAGS +=`
+	# above, and once a variable carries that origin GNU make *ignores* every
+	# later ordinary assignment to it - so a plain `CFLAGS +=` here vanished
+	# whenever WERROR was set, with no warning. CI sets WERROR=1 for every job,
+	# so every check this project runs was building -O0 while what ships is
+	# -O2: the sanitizer legs, valgrind and the mutation sweep were all
+	# measuring code the release never executes. Verified by DW_AT_producer,
+	# which records what the compiler actually did rather than what the
+	# makefile appears to say.
+	override CFLAGS += -O2 $(HARDENING)
 	LIBRARY_FLAGS += -Wl,-z,relro -Wl,-z,now
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DEPENDS := $(CFILES:.c=.d)
 # or every symbol in them is defined twice. Everything else the suite needs is
 # an ordinary object it shares with the binary.
 TEST_INLINED := file_scan.c progress.c find_dupes.c dbfile.c hash-tree.c \
-		results-tree.c fiemap.c glob.c csum.c interrupt.c longpath.c
+		results-tree.c fiemap.c glob.c csum.c interrupt.c longpath.c storage.c
 TEST_SKIP    := $(addprefix src/,$(TEST_INLINED:.c=.o)) src/oans.o src/run_dedupe.o
 TEST_LINKED  := $(filter-out $(TEST_SKIP),$(OBJECTS))
 TEST_SOURCES := $(sort $(wildcard tests/unit/tu_*.c)) tests/unit/main.c

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ integration-valgrind: oans
 lint:
 	@python3 scripts/lint-longpath.py
 	@python3 scripts/lint-escape.py
+	@python3 scripts/lint-build-flags.py
 	@python3 scripts/lint-test-registry.py
 	@python3 scripts/lint-mutate-core.py
 	@python3 scripts/mutate/test_report.py

--- a/scripts/lint-build-flags.py
+++ b/scripts/lint-build-flags.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""WERROR=1 must not change what the compiler optimizes.
+
+This exists because it silently did, for however long CI has been running.
+
+`ifdef WERROR` does `override CFLAGS += -Werror` near the top of the Makefile,
+and once a variable carries the `override` origin GNU make **ignores every
+later ordinary assignment to it**. The release block's `CFLAGS += -O2
+$(HARDENING)` sat below that, so with WERROR set it evaporated - no warning, no
+error, just a different binary.
+
+.github/workflows/ci.yml sets `WERROR: 1` for every job, so every check this
+project runs - btrfs, xfs, the four valgrind shards, the three sanitizer legs,
+the mutation sweep - was verifying -O0 code while what ships is -O2. That is
+the configuration where UB-sensitive differences hide, and CLAUDE.md already
+records that 17 of dbfile.c's 1,879 mutants differ between the two builds.
+
+Nothing noticed because a build that is merely *slower and less checked* still
+passes every test. A comment would rot the same way the original did, so the
+invariant is asserted instead: ask make what it would run, and compare.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+OPT = re.compile(r"(?:^|\s)(-O[0-3sgz])(?:\s|$)")
+
+
+def first_compile_flags(env_extra):
+    """The -O level make would use for a test object.
+
+    `-B` because `make -n` alone prints nothing when the tree is already
+    built, and a check that silently examines an empty command list would
+    pass for the wrong reason.
+    """
+    out = subprocess.run(["make", "-Bn", "test-build"], cwd=REPO, text=True,
+                         capture_output=True,
+                         env={**dict(__import__("os").environ), **env_extra})
+    for line in out.stdout.split("\n"):
+        if line.lstrip().startswith(("cc ", "gcc ", "clang ", "$(CC)")) and ".c" in line:
+            found = OPT.findall(line)
+            return found[-1] if found else None
+    return None
+
+
+def main():
+    plain = first_compile_flags({})
+    werror = first_compile_flags({"WERROR": "1"})
+
+    if plain is None:
+        sys.stderr.write("lint-build-flags: no optimization flag in a plain "
+                         "build - the release block is not being applied\n")
+        return 1
+    if werror != plain:
+        sys.stderr.write(
+            "lint-build-flags: WERROR changes the optimization level\n"
+            "  plain build:    %s\n  WERROR=1 build: %s\n\n"
+            "Almost certainly the `override` bug again: `ifdef WERROR` marks\n"
+            "CFLAGS with the override origin, and make then ignores any later\n"
+            "plain `CFLAGS +=`. The release block must use `override` too.\n"
+            "CI sets WERROR=1 for every job, so this makes every check run\n"
+            "against a build that is not the one being shipped.\n"
+            % (plain, werror or "no -O at all"))
+        return 1
+    print("lint-build-flags: WERROR keeps %s" % plain)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/debug.h
+++ b/src/debug.h
@@ -33,7 +33,24 @@ extern int quiet;
 /*
  * All four print around the live progress block; see progress_printf() in
  * progress.c for what that costs and why every message must go through it.
+ *
+ * Two of these names are also libc's. `dprintf(3)` is POSIX and `vprintf(3)`
+ * is C89, and glibc turns both into macros in bits/stdio2.h *when
+ * _FORTIFY_SOURCE is on* - which needs optimization, so a -O0 build never sees
+ * them. clang then reports -Wmacro-redefined and -Werror stops the build; gcc
+ * does not. That combination went unbuilt for as long as WERROR=1 was
+ * silently dropping -O2 (see scripts/lint-build-flags.py), which is why this
+ * only surfaced now.
+ *
+ * Undefining first is safe here rather than merely quiet: every `dprintf(` in
+ * the tree is this macro - format string first - and nothing calls POSIX
+ * dprintf(fd, ...) or C vprintf(fmt, ap). Shadowing two libc names is still a
+ * trap for whoever wants the real ones one day; renaming them is a
+ * tree-wide change and belongs in its own commit, not in a build fix.
  */
+#undef dprintf
+#undef vprintf
+
 #define dprintf(format, ...) if (debug) progress_printf(stdout, format, ##__VA_ARGS__)
 #define vprintf(format, ...) if (verbose) progress_printf(stdout, format, ##__VA_ARGS__)
 #define qprintf(format, ...) if (!quiet) progress_printf(stdout, format, ##__VA_ARGS__)

--- a/src/progress.c
+++ b/src/progress.c
@@ -351,12 +351,27 @@ static void ellipsize_path(const char *path, char *out, size_t out_len,
 
 void progress_copy_path(char *dst, size_t cap, const char *src)
 {
+	size_t n;
+
 	if (cap == 0)
 		return;
-	if (strlen(src) < cap || cap < ELIDE_MIN_CAP)
-		snprintf(dst, cap, "%s", src);
-	else
+	if (strlen(src) >= cap && cap >= ELIDE_MIN_CAP) {
 		ellipsize_path(src, dst, cap, (int)cap - 3);
+		return;
+	}
+
+	/*
+	 * A plain truncating copy, and the truncation is deliberate - a buffer
+	 * too small to elide cleanly is documented above as getting exactly
+	 * this. snprintf() does the same thing, but -Wformat-truncation cannot
+	 * tell a deliberate truncation from an accidental one and warns at -O2,
+	 * so the bound is spelled out instead of implied.
+	 */
+	n = strlen(src);
+	if (n >= cap)
+		n = cap - 1;
+	memcpy(dst, src, n);
+	dst[n] = '\0';
 }
 
 static const char *const stage_name[STAGE_COUNT] = {

--- a/src/proptest.h
+++ b/src/proptest.h
@@ -63,6 +63,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -221,12 +222,65 @@ static inline uint64_t prop_stream(const char *name)
 	return h;
 }
 
+/*
+ * How many times more than a property asks for. `OANS_PROPTEST_SCALE=100 ./test`
+ * is a soak run: the same properties, two orders of magnitude more cases.
+ *
+ * A multiplier rather than a fixed count, so the ordinary run stays the
+ * number each property chose for itself - those are tuned, and the glob ones
+ * in particular are shaped around how expensive compiling a GRegex is.
+ *
+ * Each property still draws from its own stream, so scaling *extends* a run
+ * rather than replacing it: the first N cases of a soak are exactly the cases
+ * an unscaled run would have tried. A soak that fails at case 40,000 says
+ * something the default run genuinely could not have found, and the failure
+ * still names the seed and the case number to replay it.
+ *
+ * File scope and defined once, for the reason prop_seed_value is: a `static`
+ * inside a `static inline` is per translation unit, and the suite is eight of
+ * them.
+ */
+#ifndef PROP_SCALE_MAX
+#define PROP_SCALE_MAX 100000u
+#endif
+
+extern unsigned int prop_scale_value;
+extern bool prop_scale_resolved;
+
+static inline unsigned int prop_scale(void)
+{
+	const char *env;
+
+	if (prop_scale_resolved)
+		return prop_scale_value;
+	prop_scale_resolved = true;
+	prop_scale_value = 1;
+	env = getenv("OANS_PROPTEST_SCALE");
+	if (env) {
+		unsigned long v = strtoul(env, NULL, 0);
+
+		if (v >= 1 && v <= PROP_SCALE_MAX)
+			prop_scale_value = (unsigned int)v;
+		else
+			printf("\n[proptest] ignoring OANS_PROPTEST_SCALE=%s "
+			       "(want 1..%u)\n", env, PROP_SCALE_MAX);
+	}
+	if (prop_scale_value != 1)
+		printf("\n[proptest] soak: %ux the usual cases\n",
+		       prop_scale_value);
+	return prop_scale_value;
+}
+
 static inline struct prop prop_init(const char *name, unsigned int iterations)
 {
 	struct prop p = {
 		.state = prop_stream(name),
 		.iteration = 0,
-		.iterations = iterations,
+		/* Saturating: a scale big enough to overflow would mean a run
+		 * nobody waits for anyway, so clamp rather than wrap to a
+		 * *smaller* number than asked for. */
+		.iterations = (iterations > UINT_MAX / prop_scale())
+			      ? UINT_MAX : iterations * prop_scale(),
 	};
 
 	return p;

--- a/src/storage.c
+++ b/src/storage.c
@@ -35,20 +35,33 @@
  * partitions have no queue/ of their own, so we retry via the parent ("..",
  * which resolves against the symlink target's real directory).
  */
-static int read_rotational(dev_t dev, bool *rot)
+/*
+ * The sysfs root, so a test can point this at a tree it built.
+ *
+ * This is the one place in the residue that genuinely needed a seam rather
+ * than a hostile fixture: the ioctl wrappers take an fd and the sqlite paths
+ * have query_only, but this builds an absolute path and reads it, so nothing a
+ * caller controls decides what it opens. 29 of its 36 mutants survived because
+ * of that - the two path forms, the open-fails-so-try-the-next branch, the
+ * short-read branch and the `!= '0'` are all real behaviour with no way in.
+ *
+ * A parameter, not an environment variable: the product must not grow a knob
+ * that changes where it reads hardware facts from.
+ */
+static int read_rotational_at(const char *sysfs, dev_t dev, bool *rot)
 {
-	static const char *const forms[] = {
-		"/sys/dev/block/%u:%u/queue/rotational",
-		"/sys/dev/block/%u:%u/../queue/rotational",
+	const char *forms[] = {
+		"%s/dev/block/%u:%u/queue/rotational",
+		"%s/dev/block/%u:%u/../queue/rotational",
 	};
-	char path[64];
+	char path[PATH_MAX];
 	unsigned maj = major(dev), min = minor(dev);
 
 	for (size_t i = 0; i < sizeof(forms) / sizeof(forms[0]); i++) {
 		char c;
 		int fd, n;
 
-		snprintf(path, sizeof(path), forms[i], maj, min);
+		snprintf(path, sizeof(path), forms[i], sysfs, maj, min);
 		/* longpath-ok: a generated /sys path, never a scanned file. */
 		fd = open(path, O_RDONLY | O_CLOEXEC);
 		if (fd < 0)
@@ -62,6 +75,11 @@ static int read_rotational(dev_t dev, bool *rot)
 		}
 	}
 	return -ENOENT;
+}
+
+static int read_rotational(dev_t dev, bool *rot)
+{
+	return read_rotational_at("/sys", dev, rot);
 }
 
 /* Merge one device's rotational reading into the aggregate profile. */

--- a/tests/unit/fixtures.h
+++ b/tests/unit/fixtures.h
@@ -98,6 +98,29 @@ struct fm_rec { uint64_t log, phys, len; uint32_t flags; };
 		abort();
 	sqlite3_free(err);
 }
+
+/*
+ * Make this connection refuse writes.
+ *
+ * dbfile.c has 82 `perror_sqlite` + `goto out` pairs and no unit test could
+ * reach one: they guard a bind or a step failing, which a healthy in-memory
+ * database never does. That was triaged as "the next honest move is a
+ * fault-injection seam" - and the seam turns out to be sqlite's own, needing
+ * no change to the product at all.
+ *
+ * `query_only` is a *connection* setting, so poisoning one handle leaves the
+ * shared in-memory database every other test uses untouched. Writes then fail
+ * at step with SQLITE_READONLY, which is exactly the shape those pairs handle.
+ *
+ * What this pins is the invariant that matters for a cache nothing downstream
+ * validates: a write that failed must be *reported*, not swallowed into a run
+ * that exits 0 and looks like a correct one.
+ */
+[[maybe_unused]] static void db_refuse_writes(struct dbhandle *db)
+{
+	exec(db, "PRAGMA query_only = ON");
+}
+
 [[maybe_unused]] static uint64_t rows(struct dbhandle *db, const char *table)
 {
 	char sql[64];

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -31,6 +31,8 @@ void (*minunit_setup)(void) = NULL;
 void (*minunit_teardown)(void) = NULL;
 uint64_t prop_seed_value;
 bool prop_seed_resolved;
+unsigned int prop_scale_value;
+bool prop_scale_resolved;
 
 unsigned int blocksize = DEFAULT_BLOCKSIZE;
 char *exec_path;

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -55,6 +55,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_progress_path_two_stage_render);
 	MU_RUN(test_storage_recommend_io_threads);
 	MU_RUN(test_storage_describe);
+	MU_RUN(test_read_rotational_reads_what_sysfs_says);
 	MU_RUN(test_prop_a_recommendation_is_never_zero_and_never_over_the_cap);
 	MU_RUN(test_scan_bucket);
 	MU_RUN(test_scan_workq_priority);
@@ -117,6 +118,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_fiemap_maps_a_real_file);
 	MU_RUN(test_fiemap_range_answers_for_the_range_asked_for);
 	MU_RUN(test_fiemap_counts_nothing_shared_in_a_fresh_file);
+	MU_RUN(test_a_refused_ioctl_is_an_error_not_a_zero_answer);
+	MU_RUN(test_a_closed_descriptor_is_refused_too);
 	MU_RUN(test_dedupe_classify_probe);
 
 	/* The hashfile, against an in-memory SQLite - the same path a run
@@ -130,6 +133,8 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_dbfile_layout_matches_compares_every_record);
 	MU_RUN(test_dbfile_copying_a_donor_brings_all_three);
 	MU_RUN(test_dbfile_a_stored_file_round_trips_every_field);
+	MU_RUN(test_a_refused_write_is_reported_rather_than_swallowed);
+	MU_RUN(test_reads_still_answer_while_writes_are_refused);
 	MU_RUN(test_dbfile_hashes_round_trip_their_offsets);
 	MU_RUN(test_dbfile_load_checkpoint_declines_what_it_cannot_vouch_for);
 	MU_RUN(test_dbfile_pruning_keeps_what_still_exists);

--- a/tests/unit/suite.h
+++ b/tests/unit/suite.h
@@ -51,6 +51,7 @@
 #include "opt.h"
 #include "util.h"
 #include "debug.h"
+#include "btrfs-util.h"
 #include "dedupe.h"
 #include "glob.h"
 #include "storage.h"

--- a/tests/unit/test_btrfs_util.c
+++ b/tests/unit/test_btrfs_util.c
@@ -1,0 +1,63 @@
+/*
+ * The btrfs ioctl wrappers, asked what they do when the ioctl says no.
+ *
+ * Compiled as part of tu_plain.c: these are public, so nothing here needs a
+ * static.
+ *
+ * All 28 of this file's mutants used to survive, and the triage said the only
+ * honest move was a fault-injection seam. It turns out no seam is needed for
+ * half of it: every one of these takes an `fd`, so handing it a descriptor
+ * that is not a btrfs subvolume makes the kernel refuse and the error path
+ * runs. That is not a stub or an injected failure - it is the real ioctl
+ * returning the real errno a non-btrfs filesystem returns, which is the case
+ * oans meets whenever someone points it at ext4.
+ *
+ * The success paths still need btrfs and stay uncovered here; CI runs the
+ * end-to-end suite on it.
+ */
+
+/* A descriptor that is definitely not a btrfs subvolume. */
+static int not_a_subvol(void)
+{
+	int fd = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+
+	if (fd < 0)
+		abort();
+	return fd;
+}
+
+MU_TEST(test_a_refused_ioctl_is_an_error_not_a_zero_answer) {
+	int fd = not_a_subvol();
+	uint64_t subvol = 12345;
+	uuid_t uuid;
+	bool rdonly = true;
+
+	/*
+	 * Each must *report*. Answering 0 while leaving the out-parameter
+	 * untouched is the failure that matters: a caller then treats
+	 * uninitialised stack as a subvolume id, a filesystem uuid, or a
+	 * read-only flag - and #182 turns on precisely that last one.
+	 */
+	mu_assert(lookup_btrfs_subvol(fd, &subvol) != 0,
+		  "a refused SUBVOL_INFO reported success");
+	mu_assert(btrfs_get_fsuuid(fd, &uuid) != 0,
+		  "a refused FS_INFO reported success");
+	mu_assert(btrfs_subvol_is_readonly(fd, &rdonly) != 0,
+		  "a refused GET_SUBVOL_INFO reported success");
+
+	close(fd);
+}
+
+MU_TEST(test_a_closed_descriptor_is_refused_too) {
+	int fd = not_a_subvol();
+	uint64_t subvol;
+
+	close(fd);
+	/*
+	 * EBADF rather than ENOTTY, so this is a different errno down the same
+	 * branch - which is what says the wrapper checks the return value and
+	 * not one particular error.
+	 */
+	mu_assert(lookup_btrfs_subvol(fd, &subvol) != 0,
+		  "an ioctl on a closed descriptor reported success");
+}

--- a/tests/unit/test_dbfile.c
+++ b/tests/unit/test_dbfile.c
@@ -1379,3 +1379,90 @@ MU_TEST(test_a_file_with_nothing_unique_yields_no_nondupe_extents) {
  * at the time.
  * ---------------------------------------------------------------------------
  */
+
+/*
+ * What every `perror_sqlite` + `goto out` pair is for.
+ *
+ * dbfile.c has 82 of them and until now no unit test reached one: they guard a
+ * bind or a step failing, which a healthy in-memory database never does. The
+ * residue was triaged as needing a fault-injection seam - and the seam is
+ * sqlite's own `query_only`, which needs no change to the product.
+ *
+ * The invariant is the one that matters for a cache nothing downstream
+ * validates. A hashfile is not checked by anything that reads it, so a write
+ * that failed and *said so* costs one re-hash, while a write that failed and
+ * returned success produces a run that exits 0, looks correct, and has a hole
+ * in it. Every one of these asserts the first and would fail on the second.
+ */
+MU_TEST(test_a_refused_write_is_reported_rather_than_swallowed) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t fileid;
+	struct file f;
+	unsigned char digest[DIGEST_LEN];
+	struct block_csum block;
+	struct scan_checkpoint cp;
+	struct run_record run;
+
+	/* A real row first, on a healthy connection, so the ids below are not
+	 * themselves the reason a write fails. */
+	fileid = put_file(db, "/refused", 4001, 1);
+	mu_check(fileid > 0);
+
+	db_refuse_writes(db);
+
+	/* Each of these binds and steps a write. Under query_only the step
+	 * answers SQLITE_READONLY, which is precisely the branch the pairs
+	 * guard - and the answer must not be "fine". */
+	memset(&f, 0, sizeof(f));
+	f.filename = "/also-refused";
+	f.ino = 4002;
+	f.subvol = 1;
+	f.size = 4096;
+	f.mtime = 222;
+	mu_assert(dbfile_store_file_info(db, &f) <= 0,
+		  "a refused insert reported a rowid");
+
+	memset(digest, 0xcd, sizeof(digest));
+	mu_assert(dbfile_update_scanned_file(db, fileid, digest, 0, 1) != 0,
+		  "a refused digest update reported success");
+
+	memset(&block, 0, sizeof(block));
+	block.loff = 0;
+	memcpy(block.digest, digest, DIGEST_LEN);
+	mu_assert(dbfile_store_block_hashes(db, fileid, 1, &block) != 0,
+		  "a refused block-hash write reported success");
+
+	memset(&cp, 0, sizeof(cp));
+	cp.loff = 4096;
+	cp.mtime = 222;
+	cp.size = 4096;
+	mu_assert(dbfile_store_checkpoint(db, fileid, &cp) != 0,
+		  "a refused checkpoint reported success - the one write whose\n"
+		  "  whole purpose is that a later run can trust it");
+
+	memset(&run, 0, sizeof(run));
+	run.files_scanned = 1;
+	mu_assert(dbfile_record_run(db, &run) != 0,
+		  "a refused run-history append reported success");
+}
+
+/*
+ * The read side still works while writes are refused.
+ *
+ * Without this the test above is satisfied by a connection that is simply
+ * broken - every call failing for any reason would pass it. This is what makes
+ * "the write was refused" a different statement from "nothing works".
+ */
+MU_TEST(test_reads_still_answer_while_writes_are_refused) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	int64_t fileid = put_file(db, "/still-readable", 4010, 1);
+	struct file out;
+
+	mu_check(fileid > 0);
+	db_refuse_writes(db);
+
+	memset(&out, 0, sizeof(out));
+	mu_check(dbfile_describe_file(db, 4010, 1, &out) == 0);
+	mu_assert(out.id == fileid,
+		  "the read path stopped answering, so the test above proves nothing");
+}

--- a/tests/unit/test_dbfile.c
+++ b/tests/unit/test_dbfile.c
@@ -1465,4 +1465,7 @@ MU_TEST(test_reads_still_answer_while_writes_are_refused) {
 	mu_check(dbfile_describe_file(db, 4010, 1, &out) == 0);
 	mu_assert(out.id == fileid,
 		  "the read path stopped answering, so the test above proves nothing");
+	/* describe_file strdup()s the name into `out`; dbfile.h says free it
+	 * through file_cleanup(). LeakSanitizer caught this missing. */
+	file_cleanup(&out);
 }

--- a/tests/unit/test_storage.c
+++ b/tests/unit/test_storage.c
@@ -174,7 +174,7 @@ static void rm_rf(const char *path)
 static void fake_rotational(const char *root, unsigned maj, unsigned min,
 			    const char *content)
 {
-	char dir[PATH_MAX], file[PATH_MAX], cmd[PATH_MAX + 16];
+	char dir[PATH_MAX / 2], file[PATH_MAX], cmd[PATH_MAX + 32];
 	FILE *f;
 
 	snprintf(dir, sizeof(dir), "%s/dev/block/%u:%u/queue", root, maj, min);

--- a/tests/unit/test_storage.c
+++ b/tests/unit/test_storage.c
@@ -144,7 +144,16 @@ MU_TEST(test_storage_describe) {
 	p = (struct storage_profile){ .rotational = true,
 		.rotational_known = true, .num_devices = 12 };
 	memset(buf, 'x', sizeof(buf));
-	storage_describe(&p, buf, 12);
+	/*
+	 * volatile so the size is not a compile-time constant. storage.c is
+	 * #included into this TU, so at -O2 gcc can otherwise see a literal 12
+	 * reaching snprintf() and reports the truncation this test exists to
+	 * cause - a warning about the test, raised against the product. No
+	 * production caller passes a buffer this small.
+	 */
+	volatile size_t small = 12;
+
+	storage_describe(&p, buf, small);
 	mu_assert_string_eq("btrfs pool ", buf);	/* 11 chars + NUL */
 	mu_check(buf[12] == 'x');	/* nothing written past the length */
 }

--- a/tests/unit/test_storage.c
+++ b/tests/unit/test_storage.c
@@ -148,3 +148,104 @@ MU_TEST(test_storage_describe) {
 	mu_assert_string_eq("btrfs pool ", buf);	/* 11 chars + NUL */
 	mu_check(buf[12] == 'x');	/* nothing written past the length */
 }
+
+/*
+ * read_rotational, against a sysfs tree the test builds.
+ *
+ * The seam is read_rotational_at()'s root parameter, and it is the only one
+ * the residue actually needed: everything else that looked unreachable takes
+ * an fd or a database handle a test already controls. This builds an absolute
+ * path and opens it, so without the parameter there is no way in at all - 29
+ * of its 36 mutants survived on that.
+ *
+ * What is exercised here is real: a real open() of a real file, returning the
+ * real errno when it is missing. Nothing is stubbed.
+ */
+static void rm_rf(const char *path)
+{
+	char cmd[PATH_MAX + 16];
+
+	snprintf(cmd, sizeof(cmd), "rm -rf '%s'", path);
+	if (system(cmd) < 0)
+		abort();
+}
+
+/* Writes `content` to <root>/dev/block/<maj>:<min>/queue/rotational. */
+static void fake_rotational(const char *root, unsigned maj, unsigned min,
+			    const char *content)
+{
+	char dir[PATH_MAX], file[PATH_MAX], cmd[PATH_MAX + 16];
+	FILE *f;
+
+	snprintf(dir, sizeof(dir), "%s/dev/block/%u:%u/queue", root, maj, min);
+	snprintf(cmd, sizeof(cmd), "mkdir -p '%s'", dir);
+	if (system(cmd) < 0)
+		abort();
+	snprintf(file, sizeof(file), "%s/rotational", dir);
+	f = fopen(file, "w");
+	if (!f)
+		abort();
+	fputs(content, f);
+	fclose(f);
+}
+
+MU_TEST(test_read_rotational_reads_what_sysfs_says) {
+	char root[] = "/tmp/oans-sysfs-XXXXXX";
+	bool rot = true;
+
+	if (!mkdtemp(root))
+		abort();
+
+	/* Absent: neither path form exists, so it must say so rather than
+	 * leave `rot` at whatever the caller had. */
+	rot = true;
+	mu_assert(read_rotational_at(root, makedev(7, 0), &rot) == -ENOENT,
+		  "a missing sysfs entry was not reported");
+
+	/* '0' is an SSD, and anything else is a spinner - the test is on the
+	 * byte, not on truthiness, which is what `c != '0'` means. */
+	fake_rotational(root, 8, 0, "0\n");
+	mu_check(read_rotational_at(root, makedev(8, 0), &rot) == 0);
+	mu_assert(!rot, "'0' was read as rotational");
+
+	fake_rotational(root, 8, 16, "1\n");
+	mu_check(read_rotational_at(root, makedev(8, 16), &rot) == 0);
+	mu_assert(rot, "'1' was not read as rotational");
+
+	/*
+	 * A partition, which is the whole reason there are two forms.
+	 *
+	 * In sysfs /sys/dev/block/8:1 is a *symlink* to the partition's real
+	 * directory, which has no queue/ of its own - so `..` resolves against
+	 * the symlink target and lands on the parent disk, which does. The
+	 * fixture has to be that shape or the first form finds the file and
+	 * the second is never reached: built the obvious way, with a real
+	 * directory holding queue/rotational, deleting the second form outright
+	 * left this test green.
+	 */
+	{
+		char cmd[PATH_MAX * 2];
+
+		snprintf(cmd, sizeof(cmd),
+			 "mkdir -p '%s/devices/sda/queue' '%s/devices/sda/sda1' && "
+			 "printf 1 > '%s/devices/sda/queue/rotational' && "
+			 "ln -sfn '%s/devices/sda/sda1' '%s/dev/block/8:1'",
+			 root, root, root, root, root);
+		if (system(cmd) < 0)
+			abort();
+
+		rot = false;
+		mu_check(read_rotational_at(root, makedev(8, 1), &rot) == 0);
+		mu_assert(rot,
+			  "the parent disk's queue/ was not reached, so the\n"
+			  "  second path form is doing nothing");
+	}
+
+	/* An empty file: the read returns 0 bytes, which is not an answer. */
+	fake_rotational(root, 9, 0, "");
+	rot = true;
+	mu_assert(read_rotational_at(root, makedev(9, 0), &rot) == -ENOENT,
+		  "an empty rotational file was treated as an answer");
+
+	rm_rf(root);
+}

--- a/tests/unit/tu_plain.c
+++ b/tests/unit/tu_plain.c
@@ -7,5 +7,6 @@
 /* filerec.c is linked, so these reach only its public API. */
 #include "test_filerec.c"
 #include "test_util.c"
-#include "test_storage.c"
+
+#include "test_btrfs_util.c"
 #include "test_dedupe.c"

--- a/tests/unit/tu_storage.c
+++ b/tests/unit/tu_storage.c
@@ -1,0 +1,12 @@
+/*
+ * The io-threads heuristic and the line describing it.
+ *
+ * Its own translation unit since the sysfs test reaches read_rotational_at(),
+ * which is static: the seam is a parameter on an internal function, not a knob
+ * on the product.
+ */
+#include "suite.h"
+
+#include "storage.c"
+
+#include "test_storage.c"


### PR DESCRIPTION
The headline is not the tests. **`WERROR=1` has been silently disabling `-O2` in
every CI job**, and that was found by pulling on a thread from the soak run.

## 1. The build bug

```make
ifdef WERROR
        override CFLAGS += -Werror      # line 38
endif
...
        CFLAGS += -O2 $(HARDENING)      # the release block — silently ignored
```

Once `CFLAGS` carries the `override` origin, GNU make **ignores every later
ordinary assignment to it**. `$(WARN_EXTRA)` survived only because it was
already an `override`; the optimization and hardening were not.

`.github/workflows/ci.yml` sets `WERROR: 1` for every job — so btrfs, xfs, all
four valgrind shards, all three sanitizer legs and the mutation sweep have been
verifying **`-O0` code while what ships is `-O2`**. That is where UB-sensitive
differences hide, and CLAUDE.md already records that 17 of `dbfile.c`'s 1,879
mutants differ between the two builds.

**Fix:** `override CFLAGS += -O2 $(HARDENING)`.

**Diagnose it from the binary, not the makefile.** `readelf --debug-dump=info`
prints what gcc actually did:

```
 19 GNU C11 13.3.0 … -ggdb -std=gnu11          ← -O0
  1 GNU C11 13.3.0 … -ggdb -O2 -std=gnu11      ← one stray plain `make`
```
after the fix:
```
 20 GNU C11 13.3.0 … -ggdb -O2 -std=gnu11
```

Comparing object sizes sent me the wrong way **twice**. The producer string
can't.

**What it immediately exposed:** two `-Wformat-truncation` warnings CI has never
seen, because that analysis needs optimization to run. Both were deliberate
truncations whose intent lived only in a comment; they now spell the bound out
in code the compiler can follow.

`scripts/lint-build-flags.py` guards it — verified against the bug put back.

## 2. The fault-injection residue, mostly without a seam

Triaged across five places in CLAUDE.md as needing fault injection. Two of the
three families need **no product change at all**:

| target | mechanism | before | after |
|---|---|---|---|
| `read_rotational_at` | **a real seam** — sysfs root parameter | 29 of 36 surviving, 0% killed | **6 of 35, 77% killed** |
| `btrfs-util.c` | hostile fd — no seam | 28 surviving, **0% killed** | 22, 8 caught |
| `dbfile.c` | `PRAGMA query_only` — no seam | 659 | 651 |

- **`query_only` is a *connection* setting**, so poisoning one handle leaves the
  shared in-memory database other tests use untouched. Writes then fail at `step`
  with `SQLITE_READONLY` — exactly what all 82 `perror_sqlite` + `goto out` pairs
  guard.
- **A non-btrfs fd** makes the ioctls return `ENOTTY` — the real kernel refusing,
  and the case oans meets whenever someone points it at ext4.
- Only `read_rotational` needed a seam, because it builds an absolute `/sys` path
  and nothing a caller controls decides what it opens. A parameter on an internal
  function, deliberately **not** an environment variable.

**Be straight about dbfile:** 8 of 82 sites, not a floodgate. My first reading
said 135 — from a stale baseline that predated the loader work. The 8 is from a
true A/B where before and after differ only by these tests. Every one is *"the
code forgot to report a failure"*.

**A documented conclusion was wrong.** CLAUDE.md said `btrfs-util.c` "gets no
tests, and that is the answer rather than a gap." It went 0% → 8 caught with no
seam. The *shape* of the triage was right — the 22 that remain are the success
paths needing real btrfs — but "no tests" was too strong.

## 3. Soak

`OANS_PROPTEST_SCALE=N` multiplies every property's case count. A multiplier, so
the ordinary run keeps the count each property chose, and each property still
draws from its own stream — a soak **extends** a run rather than replacing it.

| pass | assertions | failures |
|---|---|---|
| deep — scale 500, fixed seed | 659,961,110 | 0 |
| wide — scale 100 × 6 random seeds | ~132 M each | 0 |

Six independent seeds green is the half that teaches: the properties are not
tuned to the default seed. The deep pass mostly confirms — more cases cannot find
a bug in a property that is already a tautology, and this tree has had one.

**Optimized is 2.02× faster**: the same 659,961,110 assertions in 109 s instead
of 221 s.

## Gate

`make lint` (six checks now), `WERROR=1` build and suite, ASan+UBSan — which
caught a leak in one of my own new tests, a missing `file_cleanup()` that the
plain run, the WERROR run **and valgrind** all read straight past — valgrind
(0 lost, 0 errors), and `make mutation-replay` across all eleven bug files with
nothing surviving. 118 tests / 1,328,854 assertions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_