### PR TITLE
Separate head from tail with a hole, so the extent test runs on XFS too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,37 @@ in `tests/`; no shell tests.
   over-subscribes (`2 × nproc`, capped) — don't "fix" it back to `nproc`.
 - **A test asserting on the *physical* extent layout must set `serial = True`**
   (`DuperemoveTest.serial`), which holds it back to a one-at-a-time pass after
-  the pool drains. Per-test scratch isolation doesn't help here: the
-  fsync-forced-extent-boundary trick and fiemap counts depend on btrfs
-  writeback, which concurrent I/O perturbs — CI caught exactly this on btrfs
+  the pool drains. Per-test scratch isolation doesn't help here: the physical
+  layout and fiemap counts depend on btrfs writeback, which concurrent I/O
+  perturbs — CI caught exactly this on btrfs
   (`test_extent_order_independent`, `test_streaming_dedupe`) while xfs passed.
-  The four `fsync`-boundary files are already marked.
+  The four affected files are already marked.
+
+- **A hole is how a test gets two extents on *any* filesystem — not an fsync,
+  and not copy-on-write (#242).** `test_extent_dedupe.py` was `@requires_btrfs`
+  for years on the strength of a docstring saying "XFS overwrites in place and
+  keeps the file as one extent, so it cannot reproduce the partially-shared
+  layout", and `harness.py`'s `requires_btrfs` comment said the same. Both were
+  wrong, and the repo disproved them one file over the whole time:
+  `test_einval.py` builds the identical unique-head / hole / shared-tail layout,
+  is only `@requires_reflink`, and has been passing on the xfs leg all along. An
+  outside report with `filefrag` and `xfs_bmap` output is what finally said so.
+  - **Punch the hole, don't seek over it.** Seeking leaves one on btrfs and
+    ext4 — measured identical, 106,496 bytes allocated either way — but XFS
+    reserves blocks past the end of a buffered extending write and the gap can
+    come back mapped as one DELALLOC record. `make_sparse()` punches and then
+    `ftruncate`s, the same recipe `mkfile_fiemap()` in `tests/unit/fixtures.h`
+    already used for the same reason.
+  - **The test for that can only fail on one leg**, since ext4 and btrfs leave
+    a hole whichever way it was built. So `punch_hole()` *raises* instead of
+    ignoring the return value, and a second test pins that — the half of the
+    guarantee every filesystem can show. Reverting the raise fails it; reverting
+    the punch fails nothing outside CI's xfs leg, which is worth knowing before
+    reading a green run as proof.
+  - Copy-on-write is still genuinely required for one thing: reflinking a file
+    and rewriting its head *in place* so the tail extents survive untouched.
+    That is what `ExtentDedupeCowTest` still needs btrfs for, and it is the only
+    thing `requires_btrfs` should be read as meaning.
 
 - **Never scan/benchmark out of `/tmp` — it's tmpfs**, not reflink-capable and
   rejected by `is_fs_supported()`, so a scan there stores **0 files silently**

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,9 +64,15 @@ gets a fresh scratch directory in `self.work` and a per-test hashfile in
 
 That isolation is what lets the suite run in parallel, so keep to it — a test
 reaching outside its own `self.work` will flake. If a test asserts on the
-*physical* extent layout (the fsync-forced extent boundary trick, or fiemap
-extent counts), set `serial = True` on the class: no amount of file isolation
-helps there, because concurrent I/O changes how the kernel lays extents out.
+*physical* extent layout (which extents a file ended up in, or fiemap extent
+counts), set `serial = True` on the class: no amount of file isolation helps
+there, because concurrent I/O changes how the kernel lays extents out.
+
+Build a hole with `make_sparse`, which punches it. Seeking over a gap leaves one
+on btrfs and ext4 but not necessarily on XFS, where a buffered extending write
+reserves blocks past the end and the gap can come back mapped — so a fixture
+built that way has no hole at all on half the CI matrix, and every assertion
+about holes passes by not being about anything (#242).
 
 ```python
 from harness import DuperemoveTest, requires_reflink

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -209,9 +209,12 @@ def scratch_fstype(directory=TEST_ROOT):
 
 
 # btrfs is copy-on-write, so an in-place overwrite of alternate blocks splits a
-# file into many physical extents. xfs (even with reflink) overwrites in place
-# and stays one extent, so tests that need to *build* a fragmented file can only
-# run on btrfs. (btrfs is reflink-capable, so this implies @requires_reflink.)
+# file into many physical extents; xfs overwrites in place instead. So this is
+# for a test that fragments a file *by rewriting part of it*, and for nothing
+# else. It is not what a test needs merely to get more than one extent: writing
+# around a hole does that anywhere (#242, and see make_sparse), and this comment
+# claimed the opposite for long enough to keep an extent-pass test off xfs.
+# (btrfs is reflink-capable, so this implies @requires_reflink.)
 BTRFS = scratch_fstype() == "btrfs"
 requires_btrfs = unittest.skipUnless(
     BTRFS, "test needs btrfs (copy-on-write fragmentation)")
@@ -228,6 +231,29 @@ def btrfs_ok(*args):
 # --------------------------------------------------------------------------
 
 _libc = ctypes.CDLL("libc.so.6", use_errno=True)
+
+# fallocate(2) mode bits - the os module exposes posix_fallocate() only.
+_FALLOC_FL_KEEP_SIZE = 0x01
+_FALLOC_FL_PUNCH_HOLE = 0x02
+
+# off_t is 64-bit; without this ctypes passes the offsets as int and a hole
+# past 2 GiB lands somewhere else entirely.
+_libc.fallocate.argtypes = [ctypes.c_int, ctypes.c_int,
+                            ctypes.c_longlong, ctypes.c_longlong]
+
+
+def punch_hole(fd, offset, length):
+    """Punch a real hole into fd, keeping the file size.
+
+    Raises rather than returning a status: a fixture that silently failed to
+    punch would leave a file with no hole in it, and every assertion about
+    holes would then pass by not being about anything.
+    """
+    if _libc.fallocate(fd, _FALLOC_FL_PUNCH_HOLE | _FALLOC_FL_KEEP_SIZE,
+                       offset, length):
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err),
+                      f"punch_hole(offset={offset}, length={length})")
 
 
 def _settle_scratch():
@@ -255,8 +281,8 @@ class DuperemoveTest(unittest.TestCase):
     """Base class: a fresh scratch dir + hashfile per test, plus helpers."""
 
     # Set True on a class whose assertions depend on the *physical* extent
-    # layout the kernel happens to produce - the fsync-forced extent boundary
-    # trick, or fiemap counts. Concurrent I/O perturbs btrfs writeback enough
+    # layout the kernel happens to produce - which extents a file ended up in,
+    # or fiemap counts. Concurrent I/O perturbs btrfs writeback enough
     # that the layout the setup intends is not the one it gets, so tests/run.py
     # holds these back and runs them one at a time after the pool drains.
     # Per-test scratch isolation is *not* what this is for; that already works.
@@ -517,6 +543,21 @@ class DuperemoveTest(unittest.TestCase):
     def make_sparse(self, relpath, head, hole, tail):
         """Write head bytes, a real hole of `hole` bytes, then tail bytes.
 
+        The hole is punched rather than merely seeked over. XFS reserves blocks
+        past the end of a buffered extending write - for these sizes, about the
+        size of the gap - and reports the reservation as one DELALLOC record,
+        so a seeked-over gap can come back mapped and the file has no hole at
+        all on half the CI matrix. Punching says what is meant; the truncate
+        drops whatever the last write reserved past EOF. Same recipe, and the
+        same reason, as mkfile_fiemap() in tests/unit/fixtures.h.
+
+        A punched hole is also what puts head and tail in *separate extents* on
+        a filesystem that does not fragment a file by itself, which is what
+        lets an extent-pass test run somewhere other than btrfs (#242).
+
+        `hole` and len(head) should be block multiples; an unaligned edge is
+        zeroed rather than punched, which costs sparseness but not content.
+
         head/tail are bytes objects; pass the same ones to two calls to build
         identical, independently-stored sparse twins.
         """
@@ -525,6 +566,9 @@ class DuperemoveTest(unittest.TestCase):
             f.write(head)
             f.seek(len(head) + hole)
             f.write(tail)
+            f.flush()               # punch after the writes, not before
+            punch_hole(f.fileno(), len(head), hole)
+            f.truncate(len(head) + hole + len(tail))
         return p
 
     def make_trailing_hole(self, relpath, data, size):

--- a/tests/integration/test_einval.py
+++ b/tests/integration/test_einval.py
@@ -28,8 +28,8 @@ class EinvalTest(DuperemoveTest):
         # tail is the shared extent whose block-rounded length overshoots EOF.
         head_a, head_b = os.urandom(262144), os.urandom(262144)
         tail = os.urandom(12345)
-        a = self.make_sparse_headtail("tree/a", head_a, 327680, tail)
-        b = self.make_sparse_headtail("tree/b", head_b, 327680, tail)
+        a = self.make_sparse("tree/a", head_a, 65536, tail)
+        b = self.make_sparse("tree/b", head_b, 65536, tail)
         self.sync()
 
         before = self.tree_digest(self.path("tree"))
@@ -53,10 +53,3 @@ class EinvalTest(DuperemoveTest):
         self.assertEqual(before, self.tree_digest(self.path("tree")), "data preserved")
 
     # A sparse file with a *unique* head and a shared tail placed after a hole.
-    def make_sparse_headtail(self, relpath, head, tail_offset, tail):
-        p = self.path(relpath)
-        with open(p, "wb") as f:
-            f.write(head)
-            f.seek(tail_offset)
-            f.write(tail)
-        return p

--- a/tests/integration/test_extent_dedupe.py
+++ b/tests/integration/test_extent_dedupe.py
@@ -8,51 +8,60 @@ only a hint for the "already deduped" check, and the kernel byte-verifies every
 dedupe, so a wrong hint changes neither data nor sharing. This guards the path
 against crashes/errors and against sharing/data regressions.)
 
-Requires btrfs: the setup relies on an fsync-forced extent boundary between the
-head and the shared tail so the tail is its own extent the extent pass can
-match. That boundary only forms under copy-on-write; XFS overwrites in place and
-keeps the file as one extent, so it cannot reproduce the partially-shared layout
-(genuine whole-file and naturally-aligned dedupe still works on XFS).
+A punched hole separates the unique head from the shared tail, which is what
+puts the tail in an extent of its own for the extent pass to match. A hole is a
+property of the extent map rather than of how one filesystem allocates, so
+test_shared_tail_is_deduped runs anywhere reflink does.
+
+It used to force that boundary with an fsync, and this file used to explain that
+only copy-on-write can produce one - "XFS overwrites in place and keeps the file
+as one extent, so it cannot reproduce the partially-shared layout". That was
+wrong twice: a hole owes nothing to copy-on-write, and XFS does fragment a file
+written around unmapped regions (#242, with filefrag and xfs_bmap output).
+test_einval.py has been building this very layout and passing on the XFS leg all
+along, which is the evidence the claim was never checked.
+
+The second case stays btrfs-only for a reason the first no longer shares: it
+reflinks a file and rewrites the head in place, and it is copy-on-write that
+makes such a rewrite replace the head while leaving the tail extents untouched.
+XFS reflink is expected to do the same, but that is unverified here.
 """
 
 import os
-from harness import DuperemoveTest, requires_btrfs
+from harness import DuperemoveTest, requires_btrfs, requires_reflink
 
 MiB = 1 << 20
 
+# Between the unique head and the shared tail: what puts the tail in an extent
+# of its own. Block-aligned, and generous, which costs nothing - it is a hole.
+HOLE = MiB
 
-@requires_btrfs
-class ExtentDedupeTest(DuperemoveTest):
-    # Extent-layout sensitive: see DuperemoveTest.serial.
-    serial = True
+
+class _ExtentFixtures:
+    """Setup shared by both cases below.
+
+    A plain mixin rather than a shared TestCase base: unittest collects every
+    TestCase subclass, so a base holding tests as well as helpers would run
+    those tests again for each case that inherits from it.
+    """
 
     def _mkfile(self, rel, head, tail):
-        """head, an fsync to force an extent boundary, then the shared tail."""
-        p = self.path(rel)
-        with open(p, "wb") as f:
-            f.write(head)
-            f.flush()
-            os.fsync(f.fileno())
-            f.write(tail)
-        return p
-
-    def _reflink_new_head(self, src_rel, dst_rel, head_len):
-        """Reflink src, then rewrite its head in place.
-
-        Copy-on-write replaces only the head blocks, so the copy keeps the
-        seed's tail extents byte for byte - a physical class of two that does
-        not depend on how writeback laid anything out.
-        """
-        p = self.reflink(src_rel, dst_rel)
-        with open(p, "r+b") as f:
-            f.write(os.urandom(head_len))
-        return p
+        """head, a punched hole, then the shared tail."""
+        return self.make_sparse(rel, head, HOLE, tail)
 
     def _layout(self, **files):
         """Physical extents per file, for a failure message worth reading."""
         from harness import phys_extents
         return "\n  " + "\n  ".join(
             f"{name}: {sorted(phys_extents(p))}" for name, p in files.items())
+
+
+@requires_reflink
+class ExtentDedupeTest(_ExtentFixtures, DuperemoveTest):
+    # Extent-layout sensitive: see DuperemoveTest.serial. The hole makes the
+    # boundary itself deterministic, but the assertions still read a map that
+    # concurrent writeback moves around, so this stays held back.
+    serial = True
 
     def test_shared_tail_is_deduped(self):
         # Distinct heads, identical tail -> not whole-file dupes, so only the
@@ -78,6 +87,24 @@ class ExtentDedupeTest(DuperemoveTest):
         self.assertDmOk()
         self.assertNoNewSharing()
 
+
+@requires_btrfs
+class ExtentDedupeCowTest(_ExtentFixtures, DuperemoveTest):
+    # Extent-layout sensitive: see DuperemoveTest.serial.
+    serial = True
+
+    def _reflink_new_head(self, src_rel, dst_rel, head_len):
+        """Reflink src, then rewrite its head in place.
+
+        Copy-on-write replaces only the head blocks, so the copy keeps the
+        seed's tail extents byte for byte - a physical class of two that does
+        not depend on how writeback laid anything out.
+        """
+        p = self.reflink(src_rel, dst_rel)
+        with open(p, "r+b") as f:
+            f.write(os.urandom(head_len))
+        return p
+
     def test_group_on_two_physical_extents_converges_in_one_run(self):
         """Every member lands on the target, not just one per physical extent.
 
@@ -97,8 +124,8 @@ class ExtentDedupeTest(DuperemoveTest):
         hoping writeback splits all four tails the same way does not survive a
         different allocator (it failed on CI's fresh 2 GiB image while passing
         on a large aged filesystem). Only a1-vs-b1 still relies on two
-        head+fsync+tail writes matching, which test_shared_tail_is_deduped
-        above already depends on.
+        head+hole+tail writes matching, and a punched hole puts that boundary
+        in the extent map by construction rather than leaving it to writeback.
         """
         head = 64 * 1024        # block-aligned, so rewriting it spares the tail
         tail = os.urandom(4 * MiB)

--- a/tests/integration/test_sparse.py
+++ b/tests/integration/test_sparse.py
@@ -1,10 +1,53 @@
 """Sparse files, holes, unaligned tails, and empty/zero files."""
 
+import errno
 import os
 from harness import DuperemoveTest, requires_reflink
 
 
 class SparseTest(DuperemoveTest):
+    def test_make_sparse_really_punches_a_hole(self):
+        """The gap is in the extent map, not merely skipped by the writer.
+
+        Seeking over a gap leaves a hole on btrfs and ext4, but XFS reserves
+        blocks past the end of a buffered extending write - for these sizes,
+        about the size of the gap - so the gap can come back mapped and the
+        file has no hole at all on half the CI matrix. Every other assertion in
+        this file would then pass by not being about anything (#242).
+
+        SEEK_HOLE/SEEK_DATA ask the kernel what the map really is, which is the
+        only way to tell a punched hole from a gap the filesystem filled in.
+        """
+        head, hole, tail = 65536, 131072, 40000
+        p = self.make_sparse("tree/sp", os.urandom(head), hole, os.urandom(tail))
+        self.sync()
+        with open(p, "rb") as f:
+            fd = f.fileno()
+            self.assertEqual(head, os.lseek(fd, 0, os.SEEK_HOLE),
+                             "the hole begins where the head ends")
+            self.assertEqual(head + hole, os.lseek(fd, head, os.SEEK_DATA),
+                             "and ends where the tail begins")
+        self.assertEqual(head + hole + tail, os.stat(p).st_size,
+                         "punching kept the file size")
+
+    def test_a_punch_that_fails_is_raised_not_swallowed(self):
+        """The test above can only fail on XFS - btrfs and ext4 leave a hole
+        whether or not anything punched - so this pins the other half of the
+        guarantee, which every filesystem can show: a punch that did not happen
+        must not pass for one. tests/unit/fixtures.h can ignore the return
+        value because it aborts on the following ftruncate anyway; here the
+        file would simply come back without its hole and nothing would say so.
+        """
+        from harness import punch_hole
+        p = self.write("tree/ro", os.urandom(65536))
+        fd = os.open(p, os.O_RDONLY)           # fallocate needs it writable
+        try:
+            with self.assertRaises(OSError) as caught:
+                punch_hole(fd, 0, 4096)
+        finally:
+            os.close(fd)
+        self.assertEqual(errno.EBADF, caught.exception.errno)
+
     def test_sparse_file_scans(self):
         self.make_sparse("tree/sp", os.urandom(65536), 131072, os.urandom(40000))
         self.scan(self.path("tree"))


### PR DESCRIPTION
Closes #242.

## The premise, checked

@crass reports that `test_extent_dedupe.py` has an incorrect model of XFS. It does. The docstring said:

> That boundary only forms under copy-on-write; XFS overwrites in place and keeps the file as one extent, so it cannot reproduce the partially-shared layout

and `harness.py`'s `requires_btrfs` comment said the same thing. Both are wrong: an extent boundary does not need copy-on-write, because writing around an unmapped region produces one anywhere. The issue shows this with `filefrag` and `xfs_bmap` output from a real XFS.

**The repository had been disproving its own claim the whole time.** `test_einval.py::test_unaligned_shared_tail` builds the identical unique-head / hole / shared-tail layout, is only `@requires_reflink`, and has been passing on the xfs leg every run. That is what settles the premise here — see *Verification* below for why it had to.

## What changed

`test_shared_tail_is_deduped` separates the unique head from the shared tail with a **hole** rather than an fsync, and drops to `@requires_reflink`. The new layout is also strictly more deterministic than the one it replaces: a hole is in the extent map by construction, where the fsync trick left the boundary to writeback. Both classes keep `serial = True` regardless, since the assertions still read a map concurrent I/O moves around.

The reflink-then-rewrite-the-head case genuinely does need copy-on-write — that is what makes such a rewrite replace the head while leaving the tail extents untouched — so it stays btrfs-only, in its own `ExtentDedupeCowTest`. The shared helpers move to a plain mixin so unittest does not collect them twice.

### Punch the hole, don't seek over it

`make_sparse()` built its hole by seeking. CLAUDE.md already recorded why that is not enough, from the fiemap unit fixture:

> XFS speculative preallocation (`xfs_iomap_prealloc_size`) fills the gap and reports it `DELALLOC`, so a sparse fixture built by seeking has no hole on the very filesystem half the CI matrix runs.

So `make_sparse()` now punches and then truncates — the same recipe `mkfile_fiemap()` in `tests/unit/fixtures.h` uses, for the same reason. Measured on ext4, seek and punch are identical (106,496 bytes allocated for a 236,608-byte file either way), so this is a no-op wherever seeking already worked and only bites where a filesystem fills the gap.

`test_einval.py` carried a near-duplicate copy of the helper with the same weakness; it now uses the shared one.

`punch_hole()` **raises** instead of ignoring the return value the way the C fixture does. That fixture can ignore it because it aborts on the following `ftruncate` anyway; here the file would simply come back without its hole and nothing would say so.

## Two tests, and they see different things

Worth being explicit, because one of them is decoration on three of the four legs:

| test | ext4 | btrfs | xfs |
|---|---|---|---|
| `test_make_sparse_really_punches_a_hole` | cannot fail | cannot fail | **load-bearing** |
| `test_a_punch_that_fails_is_raised_not_swallowed` | **load-bearing** | load-bearing | load-bearing |

The first uses `SEEK_HOLE`/`SEEK_DATA` to ask the kernel what the map really is — but ext4 and btrfs leave a hole whether or not anything punched, so only the xfs leg can ever see it fail. The second exists precisely because of that: it pins the half of the guarantee every filesystem can show, and it fails when the raise is removed:

```
mutated: punch_hole now swallows the error
AssertionError: OSError not raised
----------------------------------------------------------------------
Ran 1 test in 0.001s
FAILED (failures=1)
```

## Verification, and its limits

**This session's kernel has neither btrfs nor XFS** — it is a Firecracker microVM whose `/proc/filesystems` lists only ext2/3/4, squashfs, erofs and overlay, and `mkfs.xfs` mounts fail with `unknown filesystem type 'xfs'`. So the dedupe assertions could not be run locally at all, and **CI is the only verification of the headline change**. That is the reason the premise was settled from `test_einval.py`'s existing xfs-leg result rather than from a fresh measurement.

What was checked here:

- Full integration suite against `origin/master`'s copy of `tests/` with the same binary: **249 tests, 106 failures, 3 errors, 112 skipped** (all failures are `FIDEDUPERANGE` unsupported on ext4). With this change: **251 tests, 106 failures, 3 errors, 112 skipped** — the delta is exactly the two new tests, both passing.
- Collection: 2 tests collected from `test_extent_dedupe.py`, `ExtentDedupeTest` gated on reflink, `ExtentDedupeCowTest` on btrfs, `_ExtentFixtures` not a TestCase.
- `punch_hole` produces a real hole here: `SEEK_HOLE` from 0 → 65536, `SEEK_DATA` from 65536 → 196608.
- `make lint` (six checks) and the C unit suite (118 tests, 1,328,854 assertions) green.

**What CI has to answer**, and what I would look at if it goes red: that `test_shared_tail_is_deduped` now *runs* rather than skips on both xfs legs, and passes there.

## One judgement call

`punch_hole()` raising means a filesystem without `FALLOC_FL_PUNCH_HOLE` would turn currently-passing scan tests into errors rather than silently building a non-sparse file. I think that is the right trade — the failure is loud and names the offending call — but it is a behaviour change for anyone running the suite somewhere exotic, so it is worth flagging rather than burying.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_