### PR TITLE
Publish only what survives from a failed nondupe-extent load

### DIFF
--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -315,3 +315,26 @@
 "(SELECT 1 FROM extents as e where e.digest = extents.digest "		\
 "and e.rowid = extents.rowid);"
 >>>
+
+# ---------------------------------------------------------------- #238
+
+# a failed load publishes the buffer it was about to free
+# The out-parameters are assigned before the error path frees the buffer, so a
+# caller that reads them on failure gets a pointer to freed memory and a count
+# of what had been read so far. The one caller checks the return value first,
+# which is the only reason this was latent rather than a use-after-free; a
+# second caller written to the ordinary out-parameter convention would have it.
+<<<
+	if (ret) {
+		free(extents);
+		extents = NULL;
+		count = 0;
+	}
+	*ret_extents = extents;
+	*num_extents = count;
+===
+	*ret_extents = extents;
+	*num_extents = count;
+	if (ret && extents)
+		free(extents);
+>>>

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -2391,16 +2391,27 @@ int dbfile_load_nondupe_file_extents(struct dbhandle *db, struct filerec *file,
 		count++;
 	}
 
-	*num_extents = count;
 	if (ret != SQLITE_DONE) {
 		perror_sqlite(ret, "stepping nondupe extents statement");
 		goto out;
 	}
 	ret = 0;
 out:
-	*ret_extents = extents;
-	if (ret && extents)
+	/*
+	 * Publish only what survives. Assigning the out-parameters before the
+	 * free would hand a failing caller a pointer to freed memory, and a
+	 * partial count beside it - and the count is the more dangerous half,
+	 * since a caller that trusts it over the return value reads freed
+	 * memory of a plausible length. Clearing both is what makes "this
+	 * returned an error" and "there is nothing here" the same state.
+	 */
+	if (ret) {
 		free(extents);
+		extents = NULL;
+		count = 0;
+	}
+	*ret_extents = extents;
+	*num_extents = count;
 	return ret;
 }
 

--- a/src/dbfile.h
+++ b/src/dbfile.h
@@ -311,6 +311,16 @@ struct file_extent {
 	uint64_t	loff;
 	uint64_t	len;
 };
+
+/*
+ * Extents of `file` that nothing else shares, malloc'd for the caller to free.
+ *
+ * On failure both out-parameters are left as NULL and 0, so there is nothing to
+ * read and nothing to free: an error and an empty answer are the same state.
+ * Check the return value, not the count - a loader that published what it had
+ * read before it failed would hand back a plausible array of a plausible
+ * length, which is exactly what this used to do (#238).
+ */
 int dbfile_load_nondupe_file_extents(struct dbhandle *db, struct filerec *file,
 				     struct file_extent **ret_extents,
 				     unsigned int *num_extents);

--- a/tests/unit/fixtures.h
+++ b/tests/unit/fixtures.h
@@ -121,6 +121,39 @@ struct fm_rec { uint64_t log, phys, len; uint32_t flags; };
 	exec(db, "PRAGMA query_only = ON");
 }
 
+static int abort_query_cb(void *unused [[maybe_unused]])
+{
+	return 1;			/* non-zero: abort the running statement */
+}
+
+/*
+ * Make the next query on this connection fail partway, after roughly `ops`
+ * VDBE instructions.
+ *
+ * `PRAGMA query_only` only refuses writes, so it cannot reach a *loader's*
+ * error path. A progress handler answering non-zero makes sqlite3_step()
+ * return SQLITE_INTERRUPT instead, which is the one way to fail a SELECT from
+ * outside without dropping a table - and every memdb() handle shares one
+ * in-memory database, so a schema change here would break whichever tests run
+ * after this one. The handler is per-connection, so it stays inside the test.
+ *
+ * `ops` is the whole point rather than a detail: it decides whether the
+ * failure lands before any row was read or after several, and a loader that
+ * accumulates into a growing buffer is only interesting in the second case.
+ * Too small and the statement dies before it returns anything, which is a
+ * vacuous test that no assertion can tell apart from a good one - so a test
+ * relying on this must be checked by putting the bug back.
+ */
+[[maybe_unused]] static void db_abort_queries_after(struct dbhandle *db, int ops)
+{
+	sqlite3_progress_handler(db->db, ops, abort_query_cb, NULL);
+}
+
+[[maybe_unused]] static void db_allow_queries(struct dbhandle *db)
+{
+	sqlite3_progress_handler(db->db, 0, NULL, NULL);
+}
+
 [[maybe_unused]] static uint64_t rows(struct dbhandle *db, const char *table)
 {
 	char sql[64];

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -108,6 +108,7 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_extent_hashes_load_as_groups_carrying_their_offsets);
 	MU_RUN(test_nondupe_extents_are_the_ones_nothing_else_shares);
 	MU_RUN(test_nondupe_extents_grow_past_the_initial_capacity);
+	MU_RUN(test_an_interrupted_load_publishes_nothing);
 	MU_RUN(test_a_file_with_nothing_unique_yields_no_nondupe_extents);
 	MU_RUN(test_a_whole_matching_run_is_recorded_as_one_group);
 	MU_RUN(test_a_mismatch_splits_the_run_rather_than_ending_the_search);

--- a/tests/unit/test_dbfile.c
+++ b/tests/unit/test_dbfile.c
@@ -1327,6 +1327,57 @@ MU_TEST(test_nondupe_extents_grow_past_the_initial_capacity) {
 }
 
 /*
+ * A step that fails partway publishes nothing - not a freed pointer, and not
+ * the count of what it had read so far (#238).
+ *
+ * The only caller checks the return value before it looks at either
+ * out-parameter, so nothing misbehaves today; what is wrong is a contract that
+ * invites the opposite. An out-parameter that was written is ordinarily the
+ * caller's to read and to free, and here both would be a use-after-free. This
+ * repository has already paid for that shape once, in the dbfile_prepare
+ * recreate path.
+ *
+ * `ops` was chosen by measurement, not by taste: the assertions below are only
+ * about anything if the interrupt lands *after* some rows were read, and at
+ * 4000 it does. Reverting the fix fails both of them; at 100 it fails neither,
+ * because the statement dies before returning a single row and the buggy code
+ * publishes the same NULL and zero the fixed one does.
+ */
+MU_TEST(test_an_interrupted_load_publishes_nothing) {
+	_cleanup_(sqlite3_close_cleanup) struct dbhandle *db = memdb();
+	struct file_extent *got = (struct file_extent *)0x1;
+	struct filerec *f;
+	struct extent_csum ext[64];
+	unsigned int n = 12345;
+	int64_t a;
+
+	free_all_filerecs();
+	a = put_dupe(db, "/tree/interrupted", 1, 71, 1u << 20, 1, 0, 64);
+	f = filerec_new("/tree/interrupted", a, 1u << 20);
+	if (!f)
+		abort();
+
+	for (unsigned int i = 0; i < ARRAY_SIZE(ext); i++) {
+		ext[i].loff = i * 4096;
+		ext[i].poff = (i + 700) * 4096;
+		ext[i].len = 4096;
+		digest_of(ext[i].digest, 700 + i);	/* all distinct */
+	}
+	mu_check(dbfile_store_extent_hashes(db, a, ARRAY_SIZE(ext), ext) == 0);
+
+	db_abort_queries_after(db, 4000);
+	mu_check(dbfile_load_nondupe_file_extents(db, f, &got, &n) != 0);
+	db_allow_queries(db);
+
+	/* Both, because clearing one and not the other is its own footgun: a
+	 * partial count beside a NULL pointer reads as an array to walk. */
+	mu_check(got == NULL);
+	mu_check(n == 0);
+
+	free_all_filerecs();
+}
+
+/*
  * A file whose every extent is shared has no candidates, and says so with a
  * count of zero rather than by leaving the caller's count untouched -
  * find_dupes tests `!num_extents` before it looks at the array.


### PR DESCRIPTION
Closes #238.

## The defect

`dbfile_load_nondupe_file_extents()` assigned its out-parameters *before* the error path freed the buffer:

```c
out:
	*ret_extents = extents;
	if (ret && extents)
		free(extents);
	return ret;
```

So any failure that had already allocated — the `ENOMEM` from the realloc growth, or a `sqlite3_step()` ending other than `SQLITE_DONE` — handed the caller a pointer to freed memory. `*num_extents` was set even earlier, before the `SQLITE_DONE` check, so a partial count went with it. That count is the more dangerous half: a caller trusting it over the return value reads freed memory of a plausible length.

**Nothing misbehaves today**, and the issue says so. The one caller (`find_dupes.c:323`) checks `ret` first and never touches either out-parameter. What is wrong is a contract that invites the opposite, since an out-parameter that was written is ordinarily the caller's to read and to free. This tree has already paid for that shape once, in the `dbfile_prepare` recreate path.

An error and an empty answer are now the same state, and `dbfile.h` says so where a second caller would read it.

## The fault seam, and why `PRAGMA query_only` was not enough

The issue's closing line is *"the error paths need fault injection that does not exist here"*. The seam added in #253 turned out not to be the one: `PRAGMA query_only` refuses **writes**, so it cannot reach a loader's failure path at all.

A progress handler answering non-zero can. It makes `sqlite3_step()` return `SQLITE_INTERRUPT`, it is per-connection, and it needs no schema change — which matters, because every `memdb()` handle shares one in-memory database and a dropped table would break whichever tests run after this one.

## The measurement that decides whether the test is real

`db_abort_queries_after(db, ops)` takes an op count, and **`ops` is the whole test rather than a detail**: it decides whether the interrupt lands before any row was read or after several, and only the second case can tell the two versions apart. With zero rows read, the buggy code publishes the same `NULL` and `0` the fixed one does.

Measured, with the fix reverted in the working tree:

| `ops` | verdict with the bug restored |
|---|---|
| 4000 | `test_an_interrupted_load_publishes_nothing failed` — **catches it** |
| 100 | `119 tests, 1328858 assertions, 0 failures` — **vacuous** |

```
REVERTED to the buggy publish-then-free order
dbfile_load_nondupe_file_extents()/5486: Database error 9 while stepping nondupe extents statement: interrupted
test_an_interrupted_load_publishes_nothing failed:
119 tests, 1328857 assertions, 1 failures
```

Both numbers are in the test's comment, because a vacuous fixture here would have looked exactly like a good one — the assertions read identically either way, and only the `ops` value separates them.

`bugs/dbfile.txt` gains a block putting the publish-then-free order back:

```
a failed load publishes the buffer it was about to free             caught     test_an_interrupted_load_publishes_nothing

25 caught by a test, 0 by the compiler only, 0 hung, 0 SURVIVED
score            100% killed, 100% by a test
```

## Gate

- gcc `WERROR=1` and clang `WERROR=1` builds and suites: green, 119 tests / 1,328,858 assertions
- ASan + UBSan (clang): green
- valgrind, `OANS_PROPTEST_NO_JIT=1`: `definitely lost: 0 bytes`, `ERROR SUMMARY: 0 errors from 0 contexts`
- `make lint`: six checks green
- `make mutation-replay` equivalent on `bugs/dbfile.txt`: 25/25 caught, none survived
- integration suite unchanged at 251 tests (this box is ext4, so the dedupe cases cannot run; the failures are `FIDEDUPERANGE` unsupported and match master exactly)

One correction worth recording: my first valgrind invocation reported nothing because `./test` had not been rebuilt after a `make clean` — it exited 127 and my filter matched no lines, which looks identical to a clean run. The numbers above are from the re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_