### PR TITLE
Delete de_anchored, and guard the ordering it was mistaken for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,8 @@ on, and it is worth reading before starting a ninth.
   fail.** Not a weak test — a test whose assertion held no matter what the code
   did. The list, because the shapes repeat: a fixture whose winner led on every
   column (so a `min(id)` election passed the #197 test); an `is_anchor`
-  assertion that passed against its own mutation; two symmetric file layouts,
+  assertion that passed against its own mutation, and which turned out to be
+  guarding state with no reader at all (#237); two symmetric file layouts,
   which made "which side of the pair was written" unobservable and cost 47 of
   72 mutants; a helper wrapping `list_first_entry()` on a possibly-empty list,
   which never returns NULL, so every `mu_check(t != NULL)` around it held
@@ -579,12 +580,28 @@ and `mkfilerec()`/`free_all_filerecs()` - which is why they came last.
   the real ranking picks - and the same trap sat in the tie-break case, where
   names, inos and ids all ascended together so a comparator with no tie-break
   at all still answered correctly.
-- **`is_anchor` is the one C statement in `dbfile_load_same_files()` that
-  exists for #197, and nothing observed it** - deleting it left every other
-  test green. It is asserted as a pair now (`de_anchored` on the whole-file
-  group, `!de_anchored` on an extent group), which pins the asymmetry rather
-  than each half looking arbitrary. Nothing *reads* the flag in production
-  (#237); that assertion is how the disconnection would be noticed.
+- **`de_anchored` is gone, and the way it was defended is the lesson (#237).**
+  It was written from `GET_DUPLICATE_FILES`'s `is_target` column and *never
+  read* — deleting the write left every other test green. The response at the
+  time was to assert the flag itself, on the argument that the assertion was
+  "how the disconnection would be noticed". That reasoning is backwards: with
+  no reader there is no connection to break, so what the assertion pinned was
+  the existence of dead state, and a bug block guarding it could only ever be
+  caught by that one assertion. Worse, state that *looks* like a guard invites
+  someone to restore the missing reader and reintroduce the per-pass
+  re-election #197 removed.
+  - **Row order is the actual mechanism.** `order by is_target desc, f.id`
+    carries the rank out of the query, `insert_extent_list_free()` appends, and
+    `dedupe_extent_list()` takes `list_first_entry()`. So the target being first
+    *is* the election — there is nothing else to check, and `target_of()` in the
+    #197 test was already checking it.
+  - **The trade is measurable, which is why it is the right one.** The bug block
+    that broke the flag was caught only by the assertion written for it; the one
+    that replaced it — dropping the `order by` — is caught by
+    `test_whole_file_dupes_load_at_poff_zero` and
+    `test_the_whole_file_target_prefers_readonly_then_least_fragmented`, tests
+    that are about behaviour. Prefer a guard on the mechanism over a guard on a
+    marker that merely accompanies it.
 - **The tool does not mutate string literals**, so the `GET_DUPLICATE_*` SQL
   cannot be swept - a test that only exercises SQL filtering guards against
   hand edits but moves no kill rate. `bugs/dbfile.txt` is where those go, and

--- a/scripts/mutate/bugs/dbfile.txt
+++ b/scripts/mutate/bugs/dbfile.txt
@@ -269,14 +269,21 @@
 "	where dedupe_seq <= ?2 and (digest, size) in ( "			\
 >>>
 
-# the anchor flag never reaches the group
-# The one C statement in the loader that exists for #197. Nothing reads the
-# flag today (#237), so this survives everything except a test that asserts it
-# - which is the point: it is how the disconnection would be noticed.
+# the elected target is no longer loaded first
+# Row order *is* the target election (#197). The rank is computed in the tgt
+# CTE, but `order by is_target desc` is what carries it out of the query, and
+# insert_extent_list_free() appends - so dropping it leaves the group's first
+# member, and therefore dedupe_extent_list()'s target, up to whatever order
+# SQLite felt like returning. Every pass may then pick a different one and the
+# copies never converge on one physical extent.
+#
+# This block replaces one that broke the de_anchored flag, which had no reader
+# and was removed with #237. The ordering is the mechanism the flag was mistaken
+# for, and unlike the flag it is load-bearing.
 <<<
-		ret = insert_one_result(res, digest, file, 0, size, 0, is_anchor);
+"order by is_target desc, f.id;"
 ===
-		ret = insert_one_result(res, digest, file, 0, size, 0, false);
+"order by f.id;"
 >>>
 
 # block hashes reach find_dupes in whatever order the query yielded

--- a/scripts/mutate/bugs/results-tree.txt
+++ b/scripts/mutate/bugs/results-tree.txt
@@ -54,17 +54,5 @@
 ===
 >>>
 
-# the anchor flag is assigned rather than latched
-# A group spanning several dedupe passes must keep the target the first pass
-# chose, or each pass converges the copies onto a different physical extent and
-# the run never settles. The mutation only shows if a *later* member arrives
-# without the flag, which is the shape a test has to be written for.
-<<<
-	if (is_anchor)
-		dext->de_anchored = true;
-===
-	dext->de_anchored = is_anchor;
->>>
-
 # ---------------------------------------------------------------- hash tree
 

--- a/src/dbfile.c
+++ b/src/dbfile.c
@@ -2342,8 +2342,7 @@ int dbfile_load_extent_hashes(struct dbhandle *db, struct results_tree *res,
 		if (ret)
 			return ret;
 
-		ret = insert_one_result(res, digest, file, loff, len, poff,
-					false);
+		ret = insert_one_result(res, digest, file, loff, len, poff);
 		if (ret)
 			return ENOMEM;
 	}
@@ -2551,15 +2550,10 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		bool is_anchor;
-
 		fileid = sqlite3_column_int64(stmt, 0);
 		size = sqlite3_column_int64(stmt, 1);
 		digest = (unsigned char *)sqlite3_column_blob(stmt, 2);
 		filename = sqlite3_column_text(stmt, 3);
-		/* The query elects the group's target and sorts it first; the
-		 * worker must not re-elect one (#197). */
-		is_anchor = sqlite3_column_int(stmt, 5) != 0;
 
 		file = filerec_find(fileid);
 		if (!file) {
@@ -2568,7 +2562,17 @@ int dbfile_load_same_files(struct dbhandle *db, struct results_tree *res,
 				return ENOMEM;
 		}
 
-		ret = insert_one_result(res, digest, file, 0, size, 0, is_anchor);
+		/*
+		 * The order of these calls *is* the target election (#197).
+		 * GET_DUPLICATE_FILES ranks each group and sorts `is_target
+		 * desc` first, insert_extent_list_free() appends, and
+		 * dedupe_extent_list() takes list_first_entry() - so the target
+		 * arrives first and stays first. Nothing reads the is_target
+		 * column; loading in the query's order is what carries it. Do
+		 * not add an ORDER BY of your own here, and do not sort
+		 * de_extents afterwards.
+		 */
+		ret = insert_one_result(res, digest, file, 0, size, 0);
 		if (ret)
 			return ENOMEM;
 	}

--- a/src/results-tree.c
+++ b/src/results-tree.c
@@ -219,7 +219,7 @@ static struct dupe_extents *find_alloc_dext(struct results_tree *res,
  */
 int insert_one_result(struct results_tree *res, unsigned char *digest,
 		      struct filerec *file, uint64_t startoff, uint64_t len,
-		      uint64_t poff, bool is_anchor)
+		      uint64_t poff)
 {
 	struct extent *extent = alloc_extent(file, startoff);
 	struct dupe_extents *dext;
@@ -235,8 +235,6 @@ int insert_one_result(struct results_tree *res, unsigned char *digest,
 		return ENOMEM;
 
 	abort_on(dext->de_len != len);
-	if (is_anchor)
-		dext->de_anchored = true;
 
 	g_mutex_lock(&dext->de_mutex);
 	insert_extent_list_free(dext, &extent);

--- a/src/results-tree.h
+++ b/src/results-tree.h
@@ -39,14 +39,6 @@ struct dupe_extents {
 
 	struct rb_node		de_node;
 	GMutex			de_mutex;
-
-	/*
-	 * Set when this group already contains an anchor member from an earlier
-	 * dedupe pass (loaded first). The dedupe must keep that anchor as the
-	 * target so every pass converges the copies onto the same physical
-	 * extent, rather than re-picking a least-fragmented target per pass.
-	 */
-	bool			de_anchored;
 };
 
 /*
@@ -92,7 +84,7 @@ int insert_result(struct results_tree *res, unsigned char *digest,
 		  uint64_t endoff[2]);
 int insert_one_result(struct results_tree *res, unsigned char *digest,
 		      struct filerec *file, uint64_t startoff, uint64_t len,
-		      uint64_t poff, bool is_anchor);
+		      uint64_t poff);
 
 void init_results_tree(struct results_tree *res);
 void free_results_tree(struct results_tree *res);

--- a/src/run_dedupe.c
+++ b/src/run_dedupe.c
@@ -351,16 +351,23 @@ static void clean_deduped(struct dupe_extents **ret_dext,
 }
 
 /*
- * Choose which member of the group becomes the dedupe target, i.e. the source
- * the kernel reads and every other member is pointed at.
+ * The dedupe target - the source the kernel reads, and what every other member
+ * is pointed at - is the group's *first* member, here and in the dedupe loop
+ * below.
  *
- * Deduping every copy against a fragmented target makes each copy inherit that
- * fragmentation: one extent-tree op per target extent per copy, and all copies
- * left fragmented on disk (measured ~linear in target extents once past a fixed
- * per-copy floor). For whole-file dedupe - where members are whole files whose
- * layouts can differ - pick the least-fragmented member as the target by moving
- * it to the front of the list; the loop below always dedupes against the first
- * entry. Extent-dedupe members are single extents, so this is skipped there.
+ * Nothing in this file picks it. GET_DUPLICATE_FILES does, ranking each group
+ * with row_number() over (partition by digest, size order by (flags & 2) desc,
+ * nr_extents, id) and sorting that member first: read-only first, because the
+ * kernel will not write into one (#172), then least-fragmented, then lowest id
+ * to break the tie. Every column is fixed at scan time, so every window elects
+ * the same target and the copies converge on one physical extent instead of one
+ * cluster per pass (#197).
+ *
+ * Why it matters that it is the least fragmented: deduping every copy against a
+ * fragmented target makes each copy inherit that fragmentation - one extent-tree
+ * op per target extent per copy, and all copies left fragmented on disk
+ * (measured ~linear in target extents once past a fixed per-copy floor).
+ * Extent-dedupe members are single extents, so the ranking is moot there.
  */
 /* Show this group on the thread's status line: target path (the group's first
  * member) plus the bytes the kernel still has to byte-verify as work total. */

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -94,7 +94,6 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN(test_prop_a_dup_group_counts_its_own_members);
 	MU_RUN(test_removing_an_extent_collapses_a_group_of_one);
 	MU_RUN(test_a_group_is_keyed_on_digest_and_length_together);
-	MU_RUN(test_the_anchor_flag_latches_once_claimed);
 	MU_RUN(test_insert_result_files_a_pair_under_one_length);
 	MU_RUN(test_filerec_holds_one_descriptor_however_often_it_is_opened);
 	MU_RUN(test_filerec_open_once_opens_each_file_exactly_once);

--- a/tests/unit/test_dbfile.c
+++ b/tests/unit/test_dbfile.c
@@ -980,6 +980,13 @@ MU_TEST(test_every_window_elects_the_same_whole_file_target) {
 	mu_check(dbfile_load_same_files(db, &second, 2, 3) == 0);
 	t2 = target_of(only_group(&second));
 
+	/*
+	 * These two are the #197 guard in full: target_of() is
+	 * list_first_entry(), so naming the same file from both windows says
+	 * the query ranked the whole group and the loader preserved that order.
+	 * There is no separate flag to check - there was one, and it had no
+	 * reader (#237).
+	 */
 	mu_assert_string_eq("/tree/old2", t1);
 	mu_assert_string_eq("/tree/old2", t2);
 
@@ -987,16 +994,6 @@ MU_TEST(test_every_window_elects_the_same_whole_file_target) {
 	 * else: two members, not four. */
 	mu_check(only_group(&first)->de_num_dupes == 2);
 	mu_check(only_group(&second)->de_num_dupes == 2);
-
-	/*
-	 * The loader marks the group anchored, from the query's is_target
-	 * column. Nothing reads the flag today (#237), which is precisely why
-	 * it is asserted here: without this the one C statement in
-	 * dbfile_load_same_files() that exists for #197 can be deleted with
-	 * every other test still green.
-	 */
-	mu_check(only_group(&first)->de_anchored);
-	mu_check(only_group(&second)->de_anchored);
 
 	free_results_tree(&first);
 	free_results_tree(&second);
@@ -1199,14 +1196,6 @@ MU_TEST(test_extent_hashes_load_as_groups_carrying_their_offsets) {
 	d = only_group(&res);
 	mu_check(d->de_len == 4096);
 	mu_check(!memcmp(d->de_hash, shared, DIGEST_LEN));
-
-	/*
-	 * Never anchored: only the whole-file loader elects a target, because
-	 * only there do the members have differing layouts to rank. The pair
-	 * with the assertion in the #197 test above is what pins that
-	 * asymmetry rather than each half separately looking arbitrary.
-	 */
-	mu_check(!d->de_anchored);
 
 	/* Each member keeps the physical offset its row recorded - the extent
 	 * path reads it to decide what is already shared. */

--- a/tests/unit/test_hash_tree.c
+++ b/tests/unit/test_hash_tree.c
@@ -309,8 +309,7 @@ MU_TEST(test_prop_a_dup_group_counts_its_own_members) {
 			 * its own allocation rather than counting it.
 			 */
 			if (insert_one_result(&res, digests[d], files[f],
-					      slot * PROP_LEN * 4, lens[l],
-					      0, false))
+					      slot * PROP_LEN * 4, lens[l], 0))
 				abort();
 			if (!has_group[d][l]) {
 				has_group[d][l] = true;
@@ -391,7 +390,7 @@ MU_TEST(test_removing_an_extent_collapses_a_group_of_one) {
 
 	for (unsigned int i = 0; i < 3; i++)
 		mu_check(insert_one_result(&res, digest, mkfilerec(i + 1), 0,
-					   PROP_LEN, 0, false) == 0);
+					   PROP_LEN, 0) == 0);
 	mu_check(res.num_extents == 3 && res.num_dupes == 1);
 
 	/* Three members: one comes out, two remain, and it says so. */
@@ -434,18 +433,18 @@ MU_TEST(test_a_group_is_keyed_on_digest_and_length_together) {
 	digest_of(digest, 1);
 	digest_of(other, 2);
 
-	mu_check(insert_one_result(&res, digest, a, 0, PROP_LEN, 0, false) == 0);
-	mu_check(insert_one_result(&res, digest, b, 0, PROP_LEN, 0, false) == 0);
+	mu_check(insert_one_result(&res, digest, a, 0, PROP_LEN, 0) == 0);
+	mu_check(insert_one_result(&res, digest, b, 0, PROP_LEN, 0) == 0);
 	mu_check(res.num_dupes == 1);
 
 	/* Same digest, different length: a second group, not an abort. */
 	mu_check(insert_one_result(&res, digest, a, PROP_LEN * 2, PROP_LEN * 2,
-				   0, false) == 0);
+				   0) == 0);
 	mu_check(res.num_dupes == 2);
 
 	/* Different digest, same length: a third. */
-	mu_check(insert_one_result(&res, other, a, PROP_LEN * 8, PROP_LEN, 0,
-				   false) == 0);
+	mu_check(insert_one_result(&res, other, a, PROP_LEN * 8, PROP_LEN,
+				   0) == 0);
 	mu_check(res.num_dupes == 3);
 	mu_check(res.num_extents == 4);
 
@@ -454,43 +453,6 @@ MU_TEST(test_a_group_is_keyed_on_digest_and_length_together) {
 	mu_check(find_dupe_extents(&res, digest, PROP_LEN * 2) != NULL);
 	mu_check(find_dupe_extents(&res, other, PROP_LEN) != NULL);
 	mu_check(find_dupe_extents(&res, other, PROP_LEN * 2) == NULL);
-
-	free_results_tree(&res);
-	free_all_filerecs();
-}
-
-/*
- * The anchor flag latches: once a member claims it, later members that do not
- * cannot clear it. That is what pins a group spanning several dedupe passes to
- * one target instead of re-picking a least-fragmented one per pass.
- *
- * The order matters, and it is the whole test. Asserting it right after the
- * anchored insert would pass just as well against `de_anchored = is_anchor`,
- * because nothing follows to overwrite it - so "sticks" is only a claim if a
- * non-anchored insert comes afterwards.
- */
-MU_TEST(test_the_anchor_flag_latches_once_claimed) {
-	struct results_tree res;
-	unsigned char digest[DIGEST_LEN];
-	struct dupe_extents *d;
-
-	free_all_filerecs();
-	init_results_tree(&res);
-	digest_of(digest, 1);
-
-	mu_check(insert_one_result(&res, digest, mkfilerec(1), 0, PROP_LEN, 0,
-				   false) == 0);
-	d = find_dupe_extents(&res, digest, PROP_LEN);
-	mu_check(d && !d->de_anchored);
-
-	mu_check(insert_one_result(&res, digest, mkfilerec(2), 0, PROP_LEN, 0,
-				   true) == 0);
-	mu_check(d->de_anchored);
-
-	/* The one that matters: a later plain member must not clear it. */
-	mu_check(insert_one_result(&res, digest, mkfilerec(3), 0, PROP_LEN, 0,
-				   false) == 0);
-	mu_check(d->de_anchored);
 
 	free_results_tree(&res);
 	free_all_filerecs();


### PR DESCRIPTION
Closes #237.

Two leftovers from #197, which moved the whole-file target election out of the dedupe worker and into `GET_DUPLICATE_FILES`.

## The dead flag

`de_anchored` was written from the query's `is_target` column and **never read**. The chain `is_target` → `is_anchor` → `de_anchored` terminated in a field nothing consulted, so the state that claimed to stop the worker re-electing a target per pass was doing nothing at all.

Row order is the real mechanism, and it stays: the `tgt` CTE ranks each group, `order by is_target desc, f.id` carries that out of the query, `insert_extent_list_free()` appends, and `dedupe_extent_list()` takes `list_first_entry()`. **The target arriving first *is* the election.** The comment at the load site now says that, in place of a read of a column nobody used, and warns against adding an `ORDER BY` or sorting `de_extents` afterwards — the issue's stated constraint.

## The comment describing a deleted function

`run_dedupe.c:352` explained how the least-fragmented member is moved to the front of the list — immediately above `slot_show_group()`, which shows a progress line. Its last clause was still true and worth keeping, so the rewrite says where the ranking lives now (`(flags & 2) desc, nr_extents, id`, all fixed at scan time) and keeps the sentence about the loop deduping against the first entry.

## Where I diverged from the issue, and why

The issue says to delete the flag. CLAUDE.md, from an earlier iteration of mine, said the opposite — that asserting `de_anchored` was *"how the disconnection would be noticed"*. That reasoning is backwards, and the file now says so: with no reader there is no connection to break, so the assertion pinned the existence of dead state, and a bug block guarding it could only ever be caught by the one assertion written for it.

So rather than just deleting, **the guard moves to the mechanism**. Two bug blocks broke the flag; one block replaces them and breaks `order by is_target desc` instead.

| bug block | caught by |
|---|---|
| *(removed)* the anchor flag never reaches the group | only the `de_anchored` assertion written for it |
| *(removed)* the anchor flag is assigned rather than latched | only `test_the_anchor_flag_latches_once_claimed` |
| **(new)** the elected target is no longer loaded first | `test_whole_file_dupes_load_at_poff_zero`, `test_the_whole_file_target_prefers_readonly_then_least_fragmented` |

```
[21/25] the elected target is no longer loaded first   caught (test_whole_file_dupes_load_at_poff_zero, test_the_whole_file_target_prefers_readonly_then_...)
```

That is the whole argument for the change: the old blocks were caught by assertions about a marker, the new one by tests about behaviour.

The tests move the same way. `de_anchored`'s assertions are gone; the two `mu_assert_string_eq` calls in the #197 test were always the stronger check — `target_of()` is `list_first_entry()` — and they now carry the explanation. `test_the_anchor_flag_latches_once_claimed` goes with the field it tested, which is why the suite drops from 119 to 118.

## Gate

- gcc `WERROR=1` and clang `WERROR=1`: green, 118 tests / 1,328,849 assertions
- ASan + UBSan (clang): green
- valgrind, `OANS_PROPTEST_NO_JIT=1`: `definitely lost: 0 bytes`, `ERROR SUMMARY: 0 errors from 0 contexts`
- `make lint`: six checks green
- `make mutation-replay`: all 11 bug files, 84 mutants, **0 survived**, exit 0
- integration suite unchanged at 251 tests (ext4 here, so dedupe cases cannot run; failures match master exactly)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoYWWvf2ewg87ih8DpGJ)_