### PR TITLE
tests: /proc, not /, for the descriptor that cannot be a subvolume

### DIFF
--- a/tests/unit/test_btrfs_util.c
+++ b/tests/unit/test_btrfs_util.c
@@ -16,10 +16,21 @@
  * end-to-end suite on it.
  */
 
-/* A descriptor that is definitely not a btrfs subvolume. */
+/*
+ * A descriptor that is definitely not a btrfs subvolume.
+ *
+ * It has to be a filesystem that cannot be btrfs, not merely one that usually
+ * isn't: this opened "/" until a Fedora dev box - btrfs root, which is the
+ * default there and the shape oans exists for - answered SUBVOL_INFO for real
+ * and failed the test. CI never saw it, because CI's root is not btrfs.
+ *
+ * procfs can never be btrfs and is always mounted on the only platform this
+ * builds for, so the ioctl reaches a filesystem that has no handler for it and
+ * refuses with ENOTTY - the same real error a user pointing oans at ext4 gets.
+ */
 static int not_a_subvol(void)
 {
-	int fd = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	int fd = open("/proc", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
 
 	if (fd < 0)
 		abort();


### PR DESCRIPTION
`not_a_subvol()` in `tests/unit/test_btrfs_util.c` opened `/` and asserted the three btrfs wrappers refuse it. That holds only where the root filesystem is not btrfs.

On a Fedora dev box — btrfs root is the distro default, and a btrfs root is the shape oans exists for — `BTRFS_IOC_SUBVOL_INFO` answers for real and the wrapper correctly reports success, so `test_a_refused_ioctl_is_an_error_not_a_zero_answer` fails:

```
test_a_refused_ioctl_is_an_error_not_a_zero_answer failed:
	tests/unit/test_btrfs_util.c:41: a refused SUBVOL_INFO reported success
```

Measured with a standalone probe on that box:

| fd | `GET_SUBVOL_INFO` |
| --- | --- |
| `/` | `rc=1` |
| `/proc` | `ENOTTY` |
| `/sys` | `ENOTTY` |

CI never saw it because CI's root is not btrfs, which is the part worth noticing: the test was green precisely on the machines oans is least interesting on, and red on the ones it is built for. `scripts/verify.sh` is the pre-PR gate, so this blocked releasing from a btrfs dev box — it is what stopped `release.sh prepare 1.12.0`.

procfs can never be btrfs and is always mounted on the only platform this builds for. The ioctl reaches a filesystem with no handler for it and is refused with `ENOTTY` — still the real error from the real ioctl, which was the point of #253 not needing a fault-injection seam here.

Introduced in #253.

## Verification

`scripts/verify.sh` on a btrfs root: build clean, 118 unit tests / 0 failures, 251 integration tests OK, valgrind smoke clean — `ALL CHECKS PASSED`. Before the change the same box failed `make check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)